### PR TITLE
[Quanta-LY8] Add Support for OOM:

### DIFF
--- a/packages/platforms/quanta/x86-64/modules/builds/optoe.c
+++ b/packages/platforms/quanta/x86-64/modules/builds/optoe.c
@@ -1,0 +1,1154 @@
+/*
+ * optoe.c - A driver to read and write the EEPROM on optical transceivers
+ * (SFP, QSFP and similar I2C based devices)
+ *
+ * Copyright (C) 2014 Cumulus networks Inc.
+ * Copyright (C) 2017 Finisar Corp.
+ * Copyright (C) 2017 Quanta
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Freeoftware Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+/*
+ *	Description:
+ *	a) Optical transceiver EEPROM read/write transactions are just like
+ *		the at24 eeproms managed by the at24.c i2c driver
+ *	b) The register/memory layout is up to 256 128 byte pages defined by
+ *		a "pages valid" register and switched via a "page select"
+ *		register as explained in below diagram.
+ *	c) 256 bytes are mapped at a time. 'Lower page 00h' is the first 128
+ *	        bytes of address space, and always references the same
+ *	        location, independent of the page select register.
+ *	        All mapped pages are mapped into the upper 128 bytes 
+ *	        (offset 128-255) of the i2c address.
+ *	d) Devices with one I2C address (eg QSFP) use I2C address 0x50 
+ *		(A0h in the spec), and map all pages in the upper 128 bytes
+ *		of that address.
+ *	e) Devices with two I2C addresses (eg SFP) have 256 bytes of data
+ *		at I2C address 0x50, and 256 bytes of data at I2C address
+ *		0x51 (A2h in the spec).  Page selection and paged access
+ *		only apply to this second I2C address (0x51).
+ *	e) The address space is presented, by the driver, as a linear 
+ *	        address space.  For devices with one I2C client at address
+ *	        0x50 (eg QSFP), offset 0-127 are in the lower
+ *	        half of address 50/A0h/client[0].  Offset 128-255 are in
+ *	        page 0, 256-383 are page 1, etc.  More generally, offset
+ *	        'n' resides in page (n/128)-1.  ('page -1' is the lower
+ *	        half, offset 0-127).
+ *	f) For devices with two I2C clients at address 0x50 and 0x51 (eg SFP),
+ *		the address space places offset 0-127 in the lower
+ *	        half of 50/A0/client[0], offset 128-255 in the upper 
+ *	        half.  Offset 256-383 is in the lower half of 51/A2/client[1].
+ *	        Offset 384-511 is in page 0, in the upper half of 51/A2/...
+ *	        Offset 512-639 is in page 1, in the upper half of 51/A2/...
+ *	        Offset 'n' is in page (n/128)-3 (for n > 383)
+ *
+ *	                    One I2c addressed (eg QSFP) Memory Map
+ *
+ *	                    2-Wire Serial Address: 1010000x
+ *
+ *	                    Lower Page 00h (128 bytes)
+ *	                    =====================
+ *	                   |                     |
+ *	                   |                     |
+ *	                   |                     |
+ *	                   |                     |
+ *	                   |                     |
+ *	                   |                     |
+ *	                   |                     |
+ *	                   |                     |
+ *	                   |                     |
+ *	                   |                     |
+ *	                   |Page Select Byte(127)|
+ *	                    =====================
+ *	                              |
+ *	                              |
+ *	                              |
+ *	                              |
+ *	                              V
+ *	     ------------------------------------------------------------
+ *	    |                 |                  |                       |
+ *	    |                 |                  |                       |
+ *	    |                 |                  |                       |
+ *	    |                 |                  |                       |
+ *	    |                 |                  |                       |
+ *	    |                 |                  |                       |
+ *	    |                 |                  |                       |
+ *	    |                 |                  |                       |
+ *	    |                 |                  |                       |
+ *	    V                 V                  V                       V
+ *	 ------------   --------------      ---------------     --------------
+ *	|            | |              |    |               |   |              |
+ *	|   Upper    | |     Upper    |    |     Upper     |   |    Upper     |
+ *	|  Page 00h  | |    Page 01h  |    |    Page 02h   |   |   Page 03h   |
+ *	|            | |   (Optional) |    |   (Optional)  |   |  (Optional   |
+ *	|            | |              |    |               |   |   for Cable  |
+ *	|            | |              |    |               |   |  Assemblies) |
+ *	|    ID      | |     AST      |    |      User     |   |              |
+ *	|  Fields    | |    Table     |    |   EEPROM Data |   |              |
+ *	|            | |              |    |               |   |              |
+ *	|            | |              |    |               |   |              |
+ *	|            | |              |    |               |   |              |
+ *	 ------------   --------------      ---------------     --------------
+ *
+ * The SFF 8436 (QSFP) spec only defines the 4 pages described above.
+ * In anticipation of future applications and devices, this driver
+ * supports access to the full architected range, 256 pages.
+ *
+ **/
+
+/* #define DEBUG 1 */
+
+#undef EEPROM_CLASS
+#ifdef CONFIG_EEPROM_CLASS
+#define EEPROM_CLASS
+#endif
+#ifdef CONFIG_EEPROM_CLASS_MODULE
+#define EEPROM_CLASS
+#endif
+
+#include <linux/kernel.h>
+#include <linux/init.h>
+#include <linux/module.h>
+#include <linux/slab.h>
+#include <linux/delay.h>
+#include <linux/mutex.h>
+#include <linux/sysfs.h>
+#include <linux/jiffies.h>
+#include <linux/i2c.h>
+#include <linux/memory.h>
+
+#ifdef EEPROM_CLASS
+#include <linux/eeprom_class.h>
+#endif
+
+#include <linux/types.h>
+
+/*
+ * The optoe driver is for read/write access to the EEPROM on standard
+ * I2C based optical transceivers (SFP, QSFP, etc)
+ *
+ * While based on the at24 driver, it eliminates code that supports other
+ * types of I2C EEPROMs, and adds support for pages accessed through the
+ * page-select register at offset 127.
+ */
+
+struct optoe_platform_data {
+	u32		byte_len;		/* size (sum of all addr) */
+	u16		page_size;		/* for writes */
+	u8		flags;
+
+	void		(*setup)(struct memory_accessor *, void *context);
+	void		*context;
+#ifdef EEPROM_CLASS
+	struct eeprom_platform_data *eeprom_data; /* extra data for the eeprom_class */
+#endif
+	int oom_port_name;
+};
+
+/* fundamental unit of addressing for EEPROM */
+#define OPTOE_PAGE_SIZE 128
+/*
+ * Single address devices (eg QSFP) have 256 pages, plus the unpaged
+ * low 128 bytes.  If the device does not support paging, it is
+ * only 2 'pages' long.
+ */
+#define OPTOE_ARCH_PAGES 256
+#define ONE_ADDR_EEPROM_SIZE ((1 + OPTOE_ARCH_PAGES) * OPTOE_PAGE_SIZE)
+#define ONE_ADDR_EEPROM_UNPAGED_SIZE (2 * OPTOE_PAGE_SIZE)
+/* 
+ * Dual address devices (eg SFP) have 256 pages, plus the unpaged
+ * low 128 bytes, plus 256 bytes at 0x50.  If the device does not 
+ * support paging, it is 4 'pages' long.
+ */
+#define TWO_ADDR_EEPROM_SIZE ((3 + OPTOE_ARCH_PAGES) * OPTOE_PAGE_SIZE)
+#define TWO_ADDR_EEPROM_UNPAGED_SIZE (4 * OPTOE_PAGE_SIZE)
+
+/* a few constants to find our way around the EEPROM */
+#define OPTOE_PAGE_SELECT_REG   0x7F
+#define ONE_ADDR_PAGEABLE_REG 0x02
+#define ONE_ADDR_NOT_PAGEABLE (1<<2)
+#define TWO_ADDR_PAGEABLE_REG 0x40
+#define TWO_ADDR_PAGEABLE (1<<4)
+#define OPTOE_ID_REG 0
+
+/* The maximum length of a port name */
+#define MAX_PORT_NAME_LEN 20
+struct optoe_data {
+	struct optoe_platform_data chip;
+	struct memory_accessor macc;
+	int use_smbus;
+	char port_name[MAX_PORT_NAME_LEN];
+
+	/*
+	 * Lock protects against activities from other Linux tasks,
+	 * but not from changes by other I2C masters.
+	 */
+	struct mutex lock;
+	struct bin_attribute bin;
+	struct attribute_group attr_group;
+
+	u8 *writebuf;
+	unsigned write_max;
+
+	unsigned num_addresses;
+
+#ifdef EEPROM_CLASS
+	struct eeprom_device *eeprom_dev;
+#endif
+
+	/* dev_class: ONE_ADDR (QSFP) or TWO_ADDR (SFP) */
+	int dev_class;
+
+	struct i2c_client *client[];
+};
+
+typedef enum optoe_opcode {
+	OPTOE_READ_OP = 0,
+	OPTOE_WRITE_OP = 1
+} optoe_opcode_e;
+
+/*
+ * This parameter is to help this driver avoid blocking other drivers out
+ * of I2C for potentially troublesome amounts of time. With a 100 kHz I2C
+ * clock, one 256 byte read takes about 1/43 second which is excessive;
+ * but the 1/170 second it takes at 400 kHz may be quite reasonable; and
+ * at 1 MHz (Fm+) a 1/430 second delay could easily be invisible.
+ *
+ * This value is forced to be a power of two so that writes align on pages.
+ */
+static unsigned io_limit = OPTOE_PAGE_SIZE;
+
+/*
+ * specs often allow 5 msec for a page write, sometimes 20 msec;
+ * it's important to recover from write timeouts.
+ */
+static unsigned write_timeout = 25;
+
+/*
+ * flags to distinguish one-address (QSFP family) from two-address (SFP family)
+ * If the family is not known, figure it out when the device is accessed
+ */
+#define ONE_ADDR 1
+#define TWO_ADDR 2
+
+static const struct i2c_device_id optoe_ids[] = {
+	{ "optoe1", ONE_ADDR },
+	{ "optoe2", TWO_ADDR },
+	{ "sff8436", ONE_ADDR },
+	{ "24c04", TWO_ADDR },
+	{ /* END OF LIST */ }
+};
+MODULE_DEVICE_TABLE(i2c, optoe_ids);
+
+/*-------------------------------------------------------------------------*/
+/*
+ * This routine computes the addressing information to be used for
+ * a given r/w request.
+ *
+ * Task is to calculate the client (0 = i2c addr 50, 1 = i2c addr 51),
+ * the page, and the offset.
+ *
+ * Handles both single address (eg QSFP) and two address (eg SFP).  
+ *     For SFP, offset 0-255 are on client[0], >255 is on client[1]
+ *     Offset 256-383 are on the lower half of client[1]
+ *     Pages are accessible on the upper half of client[1].
+ *     Offset >383 are in 128 byte pages mapped into the upper half
+ *
+ *     For QSFP, all offsets are on client[0]
+ *     offset 0-127 are on the lower half of client[0] (no paging)
+ *     Pages are accessible on the upper half of client[1].
+ *     Offset >127 are in 128 byte pages mapped into the upper half
+ *
+ *     Callers must not read/write beyond the end of a client or a page
+ *     without recomputing the client/page.  Hence offset (within page)
+ *     plus length must be less than or equal to 128.  (Note that this
+ *     routine does not have access to the length of the call, hence 
+ *     cannot do the validity check.)
+ *
+ * Offset within Lower Page 00h and Upper Page 00h are not recomputed
+ */
+
+static uint8_t optoe_translate_offset(struct optoe_data *optoe,
+		loff_t *offset, struct i2c_client **client)
+{
+	unsigned page = 0;
+
+	*client = optoe->client[0];
+
+	/* if SFP style, offset > 255, shift to i2c addr 0x51 */
+	if (optoe->dev_class == TWO_ADDR) {
+		if (*offset > 255) {
+			/* like QSFP, but shifted to client[1] */
+			*client = optoe->client[1];
+			*offset -= 256;  
+		}
+	}
+
+	/*
+	 * if offset is in the range 0-128...
+	 * page doesn't matter (using lower half), return 0.
+	 * offset is already correct (don't add 128 to get to paged area)
+	 */
+	if (*offset < OPTOE_PAGE_SIZE)
+		return page;
+
+	/* note, page will always be positive since *offset >= 128 */
+	page = (*offset >> 7)-1;
+	/* 0x80 places the offset in the top half, offset is last 7 bits */
+	*offset = OPTOE_PAGE_SIZE + (*offset & 0x7f);
+
+	return page;  /* note also returning client and offset */
+}
+
+static ssize_t optoe_eeprom_read(struct optoe_data *optoe,
+		    struct i2c_client *client,
+		    char *buf, unsigned offset, size_t count)
+{
+	struct i2c_msg msg[2];
+	u8 msgbuf[2];
+	unsigned long timeout, read_time;
+	int status, i;
+
+	memset(msg, 0, sizeof(msg));
+
+	switch (optoe->use_smbus) {
+	case I2C_SMBUS_I2C_BLOCK_DATA:
+		/*smaller eeproms can work given some SMBus extension calls */
+		if (count > I2C_SMBUS_BLOCK_MAX)
+			count = I2C_SMBUS_BLOCK_MAX;
+		break;
+	case I2C_SMBUS_WORD_DATA:
+		/* Check for odd length transaction */
+		count = (count == 1) ? 1 : 2;
+		break;
+	case I2C_SMBUS_BYTE_DATA:
+		count = 1;
+		break;
+	default:
+		/*
+		 * When we have a better choice than SMBus calls, use a
+		 * combined I2C message. Write address; then read up to
+		 * io_limit data bytes.  msgbuf is u8 and will cast to our
+		 * needs.
+		 */
+		i = 0;
+		msgbuf[i++] = offset;
+
+		msg[0].addr = client->addr;
+		msg[0].buf = msgbuf;
+		msg[0].len = i;
+
+		msg[1].addr = client->addr;
+		msg[1].flags = I2C_M_RD;
+		msg[1].buf = buf;
+		msg[1].len = count;
+	}
+
+	/*
+	 * Reads fail if the previous write didn't complete yet. We may
+	 * loop a few times until this one succeeds, waiting at least
+	 * long enough for one entire page write to work.
+	 */
+	timeout = jiffies + msecs_to_jiffies(write_timeout);
+	do {
+		read_time = jiffies;
+
+		switch (optoe->use_smbus) {
+		case I2C_SMBUS_I2C_BLOCK_DATA:
+			status = i2c_smbus_read_i2c_block_data(client, offset,
+					count, buf);
+			break;
+		case I2C_SMBUS_WORD_DATA:
+			status = i2c_smbus_read_word_data(client, offset);
+			if (status >= 0) {
+				buf[0] = status & 0xff;
+				if (count == 2)
+					buf[1] = status >> 8;
+				status = count;
+			}
+			break;
+		case I2C_SMBUS_BYTE_DATA:
+			status = i2c_smbus_read_byte_data(client, offset);
+			if (status >= 0) {
+				buf[0] = status;
+				status = count;
+			}
+			break;
+		default:
+			status = i2c_transfer(client->adapter, msg, 2);
+			if (status == 2)
+				status = count;
+		}
+
+		dev_dbg(&client->dev, "eeprom read %zu@%d --> %d (%ld)\n",
+				count, offset, status, jiffies);
+
+		if (status == count)  /* happy path */
+			return count;
+
+		if (status == -ENXIO) /* no module present */
+			return status;
+
+		/* REVISIT: at HZ=100, this is sloooow */
+		msleep(1);
+	} while (time_before(read_time, timeout));
+
+	return -ETIMEDOUT;
+}
+
+static ssize_t optoe_eeprom_write(struct optoe_data *optoe,
+		    		struct i2c_client *client,
+				const char *buf,
+				unsigned offset, size_t count)
+{
+	struct i2c_msg msg;
+	ssize_t status;
+	unsigned long timeout, write_time;
+	unsigned next_page_start;
+	int i = 0;
+
+	/* write max is at most a page
+	 * (In this driver, write_max is actually one byte!)
+	 */
+	if (count > optoe->write_max)
+		count = optoe->write_max;
+
+	/* shorten count if necessary to avoid crossing page boundary */
+	next_page_start = roundup(offset + 1, OPTOE_PAGE_SIZE);
+	if (offset + count > next_page_start)
+		count = next_page_start - offset;
+
+	switch (optoe->use_smbus) {
+	case I2C_SMBUS_I2C_BLOCK_DATA:
+		/*smaller eeproms can work given some SMBus extension calls */
+		if (count > I2C_SMBUS_BLOCK_MAX)
+			count = I2C_SMBUS_BLOCK_MAX;
+		break;
+	case I2C_SMBUS_WORD_DATA:
+		/* Check for odd length transaction */
+		count = (count == 1) ? 1 : 2;
+		break;
+	case I2C_SMBUS_BYTE_DATA:
+		count = 1;
+		break;
+	default:
+		/* If we'll use I2C calls for I/O, set up the message */
+		msg.addr = client->addr;
+		msg.flags = 0;
+
+		/* msg.buf is u8 and casts will mask the values */
+		msg.buf = optoe->writebuf;
+
+		msg.buf[i++] = offset;
+		memcpy(&msg.buf[i], buf, count);
+		msg.len = i + count;
+		break;
+	}
+
+	/*
+	 * Reads fail if the previous write didn't complete yet. We may
+	 * loop a few times until this one succeeds, waiting at least
+	 * long enough for one entire page write to work.
+	 */
+	timeout = jiffies + msecs_to_jiffies(write_timeout);
+	do {
+		write_time = jiffies;
+
+		switch (optoe->use_smbus) {
+		case I2C_SMBUS_I2C_BLOCK_DATA:
+			status = i2c_smbus_write_i2c_block_data(client,
+						offset, count, buf);
+			if (status == 0)
+				status = count;
+			break;
+		case I2C_SMBUS_WORD_DATA:
+			if (count == 2) {
+				status = i2c_smbus_write_word_data(client,
+					offset, (u16)((buf[0])|(buf[1] << 8)));
+			} else {
+				/* count = 1 */
+				status = i2c_smbus_write_byte_data(client,
+					offset, buf[0]);
+			}
+			if (status == 0)
+				status = count;
+			break;
+		case I2C_SMBUS_BYTE_DATA:
+			status = i2c_smbus_write_byte_data(client, offset,
+						buf[0]);
+			if (status == 0)
+				status = count;
+			break;
+		default:
+			status = i2c_transfer(client->adapter, &msg, 1);
+			if (status == 1)
+				status = count;
+			break;
+		}
+
+		dev_dbg(&client->dev, "eeprom write %zu@%d --> %ld (%lu)\n",
+				count, offset, (long int) status, jiffies);
+
+		if (status == count)
+			return count;
+
+		/* REVISIT: at HZ=100, this is sloooow */
+		msleep(1);
+	} while (time_before(write_time, timeout));
+
+	return -ETIMEDOUT;
+}
+
+
+static ssize_t optoe_eeprom_update_client(struct optoe_data *optoe,
+				char *buf, loff_t off, 
+				size_t count, optoe_opcode_e opcode)
+{
+	struct i2c_client *client;
+	ssize_t retval = 0;
+	uint8_t page = 0;
+	loff_t phy_offset = off;
+	int ret = 0;
+
+	page = optoe_translate_offset(optoe, &phy_offset, &client);
+	dev_dbg(&client->dev,
+			"optoe_eeprom_update_client off %lld  page:%d phy_offset:%lld, count:%ld, opcode:%d\n",
+			off, page, phy_offset, (long int) count, opcode);
+	if (page > 0) {
+		ret = optoe_eeprom_write(optoe, client, &page, 
+			OPTOE_PAGE_SELECT_REG, 1);
+		if (ret < 0) {
+			dev_dbg(&client->dev,
+				"Write page register for page %d failed ret:%d!\n",
+					page, ret);
+			return ret;
+		}
+	}
+
+	while (count) {
+		ssize_t	status;
+
+		if (opcode == OPTOE_READ_OP) {
+			status =  optoe_eeprom_read(optoe, client,
+				buf, phy_offset, count);
+		} else {
+			status =  optoe_eeprom_write(optoe, client,
+				buf, phy_offset, count);
+		}
+		if (status <= 0) {
+			if (retval == 0)
+				retval = status;
+			break;
+		}
+		buf += status;
+		phy_offset += status;
+		count -= status;
+		retval += status;
+	}
+
+
+	if (page > 0) {
+		/* return the page register to page 0 (why?) */
+		page = 0;
+		ret = optoe_eeprom_write(optoe, client, &page, 
+			OPTOE_PAGE_SELECT_REG, 1);
+		if (ret < 0) {
+			dev_err(&client->dev,
+				"Restore page register to 0 failed:%d!\n", ret);
+			/* error only if nothing has been transferred */
+			if (retval == 0) retval = ret;
+		}
+	}
+	return retval;
+}
+
+/*
+ * Figure out if this access is within the range of supported pages.
+ * Note this is called on every access because we don't know if the
+ * module has been replaced since the last call.
+ * If/when modules support more pages, this is the routine to update
+ * to validate and allow access to additional pages.
+ *
+ * Returns updated len for this access:
+ *     - entire access is legal, original len is returned.
+ *     - access begins legal but is too long, len is truncated to fit.
+ *     - initial offset exceeds supported pages, return -EINVAL
+ */
+static ssize_t optoe_page_legal(struct optoe_data *optoe, 
+		loff_t off, size_t len)
+{
+	struct i2c_client *client = optoe->client[0];
+	u8 regval;
+	int status;
+	size_t maxlen;
+
+	if (off < 0) return -EINVAL;
+	if (optoe->dev_class == TWO_ADDR) {
+		/* SFP case */
+		/* if no pages needed, we're good */
+		if ((off + len) <= TWO_ADDR_EEPROM_UNPAGED_SIZE) return len;
+		/* if offset exceeds possible pages, we're not good */
+		if (off >= TWO_ADDR_EEPROM_SIZE) return -EINVAL;
+		/* in between, are pages supported? */
+		status = optoe_eeprom_read(optoe, client, &regval, 
+				TWO_ADDR_PAGEABLE_REG, 1);
+		if (status < 0) return status;  /* error out (no module?) */
+		if (regval & TWO_ADDR_PAGEABLE) {
+			/* Pages supported, trim len to the end of pages */
+			maxlen = TWO_ADDR_EEPROM_SIZE - off;
+		} else {
+			/* pages not supported, trim len to unpaged size */
+			if (off >= TWO_ADDR_EEPROM_UNPAGED_SIZE) return -EINVAL;
+			maxlen = TWO_ADDR_EEPROM_UNPAGED_SIZE - off;
+		}
+		len = (len > maxlen) ? maxlen : len;
+		dev_dbg(&client->dev,
+			"page_legal, SFP, off %lld len %ld\n",
+			off, (long int) len);
+	} else {
+		/* QSFP case */
+		/* if no pages needed, we're good */
+		if ((off + len) <= ONE_ADDR_EEPROM_UNPAGED_SIZE) return len;
+		/* if offset exceeds possible pages, we're not good */
+		if (off >= ONE_ADDR_EEPROM_SIZE) return -EINVAL;
+		/* in between, are pages supported? */
+		status = optoe_eeprom_read(optoe, client, &regval, 
+				ONE_ADDR_PAGEABLE_REG, 1);
+		if (status < 0) return status;  /* error out (no module?) */
+		if (regval & ONE_ADDR_NOT_PAGEABLE) {
+			/* pages not supported, trim len to unpaged size */
+			if (off >= ONE_ADDR_EEPROM_UNPAGED_SIZE) return -EINVAL;
+			maxlen = ONE_ADDR_EEPROM_UNPAGED_SIZE - off;
+		} else {
+			/* Pages supported, trim len to the end of pages */
+			maxlen = ONE_ADDR_EEPROM_SIZE - off;
+		}
+		len = (len > maxlen) ? maxlen : len;
+		dev_dbg(&client->dev,
+			"page_legal, QSFP, off %lld len %ld\n",
+			off, (long int) len);
+	}
+	return len;
+}
+
+static ssize_t optoe_read_write(struct optoe_data *optoe,
+		char *buf, loff_t off, size_t len, optoe_opcode_e opcode)
+{
+	struct i2c_client *client = optoe->client[0];
+	int chunk;
+	int status = 0;
+	ssize_t retval;
+	size_t pending_len = 0, chunk_len = 0;
+	loff_t chunk_offset = 0, chunk_start_offset = 0;
+
+	dev_dbg(&client->dev,
+		"optoe_read_write: off %lld  len:%ld, opcode:%s\n",
+		off, (long int) len, (opcode == OPTOE_READ_OP) ? "r": "w");
+	if (unlikely(!len))
+		return len;
+
+	/*
+	 * Read data from chip, protecting against concurrent updates
+	 * from this host, but not from other I2C masters.
+	 */
+	mutex_lock(&optoe->lock);
+	
+	/*
+	 * Confirm this access fits within the device suppored addr range 
+	 */
+	status = optoe_page_legal(optoe, off, len);
+	if (status < 0) {
+		goto err;
+	}
+	len = status;
+
+	/*
+	 * For each (128 byte) chunk involved in this request, issue a
+	 * separate call to sff_eeprom_update_client(), to
+	 * ensure that each access recalculates the client/page
+	 * and writes the page register as needed.
+	 * Note that chunk to page mapping is confusing, is different for 
+	 * QSFP and SFP, and never needs to be done.  Don't try!
+	 */
+	pending_len = len; /* amount remaining to transfer */
+	retval = 0;  /* amount transferred */
+	for (chunk = off >> 7; chunk <= (off + len - 1) >> 7; chunk++) {
+
+		/*
+		 * Compute the offset and number of bytes to be read/write
+		 *
+		 * 1. start at offset 0 (within the chunk), and read/write
+		 *    the entire chunk
+		 * 2. start at offset 0 (within the chunk) and read/write less
+		 *    than entire chunk
+		 * 3. start at an offset not equal to 0 and read/write the rest
+		 *    of the chunk
+		 * 4. start at an offset not equal to 0 and read/write less than
+		 *    (end of chunk - offset)
+		 */
+		chunk_start_offset = chunk * OPTOE_PAGE_SIZE;
+
+		if (chunk_start_offset < off) {
+			chunk_offset = off;
+			if ((off + pending_len) < (chunk_start_offset +
+					OPTOE_PAGE_SIZE))
+				chunk_len = pending_len;
+			else
+				chunk_len = OPTOE_PAGE_SIZE - off;
+		} else {
+			chunk_offset = chunk_start_offset;
+			if (pending_len > OPTOE_PAGE_SIZE)
+				chunk_len = OPTOE_PAGE_SIZE;
+			else
+				chunk_len = pending_len;
+		}
+
+		dev_dbg(&client->dev,
+			"sff_r/w: off %lld, len %ld, chunk_start_offset %lld, chunk_offset %lld, chunk_len %ld, pending_len %ld\n",
+			off, (long int) len, chunk_start_offset, chunk_offset,
+			(long int) chunk_len, (long int) pending_len);
+
+		/* 
+		 * note: chunk_offset is from the start of the EEPROM, 
+		 * not the start of the chunk 
+		 */
+		status = optoe_eeprom_update_client(optoe, buf, 
+				chunk_offset, chunk_len, opcode);
+		if (status != chunk_len) {
+			/* This is another 'no device present' path */
+			dev_dbg(&client->dev, 
+	"optoe_update_client for chunk %d chunk_offset %lld chunk_len %ld failed %d!\n",
+				chunk, chunk_offset, (long int) chunk_len, status);
+			goto err;
+		}
+		buf += status;
+		pending_len -= status;
+		retval += status;
+	}
+	mutex_unlock(&optoe->lock);
+
+	return retval;
+
+err:
+	mutex_unlock(&optoe->lock);
+
+	return status;
+}
+
+static ssize_t optoe_bin_read(struct file *filp, struct kobject *kobj,
+		struct bin_attribute *attr,
+		char *buf, loff_t off, size_t count)
+{
+	struct i2c_client *client = to_i2c_client(container_of(kobj,
+				struct device, kobj));
+	struct optoe_data *optoe = i2c_get_clientdata(client);
+
+	return optoe_read_write(optoe, buf, off, count, OPTOE_READ_OP);
+}
+
+
+static ssize_t optoe_bin_write(struct file *filp, struct kobject *kobj,
+		struct bin_attribute *attr,
+		char *buf, loff_t off, size_t count)
+{
+	struct i2c_client *client = to_i2c_client(container_of(kobj,
+				struct device, kobj));
+	struct optoe_data *optoe = i2c_get_clientdata(client);
+
+	return optoe_read_write(optoe, buf, off, count, OPTOE_WRITE_OP);
+}
+/*-------------------------------------------------------------------------*/
+
+/*
+ * This lets other kernel code access the eeprom data. For example, it
+ * might hold a board's Ethernet address, or board-specific calibration
+ * data generated on the manufacturing floor.
+ */
+
+static ssize_t optoe_macc_read(struct memory_accessor *macc,
+		char *buf, off_t offset, size_t count)
+{
+	struct optoe_data *optoe = container_of(macc,
+					struct optoe_data, macc);
+
+	return optoe_read_write(optoe, buf, offset, count, OPTOE_READ_OP);
+}
+
+static ssize_t optoe_macc_write(struct memory_accessor *macc,
+		const char *buf, off_t offset, size_t count)
+{
+	struct optoe_data *optoe = container_of(macc,
+					struct optoe_data, macc);
+
+	return optoe_read_write(optoe, (char *) buf, offset,
+						count, OPTOE_WRITE_OP);
+}
+
+/*-------------------------------------------------------------------------*/
+
+static int optoe_remove(struct i2c_client *client)
+{
+	struct optoe_data *optoe;
+	int i;
+
+	optoe = i2c_get_clientdata(client);
+	sysfs_remove_group(&client->dev.kobj, &optoe->attr_group);
+	sysfs_remove_bin_file(&client->dev.kobj, &optoe->bin);
+
+	for (i = 1; i < optoe->num_addresses; i++)
+		i2c_unregister_device(optoe->client[i]);
+
+#ifdef EEPROM_CLASS
+	eeprom_device_unregister(optoe->eeprom_dev);
+#endif
+
+	kfree(optoe->writebuf);
+	kfree(optoe);
+	return 0;
+}
+
+static ssize_t show_port_name(struct device *dev,
+			struct device_attribute *dattr, char *buf)
+{
+	struct i2c_client *client = to_i2c_client(dev);
+	struct optoe_data *optoe = i2c_get_clientdata(client);
+	ssize_t count;
+
+	mutex_lock(&optoe->lock);
+	count = sprintf(buf, "%s\n", optoe->port_name);
+	mutex_unlock(&optoe->lock);
+
+	return count;
+}
+
+static ssize_t set_port_name(struct device *dev,
+			struct device_attribute *attr,
+			const char *buf, size_t count)
+{
+	struct i2c_client *client = to_i2c_client(dev);
+	struct optoe_data *optoe = i2c_get_clientdata(client);
+	char port_name[MAX_PORT_NAME_LEN];
+
+	/* no checking, this value is not used except by show_port_name */
+
+	if (sscanf(buf, "%19s", port_name) != 1)
+		return -EINVAL;
+
+	mutex_lock(&optoe->lock);
+	strcpy(optoe->port_name, port_name);
+	mutex_unlock(&optoe->lock);
+
+	return count;
+}
+
+static DEVICE_ATTR(port_name,  S_IRUGO | S_IWUSR,
+					show_port_name, set_port_name);
+
+static ssize_t show_dev_class(struct device *dev,
+			struct device_attribute *dattr, char *buf)
+{
+	struct i2c_client *client = to_i2c_client(dev);
+	struct optoe_data *optoe = i2c_get_clientdata(client);
+	ssize_t count;
+
+	mutex_lock(&optoe->lock);
+	count = sprintf(buf, "%d\n", optoe->dev_class);
+	mutex_unlock(&optoe->lock);
+
+	return count;
+}
+
+static ssize_t set_dev_class(struct device *dev,
+			struct device_attribute *attr,
+			const char *buf, size_t count)
+{
+	struct i2c_client *client = to_i2c_client(dev);
+	struct optoe_data *optoe = i2c_get_clientdata(client);
+	int dev_class;
+
+	/*
+	 * dev_class is actually the number of sfp ports used, thus
+	 * legal values are "1" (QSFP class) and "2" (SFP class)
+	 */
+	if (sscanf(buf, "%d", &dev_class) != 1 ||
+		dev_class < 1 || dev_class > 2)
+		return -EINVAL;
+
+	mutex_lock(&optoe->lock);
+	optoe->dev_class = dev_class;
+	mutex_unlock(&optoe->lock);
+
+	return count;
+}
+
+static DEVICE_ATTR(dev_class,  S_IRUGO | S_IWUSR,
+					show_dev_class, set_dev_class);
+
+static struct attribute *optoe_attrs[] = {
+	&dev_attr_port_name.attr,
+	&dev_attr_dev_class.attr,
+	NULL,
+};
+
+static struct attribute_group optoe_attr_group = {
+	.attrs = optoe_attrs,
+};
+
+static int optoe_probe(struct i2c_client *client,
+			const struct i2c_device_id *id)
+{
+	int err;
+	int use_smbus = 0;
+	struct optoe_platform_data chip;
+	struct optoe_data *optoe;
+	int num_addresses = 0;
+	int i = 0;
+
+	if (client->addr != 0x50) {
+		dev_dbg(&client->dev, "probe, bad i2c addr: 0x%x\n",
+				      client->addr);
+		err = -EINVAL;
+		goto exit;
+	}
+
+	if (client->dev.platform_data) {
+		chip = *(struct optoe_platform_data *)client->dev.platform_data;
+		dev_dbg(&client->dev, "probe, chip provided, flags:0x%x; name: %s\n", chip.flags, client->name);
+	} else {
+		if (!id->driver_data) {
+			err = -ENODEV;
+			goto exit;
+		}
+		dev_dbg(&client->dev, "probe, building chip\n");
+		chip.flags = 0;
+		chip.setup = NULL;
+		chip.context = NULL;
+#ifdef EEPROM_CLASS
+		chip.eeprom_data = NULL;
+#endif
+	}
+
+	/* Use I2C operations unless we're stuck with SMBus extensions. */
+	if (!i2c_check_functionality(client->adapter, I2C_FUNC_I2C)) {
+		if (i2c_check_functionality(client->adapter,
+				I2C_FUNC_SMBUS_READ_I2C_BLOCK)) {
+			use_smbus = I2C_SMBUS_I2C_BLOCK_DATA;
+		} else if (i2c_check_functionality(client->adapter,
+				I2C_FUNC_SMBUS_READ_WORD_DATA)) {
+			use_smbus = I2C_SMBUS_WORD_DATA;
+		} else if (i2c_check_functionality(client->adapter,
+				I2C_FUNC_SMBUS_READ_BYTE_DATA)) {
+			use_smbus = I2C_SMBUS_BYTE_DATA;
+		} else {
+			err = -EPFNOSUPPORT;
+			goto exit;
+		}
+	}
+
+
+	/*
+	 * Make room for two i2c clients
+	 */
+	num_addresses = 2;
+
+	optoe = kzalloc(sizeof(struct optoe_data) +
+			num_addresses * sizeof(struct i2c_client *),
+			GFP_KERNEL);
+	if (!optoe) {
+		err = -ENOMEM;
+		goto exit;
+	}
+
+	mutex_init(&optoe->lock);
+
+	/* determine whether this is a one-address or two-address module */
+	if ((strcmp(client->name, "optoe1") == 0) || 
+	    (strcmp(client->name, "sff8436") == 0)) {
+		/* one-address (eg QSFP) family */
+		optoe->dev_class = ONE_ADDR;
+		chip.byte_len = ONE_ADDR_EEPROM_SIZE;
+		num_addresses = 1;
+	} else if ((strcmp(client->name, "optoe2") == 0) ||
+		   (strcmp(client->name, "24c04") == 0)) {
+		/* SFP family */
+		optoe->dev_class = TWO_ADDR;
+		chip.byte_len = TWO_ADDR_EEPROM_SIZE;
+	} else {     /* those were the only two choices */
+		err = -EINVAL;
+		goto exit;
+	}
+
+	dev_dbg(&client->dev, "dev_class: %d\n", optoe->dev_class);
+	optoe->use_smbus = use_smbus;
+	optoe->chip = chip;
+	optoe->num_addresses = num_addresses;
+
+	/*
+	 * Use platform data to initial port name.
+	 * Original port name is unitialized: strcpy(optoe->port_name, "unitialized");
+	 */
+	sprintf(optoe->port_name, "%d", chip.oom_port_name);
+
+	/*
+	 * Export the EEPROM bytes through sysfs, since that's convenient.
+	 * By default, only root should see the data (maybe passwords etc)
+	 */
+	sysfs_bin_attr_init(&optoe->bin);
+	optoe->bin.attr.name = "eeprom";
+	optoe->bin.attr.mode = S_IRUGO;
+	optoe->bin.read = optoe_bin_read;
+	optoe->bin.size = chip.byte_len;
+
+	optoe->macc.read = optoe_macc_read;
+
+	if (!use_smbus ||
+			(i2c_check_functionality(client->adapter,
+				I2C_FUNC_SMBUS_WRITE_I2C_BLOCK)) ||
+			i2c_check_functionality(client->adapter,
+				I2C_FUNC_SMBUS_WRITE_WORD_DATA) ||
+			i2c_check_functionality(client->adapter,
+				I2C_FUNC_SMBUS_WRITE_BYTE_DATA)) {
+		/*
+		 * NOTE: AN-2079
+		 * Finisar recommends that the host implement 1 byte writes
+		 * only since this module only supports 32 byte page boundaries.
+		 * 2 byte writes are acceptable for PE and Vout changes per
+		 * Application Note AN-2071.
+		 */
+		unsigned write_max = 1;
+
+		optoe->macc.write = optoe_macc_write;
+
+		optoe->bin.write = optoe_bin_write;
+		optoe->bin.attr.mode |= S_IWUSR;
+
+		if (write_max > io_limit)
+			write_max = io_limit;
+		if (use_smbus && write_max > I2C_SMBUS_BLOCK_MAX)
+			write_max = I2C_SMBUS_BLOCK_MAX;
+		optoe->write_max = write_max;
+
+		/* buffer (data + address at the beginning) */
+		optoe->writebuf = kmalloc(write_max + 2, GFP_KERNEL);
+		if (!optoe->writebuf) {
+			err = -ENOMEM;
+			goto exit_kfree;
+		}
+	} else {
+			dev_warn(&client->dev,
+				"cannot write due to controller restrictions.");
+	}
+
+	optoe->client[0] = client;
+
+	/* use a dummy I2C device for two-address chips */
+	for (i = 1; i < num_addresses; i++) {
+		optoe->client[i] = i2c_new_dummy(client->adapter,
+					client->addr + i);
+		if (!optoe->client[i]) {
+			dev_err(&client->dev, "address 0x%02x unavailable\n",
+				client->addr + i);
+			err = -EADDRINUSE;
+			goto err_struct;
+		}
+	}
+
+	/* create the sysfs eeprom file */
+	err = sysfs_create_bin_file(&client->dev.kobj, &optoe->bin);
+	if (err)
+		goto err_struct;
+
+	optoe->attr_group = optoe_attr_group;
+
+	err = sysfs_create_group(&client->dev.kobj, &optoe->attr_group);
+	if (err) {
+		dev_err(&client->dev, "failed to create sysfs attribute group.\n");
+		goto err_struct;
+	}
+#ifdef EEPROM_CLASS
+	optoe->eeprom_dev = eeprom_device_register(&client->dev,
+							chip.eeprom_data);
+	if (IS_ERR(optoe->eeprom_dev)) {
+		dev_err(&client->dev, "error registering eeprom device.\n");
+		err = PTR_ERR(optoe->eeprom_dev);
+		goto err_sysfs_cleanup;
+	}
+#endif
+
+	i2c_set_clientdata(client, optoe);
+
+	dev_info(&client->dev, "%zu byte %s EEPROM, %s\n",
+		optoe->bin.size, client->name,
+		optoe->bin.write ? "read/write" : "read-only");
+
+	if (use_smbus == I2C_SMBUS_WORD_DATA ||
+	    use_smbus == I2C_SMBUS_BYTE_DATA) {
+		dev_notice(&client->dev, "Falling back to %s reads, "
+			   "performance will suffer\n", use_smbus ==
+			   I2C_SMBUS_WORD_DATA ? "word" : "byte");
+	}
+
+	if (chip.setup)
+		chip.setup(&optoe->macc, chip.context);
+
+	return 0;
+
+#ifdef EEPROM_CLASS
+err_sysfs_cleanup:
+	sysfs_remove_group(&client->dev.kobj, &optoe->attr_group);
+	sysfs_remove_bin_file(&client->dev.kobj, &optoe->bin);
+#endif
+
+err_struct:
+	for (i = 1; i < num_addresses; i++) {
+		if (optoe->client[i])
+			i2c_unregister_device(optoe->client[i]);
+	}
+
+	kfree(optoe->writebuf);
+exit_kfree:
+	kfree(optoe);
+exit:
+	dev_dbg(&client->dev, "probe error %d\n", err);
+
+	return err;
+}
+
+/*-------------------------------------------------------------------------*/
+
+static struct i2c_driver optoe_driver = {
+	.driver = {
+		.name = "optoe",
+		.owner = THIS_MODULE,
+	},
+	.probe = optoe_probe,
+	.remove = optoe_remove,
+	.id_table = optoe_ids,
+};
+
+static int __init optoe_init(void)
+{
+
+	if (!io_limit) {
+		pr_err("optoe: io_limit must not be 0!\n");
+		return -EINVAL;
+	}
+
+	io_limit = rounddown_pow_of_two(io_limit);
+	return i2c_add_driver(&optoe_driver);
+}
+module_init(optoe_init);
+
+static void __exit optoe_exit(void)
+{
+	i2c_del_driver(&optoe_driver);
+}
+module_exit(optoe_exit);
+
+MODULE_DESCRIPTION("Driver for optical transceiver (SFP, QSFP, ...) EEPROMs");
+MODULE_AUTHOR("Jonathan Tsai <jonathan.tsai@quantatw.com>");
+MODULE_LICENSE("GPL");

--- a/packages/platforms/quanta/x86-64/x86-64-quanta-ly8-rangeley/modules/builds/quanta_platform_ly8.c
+++ b/packages/platforms/quanta/x86-64/x86-64-quanta-ly8-rangeley/modules/builds/quanta_platform_ly8.c
@@ -52,6 +52,8 @@ enum i2c_types {
 	i2c_type_24c02,
 	i2c_type_emerson700,
 	i2c_type_quanta_ly8_hwmon,
+	i2c_type_optoe1_QSFP,
+	i2c_type_optoe2_SFP,
 };
 
 char *i2c_type_names[] = {
@@ -65,6 +67,8 @@ char *i2c_type_names[] = {
 	"24c02",
 	"emerson700",
 	"quanta_ly8_hwmon",
+	"optoe1",
+	"optoe2",
 };
 
 struct i2c_init_data {
@@ -72,8 +76,9 @@ struct i2c_init_data {
 	int type;
 	int addr;
 	int busno;
-    int gpio_base;
+	int gpio_base;
 	char name[I2C_NAME_SIZE];
+	int oom_port_name;
 };
 
 static struct i2c_init_data quanta_ly8_i2c_init_data[] = {
@@ -94,54 +99,54 @@ static struct i2c_init_data quanta_ly8_i2c_init_data[] = {
 	{ .parent_bus = (0x10 + 0), .type = i2c_type_pca9554, .addr = 0x25, .name = "PCA9554(PCA9698INT)\0" },
 	{ .parent_bus = (0x10 + 0), .type = i2c_type_pca9555, .addr = 0x24, .name = "PCA9555_3(FAN)\0" },
 	{ .parent_bus = (0x10 + 0), .type = i2c_type_pca9555, .addr = 0x23, .name = "PCA9555_4(QSFP_EN)\0" },
-	{ .parent_bus = (0x20 + 0), .type = i2c_type_24c02,   .addr = 0x50, .name = "SFP_1_EEPROM\0" },
-	{ .parent_bus = (0x20 + 1), .type = i2c_type_24c02,   .addr = 0x50, .name = "SFP_2_EEPROM\0" },
-	{ .parent_bus = (0x20 + 2), .type = i2c_type_24c02,   .addr = 0x50, .name = "SFP_3_EEPROM\0" },
-	{ .parent_bus = (0x20 + 3), .type = i2c_type_24c02,   .addr = 0x50, .name = "SFP_4_EEPROM\0" },
-	{ .parent_bus = (0x20 + 4), .type = i2c_type_24c02,   .addr = 0x50, .name = "SFP_5_EEPROM\0" },
-	{ .parent_bus = (0x20 + 5), .type = i2c_type_24c02,   .addr = 0x50, .name = "SFP_6_EEPROM\0" },
-	{ .parent_bus = (0x20 + 6), .type = i2c_type_24c02,   .addr = 0x50, .name = "SFP_7_EEPROM\0" },
-	{ .parent_bus = (0x20 + 7), .type = i2c_type_24c02,   .addr = 0x50, .name = "SFP_8_EEPROM\0" },
-	{ .parent_bus = (0x28 + 0), .type = i2c_type_24c02,   .addr = 0x50, .name = "SFP_9_EEPROM\0" },
-	{ .parent_bus = (0x28 + 1), .type = i2c_type_24c02,   .addr = 0x50, .name = "SFP_10_EEPROM\0" },
-	{ .parent_bus = (0x28 + 2), .type = i2c_type_24c02,   .addr = 0x50, .name = "SFP_11_EEPROM\0" },
-	{ .parent_bus = (0x28 + 3), .type = i2c_type_24c02,   .addr = 0x50, .name = "SFP_12_EEPROM\0" },
-	{ .parent_bus = (0x28 + 4), .type = i2c_type_24c02,   .addr = 0x50, .name = "SFP_13_EEPROM\0" },
-	{ .parent_bus = (0x28 + 5), .type = i2c_type_24c02,   .addr = 0x50, .name = "SFP_14_EEPROM\0" },
-	{ .parent_bus = (0x28 + 6), .type = i2c_type_24c02,   .addr = 0x50, .name = "SFP_15_EEPROM\0" },
-	{ .parent_bus = (0x28 + 7), .type = i2c_type_24c02,   .addr = 0x50, .name = "SFP_16_EEPROM\0" },
-	{ .parent_bus = (0x30 + 0), .type = i2c_type_24c02,   .addr = 0x50, .name = "SFP_17_EEPROM\0" },
-	{ .parent_bus = (0x30 + 1), .type = i2c_type_24c02,   .addr = 0x50, .name = "SFP_18_EEPROM\0" },
-	{ .parent_bus = (0x30 + 2), .type = i2c_type_24c02,   .addr = 0x50, .name = "SFP_19_EEPROM\0" },
-	{ .parent_bus = (0x30 + 3), .type = i2c_type_24c02,   .addr = 0x50, .name = "SFP_20_EEPROM\0" },
-	{ .parent_bus = (0x30 + 4), .type = i2c_type_24c02,   .addr = 0x50, .name = "SFP_21_EEPROM\0" },
-	{ .parent_bus = (0x30 + 5), .type = i2c_type_24c02,   .addr = 0x50, .name = "SFP_22_EEPROM\0" },
-	{ .parent_bus = (0x30 + 6), .type = i2c_type_24c02,   .addr = 0x50, .name = "SFP_23_EEPROM\0" },
-	{ .parent_bus = (0x30 + 7), .type = i2c_type_24c02,   .addr = 0x50, .name = "SFP_24_EEPROM\0" },
-	{ .parent_bus = (0x38 + 0), .type = i2c_type_24c02,   .addr = 0x50, .name = "SFP_25_EEPROM\0" },
-	{ .parent_bus = (0x38 + 1), .type = i2c_type_24c02,   .addr = 0x50, .name = "SFP_26_EEPROM\0" },
-	{ .parent_bus = (0x38 + 2), .type = i2c_type_24c02,   .addr = 0x50, .name = "SFP_27_EEPROM\0" },
-	{ .parent_bus = (0x38 + 3), .type = i2c_type_24c02,   .addr = 0x50, .name = "SFP_28_EEPROM\0" },
-	{ .parent_bus = (0x38 + 4), .type = i2c_type_24c02,   .addr = 0x50, .name = "SFP_29_EEPROM\0" },
-	{ .parent_bus = (0x38 + 5), .type = i2c_type_24c02,   .addr = 0x50, .name = "SFP_30_EEPROM\0" },
-	{ .parent_bus = (0x38 + 6), .type = i2c_type_24c02,   .addr = 0x50, .name = "SFP_31_EEPROM\0" },
-	{ .parent_bus = (0x38 + 7), .type = i2c_type_24c02,   .addr = 0x50, .name = "SFP_32_EEPROM\0" },
-	{ .parent_bus = (0x40 + 0), .type = i2c_type_24c02,   .addr = 0x50, .name = "SFP_33_EEPROM\0" },
-	{ .parent_bus = (0x40 + 1), .type = i2c_type_24c02,   .addr = 0x50, .name = "SFP_34_EEPROM\0" },
-	{ .parent_bus = (0x40 + 2), .type = i2c_type_24c02,   .addr = 0x50, .name = "SFP_35_EEPROM\0" },
-	{ .parent_bus = (0x40 + 3), .type = i2c_type_24c02,   .addr = 0x50, .name = "SFP_36_EEPROM\0" },
-	{ .parent_bus = (0x40 + 4), .type = i2c_type_24c02,   .addr = 0x50, .name = "SFP_37_EEPROM\0" },
-	{ .parent_bus = (0x40 + 5), .type = i2c_type_24c02,   .addr = 0x50, .name = "SFP_38_EEPROM\0" },
-	{ .parent_bus = (0x40 + 6), .type = i2c_type_24c02,   .addr = 0x50, .name = "SFP_39_EEPROM\0" },
-	{ .parent_bus = (0x40 + 7), .type = i2c_type_24c02,   .addr = 0x50, .name = "SFP_40_EEPROM\0" },
-	{ .parent_bus = (0x48 + 0), .type = i2c_type_24c02,   .addr = 0x50, .name = "SFP_41_EEPROM\0" },
-	{ .parent_bus = (0x48 + 1), .type = i2c_type_24c02,   .addr = 0x50, .name = "SFP_42_EEPROM\0" },
-	{ .parent_bus = (0x48 + 2), .type = i2c_type_24c02,   .addr = 0x50, .name = "SFP_43_EEPROM\0" },
-	{ .parent_bus = (0x48 + 3), .type = i2c_type_24c02,   .addr = 0x50, .name = "SFP_44_EEPROM\0" },
-	{ .parent_bus = (0x48 + 4), .type = i2c_type_24c02,   .addr = 0x50, .name = "SFP_45_EEPROM\0" },
-	{ .parent_bus = (0x48 + 5), .type = i2c_type_24c02,   .addr = 0x50, .name = "SFP_46_EEPROM\0" },
-	{ .parent_bus = (0x48 + 6), .type = i2c_type_24c02,   .addr = 0x50, .name = "SFP_47_EEPROM\0" },
-	{ .parent_bus = (0x48 + 7), .type = i2c_type_24c02,   .addr = 0x50, .name = "SFP_48_EEPROM\0" },
+	{ .parent_bus = (0x20 + 0), .type = i2c_type_optoe2_SFP,   .addr = 0x50, .name = "SFP_1_EEPROM\0", .oom_port_name = 1 },
+	{ .parent_bus = (0x20 + 1), .type = i2c_type_optoe2_SFP,   .addr = 0x50, .name = "SFP_2_EEPROM\0", .oom_port_name = 2 },
+	{ .parent_bus = (0x20 + 2), .type = i2c_type_optoe2_SFP,   .addr = 0x50, .name = "SFP_3_EEPROM\0", .oom_port_name = 3 },
+	{ .parent_bus = (0x20 + 3), .type = i2c_type_optoe2_SFP,   .addr = 0x50, .name = "SFP_4_EEPROM\0", .oom_port_name = 4 },
+	{ .parent_bus = (0x20 + 4), .type = i2c_type_optoe2_SFP,   .addr = 0x50, .name = "SFP_5_EEPROM\0", .oom_port_name = 5 },
+	{ .parent_bus = (0x20 + 5), .type = i2c_type_optoe2_SFP,   .addr = 0x50, .name = "SFP_6_EEPROM\0", .oom_port_name = 6 },
+	{ .parent_bus = (0x20 + 6), .type = i2c_type_optoe2_SFP,   .addr = 0x50, .name = "SFP_7_EEPROM\0", .oom_port_name = 7 },
+	{ .parent_bus = (0x20 + 7), .type = i2c_type_optoe2_SFP,   .addr = 0x50, .name = "SFP_8_EEPROM\0", .oom_port_name = 8 },
+	{ .parent_bus = (0x28 + 0), .type = i2c_type_optoe2_SFP,   .addr = 0x50, .name = "SFP_9_EEPROM\0", .oom_port_name = 9 },
+	{ .parent_bus = (0x28 + 1), .type = i2c_type_optoe2_SFP,   .addr = 0x50, .name = "SFP_10_EEPROM\0", .oom_port_name = 10 },
+	{ .parent_bus = (0x28 + 2), .type = i2c_type_optoe2_SFP,   .addr = 0x50, .name = "SFP_11_EEPROM\0", .oom_port_name = 11 },
+	{ .parent_bus = (0x28 + 3), .type = i2c_type_optoe2_SFP,   .addr = 0x50, .name = "SFP_12_EEPROM\0", .oom_port_name = 12 },
+	{ .parent_bus = (0x28 + 4), .type = i2c_type_optoe2_SFP,   .addr = 0x50, .name = "SFP_13_EEPROM\0", .oom_port_name = 13 },
+	{ .parent_bus = (0x28 + 5), .type = i2c_type_optoe2_SFP,   .addr = 0x50, .name = "SFP_14_EEPROM\0", .oom_port_name = 14 },
+	{ .parent_bus = (0x28 + 6), .type = i2c_type_optoe2_SFP,   .addr = 0x50, .name = "SFP_15_EEPROM\0", .oom_port_name = 15 },
+	{ .parent_bus = (0x28 + 7), .type = i2c_type_optoe2_SFP,   .addr = 0x50, .name = "SFP_16_EEPROM\0", .oom_port_name = 16 },
+	{ .parent_bus = (0x30 + 0), .type = i2c_type_optoe2_SFP,   .addr = 0x50, .name = "SFP_17_EEPROM\0", .oom_port_name = 17 },
+	{ .parent_bus = (0x30 + 1), .type = i2c_type_optoe2_SFP,   .addr = 0x50, .name = "SFP_18_EEPROM\0", .oom_port_name = 18 },
+	{ .parent_bus = (0x30 + 2), .type = i2c_type_optoe2_SFP,   .addr = 0x50, .name = "SFP_19_EEPROM\0", .oom_port_name = 19 },
+	{ .parent_bus = (0x30 + 3), .type = i2c_type_optoe2_SFP,   .addr = 0x50, .name = "SFP_20_EEPROM\0", .oom_port_name = 20 },
+	{ .parent_bus = (0x30 + 4), .type = i2c_type_optoe2_SFP,   .addr = 0x50, .name = "SFP_21_EEPROM\0", .oom_port_name = 21 },
+	{ .parent_bus = (0x30 + 5), .type = i2c_type_optoe2_SFP,   .addr = 0x50, .name = "SFP_22_EEPROM\0", .oom_port_name = 22 },
+	{ .parent_bus = (0x30 + 6), .type = i2c_type_optoe2_SFP,   .addr = 0x50, .name = "SFP_23_EEPROM\0", .oom_port_name = 23 },
+	{ .parent_bus = (0x30 + 7), .type = i2c_type_optoe2_SFP,   .addr = 0x50, .name = "SFP_24_EEPROM\0", .oom_port_name = 24 },
+	{ .parent_bus = (0x38 + 0), .type = i2c_type_optoe2_SFP,   .addr = 0x50, .name = "SFP_25_EEPROM\0", .oom_port_name = 25 },
+	{ .parent_bus = (0x38 + 1), .type = i2c_type_optoe2_SFP,   .addr = 0x50, .name = "SFP_26_EEPROM\0", .oom_port_name = 26 },
+	{ .parent_bus = (0x38 + 2), .type = i2c_type_optoe2_SFP,   .addr = 0x50, .name = "SFP_27_EEPROM\0", .oom_port_name = 27 },
+	{ .parent_bus = (0x38 + 3), .type = i2c_type_optoe2_SFP,   .addr = 0x50, .name = "SFP_28_EEPROM\0", .oom_port_name = 28 },
+	{ .parent_bus = (0x38 + 4), .type = i2c_type_optoe2_SFP,   .addr = 0x50, .name = "SFP_29_EEPROM\0", .oom_port_name = 29 },
+	{ .parent_bus = (0x38 + 5), .type = i2c_type_optoe2_SFP,   .addr = 0x50, .name = "SFP_30_EEPROM\0", .oom_port_name = 30 },
+	{ .parent_bus = (0x38 + 6), .type = i2c_type_optoe2_SFP,   .addr = 0x50, .name = "SFP_31_EEPROM\0", .oom_port_name = 31 },
+	{ .parent_bus = (0x38 + 7), .type = i2c_type_optoe2_SFP,   .addr = 0x50, .name = "SFP_32_EEPROM\0", .oom_port_name = 32 },
+	{ .parent_bus = (0x40 + 0), .type = i2c_type_optoe2_SFP,   .addr = 0x50, .name = "SFP_33_EEPROM\0", .oom_port_name = 33 },
+	{ .parent_bus = (0x40 + 1), .type = i2c_type_optoe2_SFP,   .addr = 0x50, .name = "SFP_34_EEPROM\0", .oom_port_name = 34 },
+	{ .parent_bus = (0x40 + 2), .type = i2c_type_optoe2_SFP,   .addr = 0x50, .name = "SFP_35_EEPROM\0", .oom_port_name = 35 },
+	{ .parent_bus = (0x40 + 3), .type = i2c_type_optoe2_SFP,   .addr = 0x50, .name = "SFP_36_EEPROM\0", .oom_port_name = 36 },
+	{ .parent_bus = (0x40 + 4), .type = i2c_type_optoe2_SFP,   .addr = 0x50, .name = "SFP_37_EEPROM\0", .oom_port_name = 37 },
+	{ .parent_bus = (0x40 + 5), .type = i2c_type_optoe2_SFP,   .addr = 0x50, .name = "SFP_38_EEPROM\0", .oom_port_name = 38 },
+	{ .parent_bus = (0x40 + 6), .type = i2c_type_optoe2_SFP,   .addr = 0x50, .name = "SFP_39_EEPROM\0", .oom_port_name = 39 },
+	{ .parent_bus = (0x40 + 7), .type = i2c_type_optoe2_SFP,   .addr = 0x50, .name = "SFP_40_EEPROM\0", .oom_port_name = 40 },
+	{ .parent_bus = (0x48 + 0), .type = i2c_type_optoe2_SFP,   .addr = 0x50, .name = "SFP_41_EEPROM\0", .oom_port_name = 41 },
+	{ .parent_bus = (0x48 + 1), .type = i2c_type_optoe2_SFP,   .addr = 0x50, .name = "SFP_42_EEPROM\0", .oom_port_name = 42 },
+	{ .parent_bus = (0x48 + 2), .type = i2c_type_optoe2_SFP,   .addr = 0x50, .name = "SFP_43_EEPROM\0", .oom_port_name = 43 },
+	{ .parent_bus = (0x48 + 3), .type = i2c_type_optoe2_SFP,   .addr = 0x50, .name = "SFP_44_EEPROM\0", .oom_port_name = 44 },
+	{ .parent_bus = (0x48 + 4), .type = i2c_type_optoe2_SFP,   .addr = 0x50, .name = "SFP_45_EEPROM\0", .oom_port_name = 45 },
+	{ .parent_bus = (0x48 + 5), .type = i2c_type_optoe2_SFP,   .addr = 0x50, .name = "SFP_46_EEPROM\0", .oom_port_name = 46 },
+	{ .parent_bus = (0x48 + 6), .type = i2c_type_optoe2_SFP,   .addr = 0x50, .name = "SFP_47_EEPROM\0", .oom_port_name = 47 },
+	{ .parent_bus = (0x48 + 7), .type = i2c_type_optoe2_SFP,   .addr = 0x50, .name = "SFP_48_EEPROM\0", .oom_port_name = 48 },
 
 	{ .parent_bus = (0x10 + 3), .type = i2c_type_pca9698, .addr = 0x23, .name = "PCA9698(SFP_1-8)\0" },
 	{ .parent_bus = (0x10 + 3), .type = i2c_type_pca9698, .addr = 0x21, .name = "PCA9698(SFP_9-16)\0" },
@@ -151,10 +156,10 @@ static struct i2c_init_data quanta_ly8_i2c_init_data[] = {
 	{ .parent_bus = (0x10 + 4), .type = i2c_type_pca9698, .addr = 0x25, .name = "PCA9698(SFP_41-48)\0" },
 
 	{ .parent_bus = (0x10 + 5), .type = i2c_type_pca9548, .addr = 0x76, .busno = 0x50, .name = "PCA9548_8\0" },
-	{ .parent_bus = (0x50 + 0), .type = i2c_type_24c02,   .addr = 0x50, .name = "QSFP_1_EEPROM\0" },
-	{ .parent_bus = (0x50 + 1), .type = i2c_type_24c02,   .addr = 0x50, .name = "QSFP_2_EEPROM\0" },
-	{ .parent_bus = (0x50 + 2), .type = i2c_type_24c02,   .addr = 0x50, .name = "QSFP_3_EEPROM\0" },
-	{ .parent_bus = (0x50 + 3), .type = i2c_type_24c02,   .addr = 0x50, .name = "QSFP_4_EEPROM\0" },
+	{ .parent_bus = (0x50 + 0), .type = i2c_type_optoe1_QSFP,   .addr = 0x50, .name = "QSFP_1_EEPROM\0", .oom_port_name = 49 },
+	{ .parent_bus = (0x50 + 1), .type = i2c_type_optoe1_QSFP,   .addr = 0x50, .name = "QSFP_2_EEPROM\0", .oom_port_name = 50 },
+	{ .parent_bus = (0x50 + 2), .type = i2c_type_optoe1_QSFP,   .addr = 0x50, .name = "QSFP_3_EEPROM\0", .oom_port_name = 51 },
+	{ .parent_bus = (0x50 + 3), .type = i2c_type_optoe1_QSFP,   .addr = 0x50, .name = "QSFP_4_EEPROM\0", .oom_port_name = 52 },
 
 	{ .parent_bus = (0x10 + 5), .type = i2c_type_pca9555, .addr = 0x24, .name = "PCA9555_1(LED)\0" },
 	{ .parent_bus = (0x10 + 6), .type = i2c_type_pca9555, .addr = 0x23, .name = "PCA9555_2(QSFP)\0" },
@@ -162,8 +167,8 @@ static struct i2c_init_data quanta_ly8_i2c_init_data[] = {
 	/* QSFP+ DB */
 	{ .parent_bus = (0x10 + 7), .type = i2c_type_pca9555, .addr = 0x23, .name = "PCA9555(QDB)\0" },
 	{ .parent_bus = (0x10 + 7), .type = i2c_type_pca9546, .addr = 0x76, .busno = 0x58, .name = "PCA9546(QDB)\0" },
-	{ .parent_bus = (0x58 + 0), .type = i2c_type_24c02,   .addr = 0x50, .name = "QDB_QSFP_1_EEPROM\0" },
-	{ .parent_bus = (0x58 + 1), .type = i2c_type_24c02,   .addr = 0x50, .name = "QDB_QSFP_2_EEPROM\0" },
+	{ .parent_bus = (0x58 + 0), .type = i2c_type_optoe1_QSFP,   .addr = 0x50, .name = "QDB_QSFP_1_EEPROM\0", .oom_port_name = 53 },
+	{ .parent_bus = (0x58 + 1), .type = i2c_type_optoe1_QSFP,   .addr = 0x50, .name = "QDB_QSFP_2_EEPROM\0", .oom_port_name = 54 },
 
 	{ .parent_bus = (0x00 + 0), .type = i2c_type_pca9546, .addr = 0x72, .busno = 0x18, .name = "PCA9546\0" },
 	{ .parent_bus = (0x18 + 0), .type = i2c_type_emerson700,   .addr = 0x6f, .name = "PSU_1\0" }, /* RPSU 1 */
@@ -244,9 +249,31 @@ static inline struct pca953x_platform_data *pca953x_platform_data_get(int type, 
 	return &platform_data;
 }
 
+struct optoe_platform_data {
+	u32		byte_len;		/* size (sum of all addr) */
+	u16		page_size;		/* for writes */
+	u8		flags;
+
+	void		(*setup)(struct memory_accessor *, void *context);
+	void		*context;
+
+	int oom_port_name;
+};
+
+static inline struct optoe_platform_data *optoe_platform_data_get(int port_name) {
+	static struct optoe_platform_data platform_data;
+
+	platform_data = (struct optoe_platform_data) {
+		.oom_port_name = port_name,
+	};
+
+	return &platform_data;
+}
+
 static inline struct i2c_board_info *i2c_board_info_get(struct i2c_init_data data) {
 	struct pca954x_platform_data *mux_platform_data;
 	struct pca953x_platform_data *gpio_platform_data;
+	struct optoe_platform_data *oom_platform_data;
 	static struct i2c_board_info board_info;
 
 	switch(data.type) {
@@ -272,6 +299,17 @@ static inline struct i2c_board_info *i2c_board_info_get(struct i2c_init_data dat
 
 			board_info = (struct i2c_board_info) {
 				.platform_data = gpio_platform_data,
+			};
+			break;
+		case i2c_type_optoe1_QSFP:
+		case i2c_type_optoe2_SFP:
+			oom_platform_data = optoe_platform_data_get(data.oom_port_name);
+			if(oom_platform_data == NULL) {
+				return (struct i2c_board_info *) NULL;
+			}
+
+			board_info = (struct i2c_board_info) {
+				.platform_data = oom_platform_data,
 			};
 			break;
 

--- a/packages/platforms/quanta/x86-64/x86-64-quanta-ly8-rangeley/onlp/builds/src/x86_64_quanta_ly8_rangeley/module/src/sfpi.c
+++ b/packages/platforms/quanta/x86-64/x86-64-quanta-ly8-rangeley/onlp/builds/src/x86_64_quanta_ly8_rangeley/module/src/sfpi.c
@@ -27,6 +27,7 @@
 #include <onlp/platformi/sfpi.h>
 #include <onlplib/sfp.h>
 #include <onlplib/gpio.h>
+#include <onlplib/file.h>
 #include "x86_64_quanta_ly8_rangeley_log.h"
 
 #include <unistd.h>
@@ -40,69 +41,84 @@ typedef struct sfpmap_s {
     int port;
     int present_gpio;
     const char* reset_gpio;
-    const char* eeprom;
+    const char* port_path;
     const char* dom;
 } sfpmap_t;
 
 static sfpmap_t sfpmap__[] =
     {
-        {  1, QUANTA_LY8_PCA9698_1_GPIO_SFP_1_PRSNT_N /* 168 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-32/32-0050/eeprom", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-32/32-0051/eeprom" },
-        {  2, QUANTA_LY8_PCA9698_1_GPIO_SFP_2_PRSNT_N /* 172 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-33/33-0050/eeprom", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-33/33-0051/eeprom" },
-        {  3, QUANTA_LY8_PCA9698_1_GPIO_SFP_3_PRSNT_N /* 176 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-34/34-0050/eeprom", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-34/34-0051/eeprom" },
-        {  4, QUANTA_LY8_PCA9698_1_GPIO_SFP_4_PRSNT_N /* 180 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-35/35-0050/eeprom", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-35/35-0051/eeprom" },
-        {  5, QUANTA_LY8_PCA9698_1_GPIO_SFP_5_PRSNT_N /* 184 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-36/36-0050/eeprom", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-36/36-0051/eeprom" },
-        {  6, QUANTA_LY8_PCA9698_1_GPIO_SFP_6_PRSNT_N /* 188 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-37/37-0050/eeprom", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-37/37-0051/eeprom" },
-        {  7, QUANTA_LY8_PCA9698_1_GPIO_SFP_7_PRSNT_N /* 192 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-38/38-0050/eeprom", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-38/38-0051/eeprom" },
-        {  8, QUANTA_LY8_PCA9698_1_GPIO_SFP_8_PRSNT_N /* 196 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-39/39-0050/eeprom", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-39/39-0051/eeprom" },
-        {  9, QUANTA_LY8_PCA9698_2_GPIO_SFP_9_PRSNT_N /* 208 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-40/40-0050/eeprom", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-40/40-0051/eeprom" },
-        { 10, QUANTA_LY8_PCA9698_2_GPIO_SFP_10_PRSNT_N /* 212 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-41/41-0050/eeprom", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-41/41-0051/eeprom" },
-        { 11, QUANTA_LY8_PCA9698_2_GPIO_SFP_11_PRSNT_N /* 216 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-42/42-0050/eeprom", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-42/42-0051/eeprom" },
-        { 12, QUANTA_LY8_PCA9698_2_GPIO_SFP_12_PRSNT_N /* 220 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-43/43-0050/eeprom", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-43/43-0051/eeprom" },
-        { 13, QUANTA_LY8_PCA9698_2_GPIO_SFP_13_PRSNT_N /* 224 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-44/44-0050/eeprom", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-44/44-0051/eeprom" },
-        { 14, QUANTA_LY8_PCA9698_2_GPIO_SFP_14_PRSNT_N /* 228 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-45/45-0050/eeprom", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-45/45-0051/eeprom" },
-        { 15, QUANTA_LY8_PCA9698_2_GPIO_SFP_15_PRSNT_N /* 232 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-46/46-0050/eeprom", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-46/46-0051/eeprom" },
-        { 16, QUANTA_LY8_PCA9698_2_GPIO_SFP_16_PRSNT_N /* 236 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-47/47-0050/eeprom", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-47/47-0051/eeprom" },
-        { 17, QUANTA_LY8_PCA9698_3_GPIO_SFP_17_PRSNT_N /* 248 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-48/48-0050/eeprom", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-48/48-0051/eeprom" },
-        { 18, QUANTA_LY8_PCA9698_3_GPIO_SFP_18_PRSNT_N /* 252 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-49/49-0050/eeprom", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-49/49-0051/eeprom" },
-        { 19, QUANTA_LY8_PCA9698_3_GPIO_SFP_19_PRSNT_N /* 256 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-50/50-0050/eeprom", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-50/50-0051/eeprom" },
-        { 20, QUANTA_LY8_PCA9698_3_GPIO_SFP_20_PRSNT_N /* 260 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-51/51-0050/eeprom", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-51/51-0051/eeprom" },
-        { 21, QUANTA_LY8_PCA9698_3_GPIO_SFP_21_PRSNT_N /* 264 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-52/52-0050/eeprom", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-52/52-0051/eeprom" },
-        { 22, QUANTA_LY8_PCA9698_3_GPIO_SFP_22_PRSNT_N /* 268 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-53/53-0050/eeprom", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-53/53-0051/eeprom" },
-        { 23, QUANTA_LY8_PCA9698_3_GPIO_SFP_23_PRSNT_N /* 272 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-54/54-0050/eeprom", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-54/54-0051/eeprom" },
-        { 24, QUANTA_LY8_PCA9698_3_GPIO_SFP_24_PRSNT_N /* 276 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-55/55-0050/eeprom", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-55/55-0051/eeprom" },
-        { 25, QUANTA_LY8_PCA9698_4_GPIO_SFP_25_PRSNT_N /* 288 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-56/56-0050/eeprom", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-56/56-0051/eeprom" },
-        { 26, QUANTA_LY8_PCA9698_4_GPIO_SFP_26_PRSNT_N /* 292 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-57/57-0050/eeprom", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-57/57-0051/eeprom" },
-        { 27, QUANTA_LY8_PCA9698_4_GPIO_SFP_27_PRSNT_N /* 296 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-58/58-0050/eeprom", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-58/58-0051/eeprom" },
-        { 28, QUANTA_LY8_PCA9698_4_GPIO_SFP_28_PRSNT_N /* 300 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-59/59-0050/eeprom", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-59/59-0051/eeprom" },
-        { 29, QUANTA_LY8_PCA9698_4_GPIO_SFP_29_PRSNT_N /* 304 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-60/60-0050/eeprom", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-60/60-0051/eeprom" },
-        { 30, QUANTA_LY8_PCA9698_4_GPIO_SFP_30_PRSNT_N /* 308 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-61/61-0050/eeprom", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-61/61-0051/eeprom" },
-        { 31, QUANTA_LY8_PCA9698_4_GPIO_SFP_31_PRSNT_N /* 312 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-62/62-0050/eeprom", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-62/62-0051/eeprom" },
-        { 32, QUANTA_LY8_PCA9698_4_GPIO_SFP_32_PRSNT_N /* 316 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-63/63-0050/eeprom", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-63/63-0051/eeprom" },
-        { 33, QUANTA_LY8_PCA9698_5_GPIO_SFP_33_PRSNT_N /* 328 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-64/64-0050/eeprom", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-64/64-0051/eeprom" },
-        { 34, QUANTA_LY8_PCA9698_5_GPIO_SFP_34_PRSNT_N /* 332 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-65/65-0050/eeprom", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-65/65-0051/eeprom" },
-        { 35, QUANTA_LY8_PCA9698_5_GPIO_SFP_35_PRSNT_N /* 336 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-66/66-0050/eeprom", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-66/66-0051/eeprom" },
-        { 36, QUANTA_LY8_PCA9698_5_GPIO_SFP_36_PRSNT_N /* 340 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-67/67-0050/eeprom", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-67/67-0051/eeprom" },
-        { 37, QUANTA_LY8_PCA9698_5_GPIO_SFP_37_PRSNT_N /* 344 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-68/68-0050/eeprom", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-68/68-0051/eeprom" },
-        { 38, QUANTA_LY8_PCA9698_5_GPIO_SFP_38_PRSNT_N /* 348 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-69/69-0050/eeprom", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-69/69-0051/eeprom" },
-        { 39, QUANTA_LY8_PCA9698_5_GPIO_SFP_39_PRSNT_N /* 352 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-70/70-0050/eeprom", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-70/70-0051/eeprom" },
-        { 40, QUANTA_LY8_PCA9698_5_GPIO_SFP_40_PRSNT_N /* 356 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-71/71-0050/eeprom", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-71/71-0051/eeprom" },
-        { 41, QUANTA_LY8_PCA9698_6_GPIO_SFP_41_PRSNT_N /* 368 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-72/72-0050/eeprom", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-72/72-0051/eeprom" },
-        { 42, QUANTA_LY8_PCA9698_6_GPIO_SFP_42_PRSNT_N /* 372 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-73/73-0050/eeprom", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-73/73-0051/eeprom" },
-        { 43, QUANTA_LY8_PCA9698_6_GPIO_SFP_43_PRSNT_N /* 376 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-74/74-0050/eeprom", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-74/74-0051/eeprom" },
-        { 44, QUANTA_LY8_PCA9698_6_GPIO_SFP_44_PRSNT_N /* 380 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-75/75-0050/eeprom", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-75/75-0051/eeprom" },
-        { 45, QUANTA_LY8_PCA9698_6_GPIO_SFP_45_PRSNT_N /* 384 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-76/76-0050/eeprom", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-76/76-0051/eeprom" },
-        { 46, QUANTA_LY8_PCA9698_6_GPIO_SFP_46_PRSNT_N /* 388 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-77/77-0050/eeprom", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-77/77-0051/eeprom" },
-        { 47, QUANTA_LY8_PCA9698_6_GPIO_SFP_47_PRSNT_N /* 392 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-78/78-0050/eeprom", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-78/78-0051/eeprom" },
-        { 48, QUANTA_LY8_PCA9698_6_GPIO_SFP_48_PRSNT_N /* 396 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-79/79-0050/eeprom", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-79/79-0051/eeprom" },
-        { 49, QUANTA_LY8_QSFP_GPIO_PRSNT_49_N /* 426 */, "/sys/class/gpio/gpio424/value", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-21/i2c-80/80-0050/eeprom", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-21/i2c-80/80-0051/eeprom" },
-        { 50, QUANTA_LY8_QSFP_GPIO_PRSNT_50_N /* 430 */, "/sys/class/gpio/gpio428/value", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-21/i2c-81/81-0050/eeprom", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-21/i2c-81/81-0051/eeprom" },
-        { 51, QUANTA_LY8_QSFP_GPIO_PRSNT_51_N /* 434 */, "/sys/class/gpio/gpio432/value", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-21/i2c-82/82-0050/eeprom", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-21/i2c-82/82-0051/eeprom" },
-        { 52, QUANTA_LY8_QSFP_GPIO_PRSNT_52_N /* 438 */, "/sys/class/gpio/gpio436/value", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-21/i2c-83/83-0050/eeprom", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-21/i2c-83/83-0051/eeprom" },
-        { 69, QUANTA_LY8_QSFP_QDB_GPIO_PRSNT_69_N /* 442 */, "/sys/class/gpio/gpio442/value", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-23/i2c-88/88-0050/eeprom", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-23/i2c-88/88-0051/eeprom" },
-        { 70, QUANTA_LY8_QSFP_QDB_GPIO_PRSNT_70_N /* 446 */, "/sys/class/gpio/gpio446/value", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-23/i2c-89/89-0050/eeprom", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-23/i2c-89/89-0051/eeprom" },
+        { }, /* Not used */
+        {  1, QUANTA_LY8_PCA9698_1_GPIO_SFP_1_PRSNT_N /* 168 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-32/32-0050/%s", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-32/32-0051/eeprom" },
+        {  2, QUANTA_LY8_PCA9698_1_GPIO_SFP_2_PRSNT_N /* 172 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-33/33-0050/%s", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-33/33-0051/eeprom" },
+        {  3, QUANTA_LY8_PCA9698_1_GPIO_SFP_3_PRSNT_N /* 176 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-34/34-0050/%s", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-34/34-0051/eeprom" },
+        {  4, QUANTA_LY8_PCA9698_1_GPIO_SFP_4_PRSNT_N /* 180 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-35/35-0050/%s", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-35/35-0051/eeprom" },
+        {  5, QUANTA_LY8_PCA9698_1_GPIO_SFP_5_PRSNT_N /* 184 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-36/36-0050/%s", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-36/36-0051/eeprom" },
+        {  6, QUANTA_LY8_PCA9698_1_GPIO_SFP_6_PRSNT_N /* 188 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-37/37-0050/%s", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-37/37-0051/eeprom" },
+        {  7, QUANTA_LY8_PCA9698_1_GPIO_SFP_7_PRSNT_N /* 192 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-38/38-0050/%s", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-38/38-0051/eeprom" },
+        {  8, QUANTA_LY8_PCA9698_1_GPIO_SFP_8_PRSNT_N /* 196 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-39/39-0050/%s", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-39/39-0051/eeprom" },
+        {  9, QUANTA_LY8_PCA9698_2_GPIO_SFP_9_PRSNT_N /* 208 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-40/40-0050/%s", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-40/40-0051/eeprom" },
+        { 10, QUANTA_LY8_PCA9698_2_GPIO_SFP_10_PRSNT_N /* 212 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-41/41-0050/%s", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-41/41-0051/eeprom" },
+        { 11, QUANTA_LY8_PCA9698_2_GPIO_SFP_11_PRSNT_N /* 216 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-42/42-0050/%s", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-42/42-0051/eeprom" },
+        { 12, QUANTA_LY8_PCA9698_2_GPIO_SFP_12_PRSNT_N /* 220 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-43/43-0050/%s", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-43/43-0051/eeprom" },
+        { 13, QUANTA_LY8_PCA9698_2_GPIO_SFP_13_PRSNT_N /* 224 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-44/44-0050/%s", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-44/44-0051/eeprom" },
+        { 14, QUANTA_LY8_PCA9698_2_GPIO_SFP_14_PRSNT_N /* 228 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-45/45-0050/%s", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-45/45-0051/eeprom" },
+        { 15, QUANTA_LY8_PCA9698_2_GPIO_SFP_15_PRSNT_N /* 232 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-46/46-0050/%s", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-46/46-0051/eeprom" },
+        { 16, QUANTA_LY8_PCA9698_2_GPIO_SFP_16_PRSNT_N /* 236 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-47/47-0050/%s", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-47/47-0051/eeprom" },
+        { 17, QUANTA_LY8_PCA9698_3_GPIO_SFP_17_PRSNT_N /* 248 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-48/48-0050/%s", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-48/48-0051/eeprom" },
+        { 18, QUANTA_LY8_PCA9698_3_GPIO_SFP_18_PRSNT_N /* 252 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-49/49-0050/%s", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-49/49-0051/eeprom" },
+        { 19, QUANTA_LY8_PCA9698_3_GPIO_SFP_19_PRSNT_N /* 256 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-50/50-0050/%s", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-50/50-0051/eeprom" },
+        { 20, QUANTA_LY8_PCA9698_3_GPIO_SFP_20_PRSNT_N /* 260 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-51/51-0050/%s", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-51/51-0051/eeprom" },
+        { 21, QUANTA_LY8_PCA9698_3_GPIO_SFP_21_PRSNT_N /* 264 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-52/52-0050/%s", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-52/52-0051/eeprom" },
+        { 22, QUANTA_LY8_PCA9698_3_GPIO_SFP_22_PRSNT_N /* 268 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-53/53-0050/%s", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-53/53-0051/eeprom" },
+        { 23, QUANTA_LY8_PCA9698_3_GPIO_SFP_23_PRSNT_N /* 272 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-54/54-0050/%s", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-54/54-0051/eeprom" },
+        { 24, QUANTA_LY8_PCA9698_3_GPIO_SFP_24_PRSNT_N /* 276 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-55/55-0050/%s", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-17/i2c-55/55-0051/eeprom" },
+        { 25, QUANTA_LY8_PCA9698_4_GPIO_SFP_25_PRSNT_N /* 288 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-56/56-0050/%s", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-56/56-0051/eeprom" },
+        { 26, QUANTA_LY8_PCA9698_4_GPIO_SFP_26_PRSNT_N /* 292 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-57/57-0050/%s", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-57/57-0051/eeprom" },
+        { 27, QUANTA_LY8_PCA9698_4_GPIO_SFP_27_PRSNT_N /* 296 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-58/58-0050/%s", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-58/58-0051/eeprom" },
+        { 28, QUANTA_LY8_PCA9698_4_GPIO_SFP_28_PRSNT_N /* 300 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-59/59-0050/%s", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-59/59-0051/eeprom" },
+        { 29, QUANTA_LY8_PCA9698_4_GPIO_SFP_29_PRSNT_N /* 304 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-60/60-0050/%s", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-60/60-0051/eeprom" },
+        { 30, QUANTA_LY8_PCA9698_4_GPIO_SFP_30_PRSNT_N /* 308 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-61/61-0050/%s", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-61/61-0051/eeprom" },
+        { 31, QUANTA_LY8_PCA9698_4_GPIO_SFP_31_PRSNT_N /* 312 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-62/62-0050/%s", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-62/62-0051/eeprom" },
+        { 32, QUANTA_LY8_PCA9698_4_GPIO_SFP_32_PRSNT_N /* 316 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-63/63-0050/%s", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-63/63-0051/eeprom" },
+        { 33, QUANTA_LY8_PCA9698_5_GPIO_SFP_33_PRSNT_N /* 328 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-64/64-0050/%s", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-64/64-0051/eeprom" },
+        { 34, QUANTA_LY8_PCA9698_5_GPIO_SFP_34_PRSNT_N /* 332 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-65/65-0050/%s", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-65/65-0051/eeprom" },
+        { 35, QUANTA_LY8_PCA9698_5_GPIO_SFP_35_PRSNT_N /* 336 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-66/66-0050/%s", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-66/66-0051/eeprom" },
+        { 36, QUANTA_LY8_PCA9698_5_GPIO_SFP_36_PRSNT_N /* 340 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-67/67-0050/%s", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-67/67-0051/eeprom" },
+        { 37, QUANTA_LY8_PCA9698_5_GPIO_SFP_37_PRSNT_N /* 344 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-68/68-0050/%s", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-68/68-0051/eeprom" },
+        { 38, QUANTA_LY8_PCA9698_5_GPIO_SFP_38_PRSNT_N /* 348 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-69/69-0050/%s", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-69/69-0051/eeprom" },
+        { 39, QUANTA_LY8_PCA9698_5_GPIO_SFP_39_PRSNT_N /* 352 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-70/70-0050/%s", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-70/70-0051/eeprom" },
+        { 40, QUANTA_LY8_PCA9698_5_GPIO_SFP_40_PRSNT_N /* 356 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-71/71-0050/%s", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-71/71-0051/eeprom" },
+        { 41, QUANTA_LY8_PCA9698_6_GPIO_SFP_41_PRSNT_N /* 368 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-72/72-0050/%s", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-72/72-0051/eeprom" },
+        { 42, QUANTA_LY8_PCA9698_6_GPIO_SFP_42_PRSNT_N /* 372 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-73/73-0050/%s", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-73/73-0051/eeprom" },
+        { 43, QUANTA_LY8_PCA9698_6_GPIO_SFP_43_PRSNT_N /* 376 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-74/74-0050/%s", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-74/74-0051/eeprom" },
+        { 44, QUANTA_LY8_PCA9698_6_GPIO_SFP_44_PRSNT_N /* 380 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-75/75-0050/%s", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-75/75-0051/eeprom" },
+        { 45, QUANTA_LY8_PCA9698_6_GPIO_SFP_45_PRSNT_N /* 384 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-76/76-0050/%s", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-76/76-0051/eeprom" },
+        { 46, QUANTA_LY8_PCA9698_6_GPIO_SFP_46_PRSNT_N /* 388 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-77/77-0050/%s", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-77/77-0051/eeprom" },
+        { 47, QUANTA_LY8_PCA9698_6_GPIO_SFP_47_PRSNT_N /* 392 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-78/78-0050/%s", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-78/78-0051/eeprom" },
+        { 48, QUANTA_LY8_PCA9698_6_GPIO_SFP_48_PRSNT_N /* 396 */, NULL, "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-79/79-0050/%s", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-18/i2c-79/79-0051/eeprom" },
+        { 49, QUANTA_LY8_QSFP_GPIO_PRSNT_49_N /* 426 */, "/sys/class/gpio/gpio424/value", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-21/i2c-80/80-0050/%s", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-21/i2c-80/80-0051/eeprom" },
+        { 50, QUANTA_LY8_QSFP_GPIO_PRSNT_50_N /* 430 */, "/sys/class/gpio/gpio428/value", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-21/i2c-81/81-0050/%s", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-21/i2c-81/81-0051/eeprom" },
+        { 51, QUANTA_LY8_QSFP_GPIO_PRSNT_51_N /* 434 */, "/sys/class/gpio/gpio432/value", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-21/i2c-82/82-0050/%s", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-21/i2c-82/82-0051/eeprom" },
+        { 52, QUANTA_LY8_QSFP_GPIO_PRSNT_52_N /* 438 */, "/sys/class/gpio/gpio436/value", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-21/i2c-83/83-0050/%s", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-21/i2c-83/83-0051/eeprom" },
+        { 69, QUANTA_LY8_QSFP_QDB_GPIO_PRSNT_69_N /* 442 */, "/sys/class/gpio/gpio442/value", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-23/i2c-88/88-0050/%s", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-23/i2c-88/88-0051/eeprom" },
+        { 70, QUANTA_LY8_QSFP_QDB_GPIO_PRSNT_70_N /* 446 */, "/sys/class/gpio/gpio446/value", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-23/i2c-89/89-0050/%s", "/sys/devices/pci0000:00/0000:00:1f.3/i2c-0/i2c-23/i2c-89/89-0051/eeprom" },
   };
 
 #define SFP_GET(_port) (sfpmap__ + _port)
+#define SFP_MAX_PORT_NUM 48
+#define QSFP_MAX_PORT_NUM 6
+#define MAX_PORT_NUM 	SFP_MAX_PORT_NUM + QSFP_MAX_PORT_NUM
+#define MAX_SFP_PATH 	128
+static char sfp_node_path[MAX_SFP_PATH] = {0};
+
+static char*sfp_get_port_path(int port, char *node_name)
+{
+    sfpmap_t* sfp = SFP_GET(port);
+
+    sprintf(sfp_node_path, sfp->port_path, node_name);
+
+    return sfp_node_path;
+}
 
 int
 onlp_sfpi_init(void)
@@ -126,8 +142,8 @@ onlp_sfpi_init(void)
         }
     }
 
-    for(i = 0; i < 54; i++) {
-        sfp = SFP_GET(i);
+    for(i = 0; i < MAX_PORT_NUM; i++) {
+        sfp = SFP_GET(i + 1);
         onlp_gpio_export(sfp->present_gpio, ONLP_GPIO_DIRECTION_IN);
     }
 
@@ -137,10 +153,12 @@ onlp_sfpi_init(void)
 int
 onlp_sfpi_bitmap_get(onlp_sfp_bitmap_t* bmap)
 {
-    int p;
+    int i, port_name;
 
-    for(p = 0; p < 54; p++) {
-        AIM_BITMAP_SET(bmap, p);
+    for(i = 0; i < MAX_PORT_NUM; i++) {
+        if(onlp_file_read_int(&port_name, sfp_get_port_path(i + 1, "port_name")) == 0) {
+            AIM_BITMAP_SET(bmap, port_name);
+        }
     }
 
     return ONLP_STATUS_OK;
@@ -162,7 +180,7 @@ onlp_sfpi_is_present(int port)
          * If we can open and read a byte from the EEPROM file
          * then we consider it present.
          */
-        int fd = open(sfp->eeprom, O_RDONLY);
+        int fd = open(sfp_get_port_path(port, "eeprom"), O_RDONLY);
         if (fd < 0) {
             /* Not Present */
             return 0;
@@ -186,8 +204,7 @@ onlp_sfpi_is_present(int port)
 int
 onlp_sfpi_eeprom_read(int port, uint8_t data[256])
 {
-    sfpmap_t* sfp = SFP_GET(port);
-    return onlplib_sfp_eeprom_read_file(sfp->eeprom, data);
+    return onlplib_sfp_eeprom_read_file(sfp_get_port_path(port, "eeprom"), data);
 }
 
 int

--- a/packages/platforms/quanta/x86-64/x86-64-quanta-ly8-rangeley/platform-config/r0/src/python/x86_64_quanta_ly8_rangeley_r0/__init__.py
+++ b/packages/platforms/quanta/x86-64/x86-64-quanta-ly8-rangeley/platform-config/r0/src/python/x86_64_quanta_ly8_rangeley_r0/__init__.py
@@ -18,6 +18,7 @@ class OnlPlatform_x86_64_quanta_ly8_rangeley_r0(OnlPlatformQuanta,
     def baseconfig(self):
         self.insmod("emerson700")
         self.insmod("quanta_hwmon_ly_series")
+        self.insmod("optoe")
         self.insmod("quanta_platform_ly8")
 
         # make ds1339 as default rtc


### PR DESCRIPTION
1. Migrate device driver from opencomputeproject/oom/optoe
2. Change device driver of eeprom from 24c02 to optoe
3. Use platform data to initial port_name
4. BITMAP is set by port_name