### PR TITLE
onlp-snmp: registering onl resource

### DIFF
--- a/packages/base/any/onlp-snmpd/builds/src/onlp_snmp/module/src/onlp_snmp_platform.c
+++ b/packages/base/any/onlp-snmpd/builds/src/onlp_snmp/module/src/onlp_snmp_platform.c
@@ -83,7 +83,7 @@ resource_int_register(int index, const char* desc,
         netsnmp_create_handler_registration(desc, handler,
                                             tree, OID_LENGTH(tree),
                                             HANDLER_CAN_RONLY);
-    if (netsnmp_register_scalar(reg) != MIB_REGISTERED_OK) {
+    if (netsnmp_register_instance(reg) != MIB_REGISTERED_OK) {
         AIM_LOG_ERROR("registering handler for %s failed", desc);
     }
 }


### PR DESCRIPTION
Reviewer: @jnealtowns 
In resource_int_register, use netsnmp_register_instance so that SNMP trap can be generated.

