### PR TITLE
allows for the use of . in onie identifiers and updates documentation

### DIFF
--- a/docs/BootProcess.md
+++ b/docs/BootProcess.md
@@ -24,7 +24,7 @@ Detailed Boot Process
 8. The ONL loader runs `/bin/boot $URL`
 9. The ONL loader retrieves the SWI file
     a) if the URL is remote (e.g., http://, ftp://, etc.), verify that there is a locally cached copy
-        of the SWI in /mnt/flash2 or if not, download it
+        of the SWI in /mnt/onl/images or if not, download it
     b) if the URL is local, verify that the device is accessible
     c) if the URL is a Zero Touch Networking (ZTN) URL, the execute the ZTN protocol to get the SWI (see below)
 10. The ONL loader reads the 'rootfs' file out of the SWI and mounts it using overlayfs[1] (SWI contents described below)
@@ -51,23 +51,24 @@ Partition 4+: Free space (unused)
 Mass Storage Device:
 
 Partition 1: ONL loader kernel  -- the format of this partition varies depending on what formats uBoot supports on the specific platform
-Partition 2: ONL Loader configuration files (mounts as "/mnt/flash" both during the loader and the main ONL phases)
-Partition 3: ONL SWitch Images (SWIs) partition (mounts as "/mnt/flash2" both during the loader and the main ONL phases)
+Partition 2: ONL Loader configuration files (mounts as "/mnt/onl/boot" both during the loader and the main ONL phases)
+Partition 3: ONL SWitch Images (SWIs) partition (mounts as "/mnt/onl/images" both during the loader and the main ONL phases)
 
 ONL file system layout
 -----------------------
 
-    root@onl-powerpc:/bin# df
-    Filesystem     1K-blocks  Used Available Use% Mounted on
-    rootfs             72040   176     71864   1% /
-    devtmpfs            1024     0      1024   0% /dev
-    none               72040   176     71864   1% /
-    tmpfs              48028   148     47880   1% /run
-    tmpfs               5120     0      5120   0% /run/lock
-    /dev/sda2          71177     7     71170   1% /mnt/flash
-    /dev/sda3        3791960 98172   3693788   3% /mnt/flash2
-    tmpfs              96040     0     96040   0% /run/shm
-
+    root@as5712-2:/mnt/onl/images# df
+    Filesystem     1K-blocks   Used Available Use% Mounted on
+    rootfs           1215292 145904   1069388  13% /
+    devtmpfs            1024      0      1024   0% /dev
+    none             1215292 145904   1069388  13% /
+    /dev/sdb5        1032088 276700    702960  29% /mnt/onl/images
+    /dev/sdb6        6313528 143612   5849200   3% /mnt/onl/data
+    /dev/sdb3         126931  37007     83371  31% /mnt/onl/boot
+    /dev/sdb4         126931   5651    114727   5% /mnt/onl/config
+    tmpfs             810196    208    809988   1% /run
+    tmpfs               5120      0      5120   0% /run/lock
+    tmpfs            1620380      0   1620380   0% /run/shm
 
 SWI
 --------

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -160,9 +160,9 @@ To enable NFS mounted root partition:
 1) Run the ONL installer normally (e.g., via the manual mode per above) so that the ONL
     loader is installed.
 
-2) Edit /mnt/flash/boot-config, enable DHCP, and change the SWI variable to point to a URL of the form "nfs://$ip[:port]/path/to/directory/".  For example, on my machine, this looks like:
+2) Edit /mnt/onl/boot/boot-config, enable DHCP, and change the SWI variable to point to a URL of the form "nfs://$ip[:port]/path/to/directory/".  For example, on my machine, this looks like:
 
-     # cat /mnt/flash/boot-config
+     # cat /mnt/onl/boot/boot-config
      SWI=nfs://10.6.0.4/home/robs/export/ly2-1/  # trailing '/' is critical
      NETAUTO=dhcp                                # optional, but likely what you want
      NETDEV=ma1                                  # leave untouched

--- a/docs/PersistWorkflow.md
+++ b/docs/PersistWorkflow.md
@@ -18,38 +18,12 @@ It has the following properites:
 
 * Any file that is editted/removed/etc is transparently copied into a RAM disk via overlayfs
 * Thus, any changes to files appear as you would expect, until a reboot
-* Any file that is uneditted remains backed by the /mnt/flash2 file system, so you 
+* Any file that is uneditted remains backed by the /mnt/onl/data file system, so you 
     do not need to have enough RAM to store the entire rootfs.  This is important with
     switches that do not have much RAM to begin with.
 
-That said, ONL does have a provision to persist explicitly marked files
-across a reboot.  This document shows how this works.
+If you want to persist files, you can either install the image directly to disk using
+the Installed installer, put debian files to the /mnt/onl/data/install-debs directory.
+Or use rc.boot files to do system management (/mnt/onl/$dir/rc.boot)
 
-
-# Persisting Files
-
-Just run `/sbin/persist /path/to/file` to mark a file as 'persisted'.  This
-file will be saved to the /mnt/flash persistent storage device and automatically
-put back into place on reboot.  Once a file has been persisted, it will always
-be persisted across reboots.  If you really want to unpersist a file, manually remove it from
-'/persist/rootfs/path/to/file'.
-
-# Under the covers
-
-Running `/sbin/persist file` makes a hardlink of that file, e.g., /foo/bar/baz, to
-/persist/rootfs/foo/bar/baz.  
-
-The `/etc/init.d/restorepersist` script runs on bootup and does a number of things:
-
-* Restores the previously saved cpio archive from /mnt/flash/persist/rootfs into both / and /persist/rootfs
-* Sets up hard links between /persist/rootfs/foo/bar/baz and /foo/bar/baz
-* Starts a `watchdir` process for changes in /persist/rootfs
-
-`watchdir` in turn uses the inotify(3) subsystem to, upon a change, run `/sbin/savepersist /persist/rootfs`.
-
-And so, any change to a persisted file is noticed by watchdir and saved
-to /mnt/flash in a cpio archive automatically using /sbin/savepersist.
-
-# Limitations
-
-You cannot persist any file that is read/used before `/etc/rcS.d/S03restorepersist` is run, including this script itself.  Also, it is NOT recommended for persisting logging files, e.g., /var/log/*.  While technically this will work, you will likely quickly exceed the write cycle limit of the underlying flash memory.  Better to use a syslog server.
+Packages present and listed in /mnt/onl/data/install-debs/list will be installed.

--- a/docs/PortingGuide.md
+++ b/docs/PortingGuide.md
@@ -84,7 +84,7 @@ specific hardware (an ethernet driver) to a device-agnostic form
 
 The following files need to be populated by the $platform boot script:
 * /etc/onl/net : The PCI device name and interface name of the management ethernet
-* /etc/onl/mounts : The devices that correspond to /mnt/flash and /mnt/flash2 at boot
+* /etc/onl/rootfs and /etc/onl/loader : The devices that correspond to /mnt/onl/data and /mnt/onl/boot at boot
 * /etc/fw_env.config : The device and configuration of the firmware device, for fw_printenv, fw_setenv
 
 

--- a/packages/base/all/vendor-config-onl/src/python/onl/install/App.py
+++ b/packages/base/all/vendor-config-onl/src/python/onl/install/App.py
@@ -224,7 +224,7 @@ class App(SubprocessMixin):
             arch = getattr(self.machineConf, 'onie_arch', None)
             if plat and arch:
                 self.log.info("ONL installer running under ONIE.")
-                plat = plat.replace('_', '-')
+                plat = plat.replace('_', '-').replace('.', '-')
         elif os.path.exists("/etc/onl/platform"):
             with open("/etc/onl/platform") as fd:
                 plat = fd.read().strip()

--- a/packages/base/all/vendor-config-onl/src/python/onl/platform/current.py
+++ b/packages/base/all/vendor-config-onl/src/python/onl/platform/current.py
@@ -32,7 +32,7 @@ def import_subsystem_platform_class(subsystem='onl', klass='OnlPlatform'):
     if platform is None:
         raise RuntimeError("cannot find a platform declaration")
 
-    platform_module = platform.replace('-', '_')
+    platform_module = platform.replace('-', '_').replace('.', '_')
 
     # Import the platform module
     m = importlib.import_module('%s.platform.%s' % (subsystem, platform_module))


### PR DESCRIPTION
reviewers @jnealtowns @carlroth trivial change to installer python files to handle Mellanox use of . in their ONIE identifier.  Also some updates to the documentation.