### PR TITLE
Added community support information.

### DIFF
--- a/builds/any/installer/APKG.yml
+++ b/builds/any/installer/APKG.yml
@@ -10,6 +10,7 @@ common:
   version: 0.$FNAME_RELEASE_ID
   copyright: Copyright 2016 Big Switch Networks
   maintainer: support@bigswitch.com
+  support: opennetworklinux@googlegroups.com
 
 packages:
   - name: onl-installer-$BOOTMODE

--- a/builds/any/rootfs/APKG.yml
+++ b/builds/any/rootfs/APKG.yml
@@ -9,6 +9,7 @@ common:
   version: 0.$FNAME_RELEASE_ID
   copyright: Copyright 2013, 2014, 2015 Big Switch Networks
   maintainer: support@bigswitch.com
+  support: opennetworklinux@googlegroups.com
 
 packages:
   - name: onl-rootfs

--- a/builds/any/swi/APKG.yml
+++ b/builds/any/swi/APKG.yml
@@ -10,6 +10,7 @@ common:
   version: 0.$FNAME_RELEASE_ID
   copyright: Copyright 2013, 2014, 2015 Big Switch Networks
   maintainer: support@bigswitch.com
+  support: opennetworklinux@googlegroups.com
 
 packages:
   - name: onl-swi


### PR DESCRIPTION
Added community support information opennetworklinux@googlegroups.com, as support@bigswitch.com "is a support line for commercial Big Switch products for customer with paid licenses."
