### PR TITLE
Use onie-sysinfo instead of machine.conf, see SWL-4279

### DIFF
--- a/builds/any/installer/installer.sh.in
+++ b/builds/any/installer/installer.sh.in
@@ -144,7 +144,14 @@ if test "$installer_debug"; then
 fi
 
 # Pickup ONIE defines for this machine.
-if test -r /etc/machine.conf; then
+if test "$onie_platform"; then
+  :
+else
+  onie_platform=$(onie-sysinfo -p 2>/dev/null) || :
+fi
+if test "$onie_platform"; then
+  :
+elif test -r /etc/machine.conf; then
   . /etc/machine.conf
 fi
 
@@ -252,7 +259,7 @@ if test "${onie_platform}"; then
   }
 else
   if test "$ARCH_X86"; then
-    echo "Missing onie_platform (invalid /etc/machine.conf)" 1>&2
+    echo "Missing onie_platform (invalid or missing onie-sysinfo or /etc/machine.conf)" 1>&2
     exit 1
   fi
   #

--- a/packages/base/all/vendor-config-onl/src/bin/onie-sysinfo
+++ b/packages/base/all/vendor-config-onl/src/bin/onie-sysinfo
@@ -1,0 +1,7 @@
+#!/usr/bin/python
+
+"""Run native onie-sysinfo
+"""
+
+import onl.install.ShellApp
+onl.install.ShellApp.OnieSysinfoApp.main()

--- a/packages/base/all/vendor-config-onl/src/lib/install/lib.sh
+++ b/packages/base/all/vendor-config-onl/src/lib/install/lib.sh
@@ -122,7 +122,7 @@ installer_mkchroot() {
     mkdir -p "${rootdir}${TMPDIR}"
   fi
 
-  # export ONIE defines to the installer
+  # export ONIE defines to the installer, if they exist
   if test -r /etc/machine.conf; then
     cp /etc/machine.conf "${rootdir}/etc/machine.conf"
   fi

--- a/packages/base/all/vendor-config-onl/src/python/onl/install/ShellApp.py
+++ b/packages/base/all/vendor-config-onl/src/python/onl/install/ShellApp.py
@@ -15,9 +15,6 @@ from InstallUtils import ProcMountsParser, ProcMtdParser
 from InstallUtils import BlkidParser
 from InstallUtils import UbootInitrdContext
 
-import onl.platform.current
-from onl.sysconfig import sysconfig
-
 class AppBase(SubprocessMixin, object):
 
     @property
@@ -228,6 +225,105 @@ class Onie(AppBase):
         with OnieBootContext(log=self.log) as ctx:
             return self._runInitrdShell(ctx.initrd)
 
+class OnieSysinfoApp(SubprocessMixin, object):
+
+    PROG = "onie-sysinfo"
+
+    def __init__(self, args=[], log=None):
+
+        if log is not None:
+            self.log = log
+        else:
+            self.log = logging.getLogger(self.__class__.__name__)
+        self.args = args or ['-p',]
+        self.output = None
+
+    def _runInitrdShell(self, initrd):
+        with InitrdContext(initrd=initrd, log=self.log) as ctx:
+            cmd = ['onie-sysinfo',]
+            cmd.extend(self.args)
+            cmd = ('chroot', ctx.dir,
+                   '/bin/sh', '-c', 'IFS=;' + " ".join(cmd))
+            try:
+                self.output = self.check_output(cmd)
+                ret = 0
+            except subprocess.CalledProcessError, what:
+                self.log.error("failed command: %s", " ".join(what.cmd))
+                for line in (what.output or "").splitlines():
+                    self.log.error(">>> %s", line)
+                ret = what.returncode
+        return ret
+
+    def run(self):
+        with OnieBootContext(log=self.log) as ctx:
+            ret = self._runInitrdShell(ctx.initrd)
+            if self.output is not None:
+                sys.stdout.write(self.output)
+            return ret
+
+    def shutdown(self):
+        pass
+
+    @classmethod
+    def main(cls):
+
+        logging.basicConfig()
+        logger = logging.getLogger(cls.PROG)
+        logger.setLevel(logging.INFO)
+
+        args = list(sys.argv[1:])
+        sysinfoArgs = []
+        while args:
+
+            if args[0] in ('-v', '--verbose',):
+                logger.setLevel(logging.DEBUG)
+                args.pop(0)
+                continue
+
+            if args[0] in ('-q', '--quiet',):
+                logger.setLevel(logging.ERROR)
+                args.pop(0)
+                continue
+
+            sysinfoArgs.append(args.pop(0))
+
+        app = cls(args=sysinfoArgs, log=logger)
+        try:
+            code = app.run()
+        except:
+            logger.exception("runner failed")
+            code = 1
+        app.shutdown()
+        sys.exit(code)
+
+class OnieSysinfo(OnieSysinfoApp):
+
+    def _runArgs(self, *args):
+        self.args = args
+        with OnieBootContext(log=self.log) as ctx:
+            ret = self._runInitrdShell(ctx.initrd)
+            if self.output is not None:
+                return self.output.rstrip()
+            raise AttributeError("cannot retrieve onie-sysinfo attribute via %s" % str(args))
+
+    @property
+    def help(self):
+        return self._runArgs('-h')
+
+    @property
+    def onie_platform(self):
+        return self._runArgs('-p')
+
+    @property
+    def onie_arch(self):
+        return self._runArgs('-c')
+
+    @property
+    def onie_version(self):
+        return self._runArgs('-v')
+
+    # XXX roth other switches too
+
 class Loader(AppBase):
     """Application shell that uses the (installed) loader runtime."""
 
@@ -331,6 +427,7 @@ class Loader(AppBase):
 
     def run(self):
 
+        import onl.platform.current
         self.platform = onl.platform.current.OnlPlatform()
         self.pc = self.platform.platform_config
 
@@ -353,6 +450,7 @@ class Upgrader(AppBase):
 
     def runGrub(self):
 
+        from onl.sysconfig import sysconfig
         d = sysconfig.upgrade.loader.package.dir
         for b in sysconfig.upgrade.loader.package.grub:
             p = os.path.join(d, b)
@@ -365,6 +463,7 @@ class Upgrader(AppBase):
 
     def runUboot(self):
 
+        from onl.sysconfig import sysconfig
         d = sysconfig.upgrade.loader.package.dir
         for b in sysconfig.upgrade.loader.package.fit:
             p = os.path.join(d, b)
@@ -377,6 +476,7 @@ class Upgrader(AppBase):
 
     def run(self):
 
+        import onl.platform.current
         self.platform = onl.platform.current.OnlPlatform()
         self.pc = self.platform.platform_config
 

--- a/packages/base/all/vendor-config-onl/src/python/onl/install/SystemInstall.py
+++ b/packages/base/all/vendor-config-onl/src/python/onl/install/SystemInstall.py
@@ -60,8 +60,9 @@ class App(SubprocessMixin):
 
                 src = os.path.join(octx.initrdDir, "etc/machine.conf")
                 dst = os.path.join(ctx.dir, "etc/machine.conf")
-                self.log.debug("+ /bin/cp %s %s", src, dst)
-                shutil.copy2(src, dst)
+                if os.path.exists(src):
+                    self.log.debug("+ /bin/cp %s %s", src, dst)
+                    shutil.copy2(src, dst)
 
             src = "/etc/fw_env.config"
             if os.path.exists(src):

--- a/packages/base/all/vendor-config-onl/src/python/onl/platform/current.py
+++ b/packages/base/all/vendor-config-onl/src/python/onl/platform/current.py
@@ -14,8 +14,9 @@
 # platform-config packages.
 #
 ############################################################
-import os
+import os, sys
 import importlib
+import subprocess
 
 def platform_name_get():
     # Determine the current platform name.
@@ -23,6 +24,22 @@ def platform_name_get():
     if os.path.exists("/etc/onl/platform"):
         with open("/etc/onl/platform", 'r') as f:
             platform=f.read().strip()
+    elif os.path.exists("/bin/onie-sysinfo"):
+        try:
+            platform = subprocess.check_output(('/bin/onie-sysinfo', '-p',)).strip()
+        except subprocess.CalledProcessError as what:
+            for line in (what.output or "").splitlines():
+                sys.stderr.write(">>> %s\n" % line)
+            sys.stderr.write("onie-sysinfo failed with code %d\n" % what.returncode)
+            platform = None
+    elif os.path.exists("/usr/bin/onie-shell"):
+        try:
+            platform = subprocess.check_output(('/usr/bin/onie-shell', '-c', "onie-sysinfo -p",)).strip()
+        except subprocess.CalledProcessError as what:
+            for line in (what.output or "").splitlines():
+                sys.stderr.write(">>> %s\n" % line)
+            sys.stderr.write("onie-sysinfo (onie-shell) failed with code %d\n" % what.returncode)
+            platform = None
     elif os.path.exists("/etc/machine.conf"):
         with open("/etc/machine.conf", 'r') as f:
             lines = f.readlines(False)

--- a/packages/base/all/vendor-config-onl/src/python/onl/upgrade/loader.py
+++ b/packages/base/all/vendor-config-onl/src/python/onl/upgrade/loader.py
@@ -12,7 +12,7 @@ from onl.upgrade import ubase
 from onl.sysconfig import sysconfig
 from onl.mounts import OnlMountManager, OnlMountContextReadOnly, OnlMountContextReadWrite
 from onl.install import BaseInstall, ConfUtils, InstallUtils
-from onl.install.ShellApp import OnieBootContext
+from onl.install.ShellApp import OnieBootContext, OnieSysinfo
 import onl.platform.current
 import onl.versions
 
@@ -83,8 +83,12 @@ class LoaderUpgrade_Fit(LoaderUpgradeBase):
         onlPlatform = onl.platform.current.OnlPlatform()
 
         with OnieBootContext(log=self.logger) as octx:
-            path = os.path.join(octx.initrdDir, "etc/machine.conf")
-            machineConf = ConfUtils.MachineConf(path=path)
+            if os.path.exists("/usr/bin/onie-shell"):
+                machineConf = OnieSysinfo(log=self.logger.getChild("onie-sysinfo"))
+            else:
+                path = os.path.join(octx.initrdDir, "etc/machine.conf")
+                if os.path.exists(path):
+                    machineConf = ConfUtils.MachineConf(path=path)
 
         installerConf = ConfUtils.InstallerConf(path="/dev/null")
         # start with an empty installerConf, fill it in piece by piece

--- a/packages/platforms/mellanox/vendor-config/src/python/mellanox/__init__.py
+++ b/packages/platforms/mellanox/vendor-config/src/python/mellanox/__init__.py
@@ -14,6 +14,7 @@ class OnlPlatformMellanox(OnlPlatformBase):
         print "Caching ONIE System EEPROM..."
         onie = self.onie_syseeprom_get()
         mc = self.onie_machine_get()
+        # XXX roth -- deprecated
         if 'onie_version' in mc:
             onie['0x29'] = mc['onie_version']
             self.onie_syseeprom_set(onie)


### PR DESCRIPTION
Reviewer: @jnealtowns 

- use onie-shell (chroot into ONIE initrd) to access onie-sysinfo bits
- machine.conf support lingers a bit for older images

Tested on x86 (GRUB) and PPC