### PR TITLE
adds base-files dependency to faultd

### DIFF
--- a/packages/base/any/faultd/APKG.yml
+++ b/packages/base/any/faultd/APKG.yml
@@ -3,13 +3,12 @@ common:
   version: 1.0.0
   copyright: Copyright 2013, 2014, 2015 Big Switch Networks
   maintainer: support@bigswitch.com
-
+  depends: base-files
 packages:
   - name: onl-faultd
     version: 1.0.0
     summary: Fault Reporting Daemon
     provides: [ faultd ]
-
     files:
       builds/$BUILD_DIR/${TOOLCHAIN}/bin/faultd.bin : /usr/bin/faultd
 


### PR DESCRIPTION
This change allows base-files to be installed and set up before faultd.