### PR TITLE
removed extra brackets from __init__.py for AS7512

### DIFF
--- a/packages/platforms/accton/x86-64/x86-64-accton-as7512-32x/platform-config/r0/src/python/x86_64_accton_as7512_32x_r0/__init__.py
+++ b/packages/platforms/accton/x86-64/x86-64-accton-as7512-32x/platform-config/r0/src/python/x86_64_accton_as7512_32x_r0/__init__.py
@@ -98,7 +98,5 @@ class OnlPlatform_x86_64_accton_as7512_32x_r0(OnlPlatformAccton):
         self.new_i2c_device('as7512_32x_sfp30', 0x50, 47)
         self.new_i2c_device('as7512_32x_sfp31', 0x50, 48)
         self.new_i2c_device('as7512_32x_sfp32', 0x50, 49)
-                ]
-            )
 
         return True


### PR DESCRIPTION
Dumb error, causes python-minimal and 28 other packages to not get installed properly. Confirmed good on as5712

previous:

root@localhost:~# apt-get upgrade
Reading package lists... Done
Building dependency tree... Done
Calculating upgrade... Done
0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
28 not fully installed or removed.
After this operation, 0 B of additional disk space will be used.
Do you want to continue? [Y/n] n

post change:

root@localhost:~# apt-get upgrade
Reading package lists... Done
Building dependency tree... Done
Calculating upgrade... Done
0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.

issue:

Setting up python2.7-minimal (2.7.9-2) ...
Linking and byte-compiling packages for runtime python2.7...
Sorry: IndentationError: unexpected indent (__init__.py, line 101)