### PR TITLE
Updated docker builds to 1.1 with new docker_shell

### DIFF
--- a/docker/images/builder7/1.0/Makefile
+++ b/docker/images/builder7/1.0/Makefile
@@ -1,4 +1,4 @@
-VERSION=1.0
+VERSION=1.1
 USER=opennetworklinux
 REPO=builder7
 

--- a/docker/images/builder8/1.0/Makefile
+++ b/docker/images/builder8/1.0/Makefile
@@ -1,4 +1,4 @@
-VERSION=1.0
+VERSION=1.1
 USER=opennetworklinux
 REPO=builder8
 

--- a/docker/tools/onlbuilder
+++ b/docker/tools/onlbuilder
@@ -17,8 +17,8 @@ g_current_user = getpass.getuser()
 g_current_uid  = os.getuid()
 g_timestamp = datetime.datetime.now().strftime("%Y-%m-%d.%H%M%S")
 
-g_builder7_image_name="opennetworklinux/builder7:1.0"
-g_builder8_image_name="opennetworklinux/builder8:1.0"
+g_builder7_image_name="opennetworklinux/builder7:1.1"
+g_builder8_image_name="opennetworklinux/builder8:1.1"
 
 g_default_image_name=g_builder7_image_name
 g_default_container_name = "%s_%s" % (g_current_user, g_timestamp)


### PR DESCRIPTION
New docker images deployed to hub.docker and tested on machine that previously failed due to issues with binfmt.