### PR TITLE
Updates the Wedge 40 and 100 systems to use the 3.16 kernel

### DIFF
--- a/packages/platforms/accton/x86-64/x86-64-accton-wedge-16x/platform-config/r0/src/lib/x86-64-accton-wedge-16x-r0.yml
+++ b/packages/platforms/accton/x86-64/x86-64-accton-wedge-16x/platform-config/r0/src/lib/x86-64-accton-wedge-16x-r0.yml
@@ -18,7 +18,7 @@ x86-64-accton-wedge-16x-r0:
       --stop=1
 
     kernel: 
-      <<: *kernel-3-18
+      <<: *kernel-3-16
 
     args: >-
       nopat

--- a/packages/platforms/accton/x86-64/x86-64-facebook-wedge100/platform-config/r0/src/lib/x86-64-facebook-wedge100-r0.yml
+++ b/packages/platforms/accton/x86-64/x86-64-facebook-wedge100/platform-config/r0/src/lib/x86-64-facebook-wedge100-r0.yml
@@ -18,7 +18,7 @@ x86-64-facebook-wedge100-r0:
       --stop=1
 
     kernel: 
-      <<: *kernel-3-18
+      <<: *kernel-3-16
 
     args: >-
       nopat


### PR DESCRIPTION
@capveg @jnealtowns only one switch (AS5512) left on the 3.18 kernel.