### PR TITLE
moved default buildroot mirror from github to opencompute server

### DIFF
--- a/setup.env
+++ b/setup.env
@@ -31,7 +31,7 @@ export ONLPM_OPTION_INCLUDE_ENV_JSON="$ONL/make/version-onl.json"
 #
 # buildroot download mirror. We suggest you setup a local repository containing these contents for faster local builds.
 #
-export BUILDROOTMIRROR=${BUILDROOTMIRROR:-"https://raw.githubusercontent.com/opennetworklinux/buildroot-download-cache/master/dl"}
+export BUILDROOTMIRROR=${BUILDROOTMIRROR:-"http://buildroot.opennetlinux.org/dl"}
 
 # These submodules are required for almost everything.
 $ONL/tools/submodules.py $ONL sm/infra


### PR DESCRIPTION
Built without issue.

INFO:onlpm:Releasing ONL-2.0.0_ONL-OS_2016-04-19.1838-6c47197_PPC_INSTALLER -> OpenNetworkLinux.br/RELEASE/wheezy/powerpc/