### PR TITLE
Handle unformatted/corrupted partition tables, see SWL-3246

### DIFF
--- a/packages/base/all/vendor-config-onl/src/python/onl/install/BaseInstall.py
+++ b/packages/base/all/vendor-config-onl/src/python/onl/install/BaseInstall.py
@@ -697,8 +697,8 @@ class UbootInstaller(SubprocessMixin, Base):
         except (DiskException, PartedException) as ex:
             self.log.error("cannot get partition table from %s: %s",
                            self.device, str(ex))
-        except Exception as ex:
-            self.log.exception("cannot get partition table from %s: %s",
+        except Exception:
+            self.log.exception("cannot get partition table from %s",
                                self.device)
 
         self.log.info("clobbering disk label on %s", self.device)


### PR DESCRIPTION
Reviewer: @jnealtowns @sonoble 

- handle more pyparted exceptions
- properly clobber the disk signature

I did some ad-hoc testing on this on a ppc machine:
1. properly handles valid msdos disk label
2. properly handles valid gpt disk label (reformats to msdos)
3. properly handles "empty" (dd if=/dev/null) disk label
