### PR TITLE
 Added community support email opennetworklinux@googlegroups.com

### DIFF
--- a/builds/any/installer/APKG.yml
+++ b/builds/any/installer/APKG.yml
@@ -10,6 +10,7 @@ common:
   version: 0.$FNAME_RELEASE_ID
   copyright: Copyright 2016 Big Switch Networks
   maintainer: support@bigswitch.com
+  support: opennetworklinux@googlegroups.com
 
 packages:
   - name: onl-installer-$BOOTMODE

--- a/builds/any/rootfs/APKG.yml
+++ b/builds/any/rootfs/APKG.yml
@@ -9,6 +9,7 @@ common:
   version: 0.$FNAME_RELEASE_ID
   copyright: Copyright 2013, 2014, 2015 Big Switch Networks
   maintainer: support@bigswitch.com
+  support: opennetworklinux@googlegroups.com
 
 packages:
   - name: onl-rootfs

--- a/builds/any/swi/APKG.yml
+++ b/builds/any/swi/APKG.yml
@@ -10,6 +10,7 @@ common:
   version: 0.$FNAME_RELEASE_ID
   copyright: Copyright 2013, 2014, 2015 Big Switch Networks
   maintainer: support@bigswitch.com
+  support: opennetworklinux@googlegroups.com
 
 packages:
   - name: onl-swi

--- a/docker/tools/PKG.yml
+++ b/docker/tools/PKG.yml
@@ -3,6 +3,7 @@ common:
   version: 1.1.0
   copyright: Copyright 2013, 2014, 2015 Big Switch Networks
   maintainer: support@bigswitch.com
+  support: opennetworklinux@googlegroups.com
 
 packages:
   - name: onl-docker-tools

--- a/packages/base/all/boot.d/PKG.yml
+++ b/packages/base/all/boot.d/PKG.yml
@@ -3,6 +3,7 @@ common:
   version: 1.0.0
   copyright: Copyright 2013, 2014, 2015 Big Switch Networks
   maintainer: support@bigswitch.com
+  support: opennetworklinux@googlegroups.com
 
 packages:
   - name: onl-bootd

--- a/packages/base/all/initrds/loader-initrd-files/PKG.yml
+++ b/packages/base/all/initrds/loader-initrd-files/PKG.yml
@@ -3,6 +3,7 @@ common:
   version: 1.0.0
   copyright: Copyright 2013, 2014, 2015 Big Switch Networks
   maintainer: support@bigswitch.com
+  support: opennetworklinux@googlegroups.com
 
 packages:
   - name: onl-loader-initrd-files

--- a/packages/base/all/onl-mibs/PKG.yml
+++ b/packages/base/all/onl-mibs/PKG.yml
@@ -3,6 +3,7 @@ common:
   version: 1.0.0
   copyright: Copyright 2013, 2014, 2015 Big Switch Networks
   maintainer: support@bigswitch.com
+  support: opennetworklinux@googlegroups.com
 
 packages:
   - name: onl-mibs

--- a/packages/base/all/vendor-config-onl/PKG.yml
+++ b/packages/base/all/vendor-config-onl/PKG.yml
@@ -8,6 +8,7 @@ packages:
     arch: all
     copyright: Copyright 2013, 2014, 2015 Big Switch Networks
     maintainer: support@bigswitch.com
+    support: opennetworklinux@googlegroups.com
     summary: ONL Base Configuration Package
 
     files:

--- a/packages/base/amd64/kernels/kernel-3.16+deb8-x86-64-all/PKG.yml
+++ b/packages/base/amd64/kernels/kernel-3.16+deb8-x86-64-all/PKG.yml
@@ -4,6 +4,7 @@ common:
   version: 1.0.0
   copyright: Copyright 2013, 2014, 2015 Big Switch Networks
   maintainer: support@bigswitch.com
+  support: opennetworklinux@googlegroups.com
 
 packages:
   - name: onl-kernel-3.16+deb8-x86-64-all

--- a/packages/base/amd64/kernels/kernel-3.18-x68-64-all/PKG.yml
+++ b/packages/base/amd64/kernels/kernel-3.18-x68-64-all/PKG.yml
@@ -4,6 +4,7 @@ common:
   version: 1.0.0
   copyright: Copyright 2013, 2014, 2015 Big Switch Networks
   maintainer: support@bigswitch.com
+  support: opennetworklinux@googlegroups.com
 
 packages:
   - name: onl-kernel-3.18-x86-64-all

--- a/packages/base/amd64/kernels/kernel-3.2-deb7-x86-64-all/PKG.yml
+++ b/packages/base/amd64/kernels/kernel-3.2-deb7-x86-64-all/PKG.yml
@@ -4,6 +4,7 @@ common:
   version: 1.0.0
   copyright: Copyright 2013, 2014, 2015 Big Switch Networks
   maintainer: support@bigswitch.com
+  support: opennetworklinux@googlegroups.com
 
 packages:
   - name: onl-kernel-3.2-deb7-x86-64-all

--- a/packages/base/amd64/kernels/legacy/kernel-3.9.6-x86-64-all/PKG.yml
+++ b/packages/base/amd64/kernels/legacy/kernel-3.9.6-x86-64-all/PKG.yml
@@ -7,6 +7,7 @@ common:
   version: 1.0.0
   copyright: Copyright 2013, 2014, 2015 Big Switch Networks
   maintainer: support@bigswitch.com
+  support: opennetworklinux@googlegroups.com
 
 packages:
   - name: onl-kernel-3.9.6-x86-64-all

--- a/packages/base/amd64/upgrade/PKG.yml
+++ b/packages/base/amd64/upgrade/PKG.yml
@@ -11,6 +11,7 @@ common:
   version: 1.0.0
   copyright: Copyright 2013, 2014, 2015 Big Switch Networks
   maintainer: support@bigswitch.com
+  support: opennetworklinux@googlegroups.com
 
 packages:
   - name: onl-upgrade

--- a/packages/base/any/faultd/APKG.yml
+++ b/packages/base/any/faultd/APKG.yml
@@ -3,6 +3,7 @@ common:
   version: 1.0.0
   copyright: Copyright 2013, 2014, 2015 Big Switch Networks
   maintainer: support@bigswitch.com
+  support: opennetworklinux@googlegroups.com
   depends: base-files
 packages:
   - name: onl-faultd

--- a/packages/base/any/fit/buildroot/APKG.yml
+++ b/packages/base/any/fit/buildroot/APKG.yml
@@ -7,6 +7,7 @@ common:
   version: 1.0.0
   copyright: Copyright 2013, 2014, 2015 Big Switch Networks
   maintainer: support@bigswitch.com
+  support: opennetworklinux@googlegroups.com
 
 packages:
   - name: onl-buildroot-fit

--- a/packages/base/any/fit/loader/APKG.yml
+++ b/packages/base/any/fit/loader/APKG.yml
@@ -7,6 +7,7 @@ common:
   version: 1.0.0
   copyright: Copyright 2013, 2014, 2015 Big Switch Networks
   maintainer: support@bigswitch.com
+  support: opennetworklinux@googlegroups.com
 
 packages:
   - name: onl-loader-fit

--- a/packages/base/any/initrds/buildroot/APKG.yml
+++ b/packages/base/any/initrds/buildroot/APKG.yml
@@ -14,6 +14,7 @@ common:
   version: 1.0.0
   copyright: Copyright 2013, 2014, 2015 Big Switch Networks
   maintainer: support@bigswitch.com
+  support: opennetworklinux@googlegroups.com
 
 packages:
   - name: onl-buildroot-initrd

--- a/packages/base/any/initrds/loader/APKG.yml
+++ b/packages/base/any/initrds/loader/APKG.yml
@@ -13,6 +13,7 @@ common:
   version: 1.0.0
   copyright: Copyright 2013, 2014, 2015 Big Switch Networks
   maintainer: support@bigswitch.com
+  support: opennetworklinux@googlegroups.com
 
 packages:
   - name: onl-loader-initrd

--- a/packages/base/any/onlp-snmpd/APKG.yml
+++ b/packages/base/any/onlp-snmpd/APKG.yml
@@ -6,6 +6,7 @@ common:
   version: 1.0.0
   copyright: Copyright 2013, 2014, 2015 Big Switch Networks
   maintainer: support@bigswitch.com
+  support: opennetworklinux@googlegroups.com
 
 packages:
   - name: onlp-snmpd

--- a/packages/base/any/onlp/APKG.yml
+++ b/packages/base/any/onlp/APKG.yml
@@ -14,6 +14,7 @@ common:
   version: 1.0.0
   copyright: Copyright 2013, 2014, 2015 Big Switch Networks
   maintainer: support@bigswitch.com
+  support: opennetworklinux@googlegroups.com
 
 packages:
   - name: onlp

--- a/packages/base/any/oom-shim/APKG.yml
+++ b/packages/base/any/oom-shim/APKG.yml
@@ -13,6 +13,7 @@ common:
   version: 1.0.0
   copyright: Copyright 2016 Big Switch Networks
   maintainer: support@bigswitch.com
+  support: opennetworklinux@googlegroups.com
 
 
 

--- a/packages/base/any/templates/onlp-platform-any.yml
+++ b/packages/base/any/templates/onlp-platform-any.yml
@@ -15,6 +15,7 @@ common:
   arch: $ARCH
   copyright: Copyright 2013, 2014, 2015 Big Switch Networks
   maintainer: support@bigswitch.com
+  support: opennetworklinux@googlegroups.com
 
 packages:
   - name: onlp-${PLATFORM}-r0

--- a/packages/base/any/templates/platform-config-platform.yml
+++ b/packages/base/any/templates/platform-config-platform.yml
@@ -13,6 +13,7 @@ packages:
     arch: $ARCH
     copyright: Copyright 2013, 2014, 2015 Big Switch Networks
     maintainer: support@bigswitch.com
+    support: opennetworklinux@googlegroups.com
     summary: ONL Platform Configuration Package for the ${PLATFORM}
 
     files:

--- a/packages/base/any/templates/platform-config-vendor.yml
+++ b/packages/base/any/templates/platform-config-vendor.yml
@@ -8,6 +8,7 @@ packages:
     arch: all
     copyright: Copyright 2013, 2014, 2015 Big Switch Networks
     maintainer: support@bigswitch.com
+    support: opennetworklinux@googlegroups.com
     summary: ONL Configuration Package for ${Vendor} Platforms
 
     files:

--- a/packages/base/arm64/kernels/kernel-3.18.25-arm64-all/PKG.yml
+++ b/packages/base/arm64/kernels/kernel-3.18.25-arm64-all/PKG.yml
@@ -4,6 +4,7 @@ common:
   version: 1.0.0
   copyright: Copyright 2013, 2014, 2015 Big Switch Networks
   maintainer: support@bigswitch.com
+  support: opennetworklinux@googlegroups.com
 
 packages:
   - name: onl-kernel-3.18.25-arm64-all

--- a/packages/base/armel/kernels/kernel-3.2-deb7-arm-iproc-all/PKG.yml
+++ b/packages/base/armel/kernels/kernel-3.2-deb7-arm-iproc-all/PKG.yml
@@ -4,6 +4,7 @@ common:
   version: 1.0.0
   copyright: Copyright 2013, 2014, 2015 Big Switch Networks
   maintainer: support@bigswitch.com
+  support: opennetworklinux@googlegroups.com
 
 packages:
   - name: onl-kernel-3.2-deb7-arm-iproc-all

--- a/packages/base/powerpc/kernels/kernel-3.2-deb7-powerpc-e500v-all/PKG.yml
+++ b/packages/base/powerpc/kernels/kernel-3.2-deb7-powerpc-e500v-all/PKG.yml
@@ -3,6 +3,7 @@ common:
   version: 1.0.0
   copyright: Copyright 2013, 2014, 2015 Big Switch Networks
   maintainer: support@bigswitch.com
+  support: opennetworklinux@googlegroups.com
 
 packages:
   - name: onl-kernel-3.2-deb7-powerpc-e500v-all

--- a/packages/base/powerpc/kernels/legacy/kernel-3.8.13-powerpc-e500mc/PKG.yml
+++ b/packages/base/powerpc/kernels/legacy/kernel-3.8.13-powerpc-e500mc/PKG.yml
@@ -7,6 +7,7 @@ common:
   version: 1.0.0
   copyright: Copyright 2013, 2014, 2015 Big Switch Networks
   maintainer: support@bigswitch.com
+  support: opennetworklinux@googlegroups.com
 
 packages:
   - name: onl-kernel-3.8.13-powerpc-e500mc

--- a/packages/base/powerpc/kernels/legacy/kernel-3.9.6-powerpc-e500v/PKG.yml
+++ b/packages/base/powerpc/kernels/legacy/kernel-3.9.6-powerpc-e500v/PKG.yml
@@ -7,6 +7,7 @@ common:
   version: 1.0.0
   copyright: Copyright 2013, 2014, 2015 Big Switch Networks
   maintainer: support@bigswitch.com
+  support: opennetworklinux@googlegroups.com
 
 packages:
   - name: onl-kernel-3.9.6-powerpc-e500v

--- a/packages/platforms/accton/powerpc/powerpc-accton-as5710-54x/onlp/PKG.yml
+++ b/packages/platforms/accton/powerpc/powerpc-accton-as5710-54x/onlp/PKG.yml
@@ -12,6 +12,7 @@ common:
   arch: powerpc
   copyright: Copyright 2013, 2014, 2015 Big Switch Networks
   maintainer: support@bigswitch.com
+  support: opennetworklinux@googlegroups.com
 
 packages:
   - name: onlp-${r0_platform}-r0

--- a/packages/platforms/accton/powerpc/powerpc-accton-as6700-32x/onlp/PKG.yml
+++ b/packages/platforms/accton/powerpc/powerpc-accton-as6700-32x/onlp/PKG.yml
@@ -8,6 +8,7 @@ common:
   arch: powerpc
   copyright: Copyright 2013, 2014, 2015 Big Switch Networks
   maintainer: support@bigswitch.com
+  support: opennetworklinux@googlegroups.com
   changelog:  Change changes changes.,
 
 

--- a/packages/platforms/accton/x86-64/x86-64-accton-wedge-16x/onlp/PKG.yml
+++ b/packages/platforms/accton/x86-64/x86-64-accton-wedge-16x/onlp/PKG.yml
@@ -7,6 +7,7 @@ common:
   arch: amd64
   copyright: Copyright 2013, 2014, 2015 Big Switch Networks
   maintainer: support@bigswitch.com
+  support: opennetworklinux@googlegroups.com
   comment: dummy package for ONLP on Wedge
 packages:
   - name: onlp-${platform}

--- a/packages/platforms/accton/x86-64/x86-64-facebook-wedge100/onlp/PKG.yml
+++ b/packages/platforms/accton/x86-64/x86-64-facebook-wedge100/onlp/PKG.yml
@@ -7,6 +7,7 @@ common:
   arch: amd64
   copyright: Copyright 2013, 2014, 2015 Big Switch Networks
   maintainer: support@bigswitch.com
+  support: opennetworklinux@googlegroups.com
   comment: dummy package for ONLP on Wedge
 packages:
   - name: onlp-${platform}

--- a/packages/platforms/agema/x86-64/x86-64-agema-agc7648/onlp/PKG.yml
+++ b/packages/platforms/agema/x86-64/x86-64-agema-agc7648/onlp/PKG.yml
@@ -7,6 +7,7 @@ common:
   arch: amd64
   copyright: Copyright 2013, 2014, 2015 Big Switch Networks
   maintainer: support@bigswitch.com
+  support: opennetworklinux@googlegroups.com
   comment: dummy package for ONLP on Wedge
 packages:
   - name: onlp-${platform}


### PR DESCRIPTION
 Added community support email opennetworklinux@googlegroups.com, as support@bigswitch.com "is a support line for commercial Big Switch products for customer with paid licenses."
