### PR TITLE
Mount the current working directory in addition to $HOME by default.

### DIFF
--- a/docker/tools/onlbuilder
+++ b/docker/tools/onlbuilder
@@ -96,6 +96,10 @@ ap.add_argument("--volumes",
                 metavar='DIRECTORY',
                 default=[])
 
+ap.add_argument("--no-mount-current",
+                help="Do not mount the current working directory. The default is the current working directory and $HOME",
+                action='store_true')
+
 ap.add_argument("--autobuild",
                 help="Automatic build in isolation mode.",
                 action='store_true')
@@ -159,6 +163,11 @@ if ops.exec_:
 else:
 
    ops.volumes += [ '/lib/modules' ]
+
+   if not ops.no_mount_current:
+      # Add the current working directory to the volume list.
+      ops.volumes.append(os.getcwd())
+
    g_arg_d['volume_options']  = " ".join( [ " -v %s:%s " % (v, v) for v in ops.volumes ] )
 
    g_docker_arguments = "docker run --privileged %(interactive)s -t -e DOCKER_IMAGE=%(image)s  --name %(name)s %(ssh_options)s %(volume_options)s  " % g_arg_d


### PR DESCRIPTION
Previously only $HOME was mounted in developer mode.
Now $HOME and $CWD are both mounted for convenience.
This can be disabled using the --no-mount-current option.