### PR TITLE
Support Prebuilt Artifacts

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "packages/platforms-closed"]
 	path = packages/platforms-closed
 	url = git@github.com:opennetworklinux/platforms-closed
+[submodule "sm/build-artifacts"]
+	path = sm/build-artifacts
+	url = git@github.com:opennetworklinux/build-artifacts

--- a/packages/platforms/delta/x86-64/x86-64-delta-ag5648/.gitignore
+++ b/packages/platforms/delta/x86-64/x86-64-delta-ag5648/.gitignore
@@ -1,3 +1,2 @@
-*x86*64*delta_agc7648a*.mk
+*x86*64*delta*ag5648*.mk
 onlpdump.mk
-

--- a/packages/platforms/quanta/x86-64/x86-64-quanta-ly4r/.gitignore
+++ b/packages/platforms/quanta/x86-64/x86-64-quanta-ly4r/.gitignore
@@ -1,2 +1,2 @@
-*x86*64*quanta*ly4r*rangeley.mk
+*x86*64*quanta*ly4r*.mk
 onlpdump.mk

--- a/setup.env
+++ b/setup.env
@@ -36,6 +36,10 @@ export BUILDROOTMIRROR=${BUILDROOTMIRROR:-"http://buildroot.opennetlinux.org/dl"
 # These submodules are required for almost everything.
 $ONL/tools/submodules.py $ONL sm/infra
 $ONL/tools/submodules.py $ONL sm/bigcode
+$ONL/tools/submodules.py $ONL sm/build-artifacts
+
+# Prepopulate local REPO with build-artifacts.
+cp -R $ONL/sm/build-artifacts/REPO/* $ONL/REPO
 
 # Export the current debian suite
 export ONL_DEBIAN_SUITE=$(lsb_release -c -s)


### PR DESCRIPTION
A new build-artifacts repository has been introduced to provide prebuilt binaries for ONL packages which change so infrequently that they should never really need to be rebuilt. 

These artifacts are part of a different repository so they can be managed separately from (and not bloat permanently and unnecessarily) the main ONL repository. 

The first artifacts added here are for the buildroot cpio packages. These will be pre populated at setup time into the local REPO. 

This prebuilt artifact does not preclude rebuilding the package locally if necessary. 
