### PR TITLE
If the thermal sensor is missing, call onlp_oid_show_state_missing().

### DIFF
--- a/packages/base/any/onlp/src/onlp/module/src/thermal.c
+++ b/packages/base/any/onlp/src/onlp/module/src/thermal.c
@@ -257,7 +257,7 @@ onlp_thermal_show(onlp_oid_t id, aim_pvs_t* pvs, uint32_t flags)
         }
         else {
             /* Not present */
-            iof_iprintf(&iof, "State: Missing.");
+            onlp_oid_show_state_missing(&iof);
         }
     }
     iof_pop(&iof);


### PR DESCRIPTION
Reviewer: @jnealtowns @sonoble 

Apparently the period at the end of "State: Missing." results in a malformed enumeration value.