### PR TITLE
Added doc and support for building behind an HTTP proxy

### DIFF
--- a/builds/any/rootfs/jessie/standard/standard.yml
+++ b/builds/any/rootfs/jessie/standard/standard.yml
@@ -42,7 +42,7 @@ Multistrap:
 
   ONL:
     packages: *Packages
-    source: http://apt.opennetlinux.org/debian
+    source: http://${APT_CACHE}apt.opennetlinux.org/debian
     suite: unstable
     omitdebsrc: true
 

--- a/builds/any/rootfs/stretch/standard/standard.yml
+++ b/builds/any/rootfs/stretch/standard/standard.yml
@@ -42,7 +42,7 @@ Multistrap:
 
   ONL:
     packages: *Packages
-    source: http://apt.opennetlinux.org/debian
+    source: http://${APT_CACHE}apt.opennetlinux.org/debian
     suite: unstable
     omitdebsrc: true
 

--- a/builds/any/rootfs/wheezy/standard/standard.yml
+++ b/builds/any/rootfs/wheezy/standard/standard.yml
@@ -42,7 +42,7 @@ Multistrap:
 
   ONL:
     packages: *Packages
-    source: http://apt.opennetlinux.org/debian
+    source: http://${APT_CACHE}apt.opennetlinux.org/debian
     suite: unstable
     omitdebsrc: true
 

--- a/docs/README-proxy.md
+++ b/docs/README-proxy.md
@@ -1,4 +1,4 @@
-===== How to build ONL behind an HTTP Proxy =====
+# How to build ONL behind an HTTP Proxy
 
 Many corporate environments don't provide native access to the Internet
 and instead all access must go through an HTTP proxy.  Since the ONL
@@ -17,7 +17,7 @@ reduce that pain.
 
      $ grep Proxy /etc/apt-cacher-ng/acng.conf
      Proxy: http://myproxy.mycompany.com:8080
-     # /etc/init.d/apt-cacher-ng restart
+     $ sudo /etc/init.d/apt-cacher-ng restart
 
 3) Make sure your git config is configured correctly for 
     proxies:

--- a/docs/README-proxy.md
+++ b/docs/README-proxy.md
@@ -6,12 +6,6 @@ build process dynamically pulls lots of things, this can be a pain.
 While everyone's setup is different, hopefully these directions help
 reduce that pain.
 
-
-* Update the git modules to point to http: instead of git:
-
-
-       sed -i -e 's/git:/http:/' $ONL/.gitmodules
-
 * Make sure you have apt-cacher-ng installed in your host (non-docker)
     environment and that docker starts it.  Next, configure it to use
     your proxy:

--- a/docs/README-proxy.md
+++ b/docs/README-proxy.md
@@ -1,0 +1,29 @@
+===== How to build ONL behind an HTTP Proxy =====
+
+Many corporate environments don't provide native access to the Internet
+and instead all access must go through an HTTP proxy.  Since the ONL
+build process dynamically pulls lots of things, this can be a pain.
+While everyone's setup is different, hopefully these directions help
+reduce that pain.
+
+
+1) Update the git modules to point to http: instead of git:
+
+    sed -i -e 's/git:/http:/' $ONL/.gitmodules
+
+2) Make sure you have apt-cacher-ng installed in your host (non-docker)
+    environment and that docker starts it.  Next, configure it to use
+    your proxy:
+
+     $ grep Proxy /etc/apt-cacher-ng/acng.conf
+     Proxy: http://myproxy.mycompany.com:8080
+     # /etc/init.d/apt-cacher-ng restart
+
+3) Make sure your git config is configured correctly for 
+    proxies:
+
+    $ cat ~/.gitconfig
+    [https]
+        proxy = myproxy.mycompany.com:8080
+    [https]
+        proxy = myproxy.mycompany.com:8080

--- a/docs/README-proxy.md
+++ b/docs/README-proxy.md
@@ -7,23 +7,24 @@ While everyone's setup is different, hopefully these directions help
 reduce that pain.
 
 
-1) Update the git modules to point to http: instead of git:
+* Update the git modules to point to http: instead of git:
 
-    sed -i -e 's/git:/http:/' $ONL/.gitmodules
 
-2) Make sure you have apt-cacher-ng installed in your host (non-docker)
+       sed -i -e 's/git:/http:/' $ONL/.gitmodules
+
+* Make sure you have apt-cacher-ng installed in your host (non-docker)
     environment and that docker starts it.  Next, configure it to use
     your proxy:
 
-     $ grep Proxy /etc/apt-cacher-ng/acng.conf
-     Proxy: http://myproxy.mycompany.com:8080
-     $ sudo /etc/init.d/apt-cacher-ng restart
+      $ grep Proxy /etc/apt-cacher-ng/acng.conf
+      Proxy: http://myproxy.mycompany.com:8080
+      $ sudo /etc/init.d/apt-cacher-ng restart
 
-3) Make sure your git config is configured correctly for 
+* Make sure your git config is configured correctly for 
     proxies:
 
-    $ cat ~/.gitconfig
-    [https]
-        proxy = myproxy.mycompany.com:8080
-    [https]
-        proxy = myproxy.mycompany.com:8080
+      $ cat ~/.gitconfig
+      [https]
+           proxy = myproxy.mycompany.com:8080
+      [https]
+           proxy = myproxy.mycompany.com:8080


### PR DESCRIPTION
Let me know if your open to changing the default git repo URLs to use https:// instead of git:// which would remove a step.  At least https://help.github.com/articles/which-remote-url-should-i-use/ seems to recommend it as a default but I'm not sure of all of the implications.