### PR TITLE
Explicit Build Dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ onl-ppc ppc:
 	$(MAKE) -C packages/base/powerpc/onlp
 	$(MAKE) -C packages/base/powerpc/onlp-snmpd
 	$(MAKE) -C packages/base/powerpc/faultd
+	$(MAKE) -C packages/base/powerpc/fit
 	$(MAKE) -C builds/powerpc/rootfs
 	$(MAKE) -C builds/powerpc/swi
 	$(MAKE) -C builds/powerpc/installer/legacy

--- a/Makefile
+++ b/Makefile
@@ -16,13 +16,21 @@ all: amd64 ppc
 	$(MAKE) -C REPO build-clean
 
 onl-amd64 onl-x86 x86 x86_64 amd64:
-	$(MAKE) -C packages/base ARCHES=amd64,all
+	$(MAKE) -C packages/base/amd64/kernels
+	$(MAKE) -C packages/base/amd64/initrds
+	$(MAKE) -C packages/base/amd64/onlp
+	$(MAKE) -C packages/base/amd64/onlp-snmpd
+	$(MAKE) -C packages/base/amd64/faultd
 	$(MAKE) -C builds/amd64/rootfs
 	$(MAKE) -C builds/amd64/swi
 	$(MAKE) -C builds/amd64/installer/legacy
 
 onl-ppc ppc:
-	$(MAKE) -C packages/base ARCHES=powerpc,all
+	$(MAKE) -C packages/base/powerpc/kernels
+	$(MAKE) -C packages/base/powerpc/initrds
+	$(MAKE) -C packages/base/powerpc/onlp
+	$(MAKE) -C packages/base/powerpc/onlp-snmpd
+	$(MAKE) -C packages/base/powerpc/faultd
 	$(MAKE) -C builds/powerpc/rootfs
 	$(MAKE) -C builds/powerpc/swi
 	$(MAKE) -C builds/powerpc/installer/legacy

--- a/packages/base/amd64/initrds/Makefile
+++ b/packages/base/amd64/initrds/Makefile
@@ -1,0 +1,1 @@
+include $(ONL)/make/pkg.mk


### PR DESCRIPTION
There are some subtle corners on the onlpm dependency processing which need to be addressed. 
Until then, the build steps in the top-level makefile have been broken into the correct sequence. 