### PR TITLE
Updates to docker_shell to setup binfmt

### DIFF
--- a/docker/tools/docker_shell
+++ b/docker/tools/docker_shell
@@ -154,6 +154,17 @@ for u in ops.addusers:
 if ops.start_cacher:
     execute("/etc/init.d/apt-cacher-ng start", "The apt-cacher-ng service could not be started.")
 
+logger.debug("checking if qemu-ppc exists")
+
+if os.path.isfile("/proc/sys/fs/binfmt_misc/qemu-ppc"):
+   logger.debug("qemu-ppc already exists")
+else:
+   if os.path.ismount("/proc/sys/fs/binfmt_misc"):
+      execute("sudo /etc/init.d/binfmt-support start", "The binfmt-support service could not be started.")
+   else:
+      execute("sudo mount binfmt_misc -t binfmt_misc /proc/sys/fs/binfmt_misc", "The binfmt_misc system could not be mounted.")
+      execute("sudo /etc/init.d/binfmt-support start", "The binfmt-support service could not be started.")
+
 # Fixme: change this to os.execvp()
 c = "/usr/bin/sudo -E -u %s %s" % (g_user.name, " ".join(ops.command))
 sys.exit(execute(c))

--- a/docker/tools/docker_shell
+++ b/docker/tools/docker_shell
@@ -159,11 +159,9 @@ logger.debug("checking if qemu-ppc exists")
 if os.path.isfile("/proc/sys/fs/binfmt_misc/qemu-ppc"):
    logger.debug("qemu-ppc already exists")
 else:
-   if os.path.ismount("/proc/sys/fs/binfmt_misc"):
-      execute("sudo /etc/init.d/binfmt-support start", "The binfmt-support service could not be started.")
-   else:
-      execute("sudo mount binfmt_misc -t binfmt_misc /proc/sys/fs/binfmt_misc", "The binfmt_misc system could not be mounted.")
-      execute("sudo /etc/init.d/binfmt-support start", "The binfmt-support service could not be started.")
+   if not os.path.ismount("/proc/sys/fs/binfmt_misc"):
+      execute("sudo mount binfmt_misc -t binfmt_misc /proc/sys/fs/binfmt_misc", "The binfmt_misc system could not be mounted.")   
+   execute("sudo /etc/init.d/binfmt-support start", "The binfmt-support service could not be started.")
 
 # Fixme: change this to os.execvp()
 c = "/usr/bin/sudo -E -u %s %s" % (g_user.name, " ".join(ops.command))


### PR DESCRIPTION
This change checks if qemu-ppc exists, if not, checks if the binfmt_misc file system is mounted, if not, mounts it and starts the binfmt-support script.