### PR TITLE
[Platform]Accton as7312_54x, fixes insertion of the wrong psu driver

### DIFF
--- a/packages/platforms/accton/x86-64/x86-64-accton-as7312-54x/platform-config/r0/src/python/x86_64_accton_as7312_54x_r0/__init__.py
+++ b/packages/platforms/accton/x86-64/x86-64-accton-as7312-54x/platform-config/r0/src/python/x86_64_accton_as7312_54x_r0/__init__.py
@@ -9,7 +9,7 @@ class OnlPlatform_x86_64_accton_as7312_54x_r0(OnlPlatformAccton,
     SYS_OBJECT_ID=".7312.54"
 
     def baseconfig(self):
-        self.insmod('cpr_4011_4mxx')
+        self.insmod('ym2651y')
         for m in [ 'cpld', 'fan', 'psu', 'leds', 'sfp' ]:
             self.insmod("x86-64-accton-as7312-54x-%s.ko" % m)
 


### PR DESCRIPTION
With wrong PSU drivers, ONLP cannot get the correct status of power modules.