### PR TITLE
onlp-snmpd: resource stat update

### DIFF
--- a/packages/base/any/onlp-snmpd/APKG.yml
+++ b/packages/base/any/onlp-snmpd/APKG.yml
@@ -17,6 +17,7 @@ packages:
       builds/$BUILD_DIR/${TOOLCHAIN}/bin/onlp-snmpd: /usr/bin/onlp-snmpd
       ${ONL}/packages/base/any/onlp-snmpd/bin/onl-snmpwalk : /usr/bin/onl-snmpwalk
       ${ONL}/packages/base/any/onlp-snmpd/bin/onl-snmp-mpstat : /usr/bin/onl-snmp-mpstat
+      ${ONL}/packages/base/any/onlp-snmpd/bin/onl-snmp-mpstat-update : /usr/bin/onl-snmp-mpstat-update
 
     init: ${ONL}/packages/base/any/onlp-snmpd/onlp-snmpd.init
 

--- a/packages/base/any/onlp-snmpd/bin/onl-snmp-mpstat
+++ b/packages/base/any/onlp-snmpd/bin/onl-snmp-mpstat
@@ -3,6 +3,13 @@
 # call mpstat and generate json output containing stats for all cpus
 
 """
+sample output from "mpstat":
+# mpstat
+Linux 3.8.13-OpenNetworkLinux-e500mc-1.5 (as6700-3) 02/09/2017 _ppc_(4 CPU)
+
+01:57:43 PM  CPU    %usr   %nice    %sys %iowait    %irq   %soft  %steal  %guest  %gnice   %idle
+01:57:43 PM  all    4.63    0.00    1.91    0.00    0.00    0.11    0.00    0.00    0.00   93.35
+
 sample output from "mpstat 1 1":
 # mpstat 1 1
 Linux 3.8.13-OpenNetworkLinux-e500mc-1.5 (as6700-3) 2016-12-15 _ppc_(4 CPU)
@@ -14,21 +21,41 @@ Average:     all    5.17    0.00    2.07    0.00    0.00    0.00    0.00    0.00
 
 import subprocess
 import json
+import sys
+
+if len(sys.argv) != 2:
+    print 'usage: %s <interval>' % sys.argv[0]
+    sys.exit(1)
+
+laststat = '/tmp/mpstat.last'
+
+# time interval over which to collect stats, in seconds
+interval = sys.argv[1]
 
 stats = {}
 
-# 1 second interval, 1 count
-out = subprocess.check_output(['mpstat','1','1'])
+# read last updated stats
+try:
+    with open(laststat, 'r') as f:
+        out = [ line.strip('\n') for line in f ]
+except IOError:
+    # use mpstats from beginning of time
+    out = subprocess.check_output('mpstat').split('\n')
 
-for line in out.split('\n'):
+for line in out:
     if "%idle" in line:
-        # extract keys from header line, skipping over time and AM/PM if present
+        # extract keys from header line,
+        # skipping over time and AM/PM if present
         tokens = line.split()
-        keys = tokens[tokens.index('CPU'):]
+        token_start = tokens.index('CPU')
+        keys = tokens[token_start:]
 
-    if "Average" in line:
-        vals = line.split()[1:]
+    if ("all" in line) and ("Average" not in line):
+        vals = line.split()[token_start:]
         stats[vals[0]] = { k:int(round(100*float(v))) \
                                for (k,v) in zip(keys[1:],vals[1:]) }
 
 print json.dumps(stats)
+
+# start up next update in the background
+subprocess.Popen(['/usr/bin/onl-snmp-mpstat-update', laststat, interval])

--- a/packages/base/any/onlp-snmpd/bin/onl-snmp-mpstat-update
+++ b/packages/base/any/onlp-snmpd/bin/onl-snmp-mpstat-update
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+PROG=`basename $0`
+TMPFILE=/tmp/$PROG.tmp
+
+if [ $# -ne 2 ]; then
+    echo "usage: $PROG <filename> <interval>"
+    exit 1
+fi
+
+# filename to which update should be written
+LASTSTAT=$1
+# time interval over which to collect stats, in seconds
+INTERVAL=$2
+
+mpstat $INTERVAL 1 > $TMPFILE
+mv $TMPFILE $LASTSTAT


### PR DESCRIPTION
Reviewer: @jnealtowns 

Move resource stat update out from netsnmp oid handler; resource update is now invoked from alarm handler.

Refactor onl-snmp-mpstat script to work around the inherent delay of mpstat. When resource stats are updated, they are extracted from previously cached mpstat output, and a new update is launched in the background. Note that reported stats will be ONLP_SNMP_CONFIG_RESOURCE_UPDATE_SECONDS out of date.