### PR TITLE
Revert "[as6812-32x] Add support for OOM"

### DIFF
--- a/packages/platforms/accton/x86-64/x86-64-accton-as6812-32x/modules/builds/x86-64-accton-as6812-32x-cpld.c
+++ b/packages/platforms/accton/x86-64/x86-64-accton-as6812-32x/modules/builds/x86-64-accton-as6812-32x-cpld.c
@@ -33,28 +33,44 @@
 #include <linux/device.h>
 #include <linux/i2c.h>
 #include <linux/i2c-mux.h>
+#include <linux/dmi.h>
 #include <linux/version.h>
-#include <linux/stat.h>
-#include <linux/hwmon-sysfs.h>
-#include <linux/delay.h>
 
-#define I2C_RW_RETRY_COUNT				10
-#define I2C_RW_RETRY_INTERVAL			60 /* ms */
+static struct dmi_system_id as6812_dmi_table[] = {
+	{
+		.ident = "Accton AS6812",
+		.matches = {
+			DMI_MATCH(DMI_BOARD_VENDOR, "Accton"),
+			DMI_MATCH(DMI_PRODUCT_NAME, "AS6812"),
+		},
+	},
+	{
+		.ident = "Accton AS6812",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "Accton"),
+			DMI_MATCH(DMI_PRODUCT_NAME, "AS6812"),
+		},
+	},
+};
+
+int platform_accton_as6812_32x(void)
+{
+	return dmi_check_system(as6812_dmi_table);
+}
+EXPORT_SYMBOL(platform_accton_as6812_32x);
 
 #define NUM_OF_CPLD1_CHANS 0x0
 #define NUM_OF_CPLD2_CHANS 0x10
 #define NUM_OF_CPLD3_CHANS 0x10
-#define CPLD_CHANNEL_SELECT_REG 0x2
-#define CPLD_DESELECT_CHANNEL   0xFF
-
-#define ACCTON_I2C_CPLD_MUX_MAX_NCHANS  NUM_OF_CPLD3_CHANS
+#define NUM_OF_ALL_CPLD_CHANS (NUM_OF_CPLD2_CHANS + NUM_OF_CPLD3_CHANS)
+#define ACCTON_I2C_CPLD_MUX_MAX_NCHANS	NUM_OF_CPLD3_CHANS
 
 static LIST_HEAD(cpld_client_list);
-static struct mutex     list_lock;
+static struct mutex		list_lock;
 
 struct cpld_client_node {
-    struct i2c_client *client;
-    struct list_head   list;
+	struct i2c_client *client;
+	struct list_head   list;
 };
 
 enum cpld_mux_type {
@@ -63,13 +79,10 @@ enum cpld_mux_type {
 	as6812_32x_cpld1
 };
 
-struct as6812_32x_cpld_data {
-    enum cpld_mux_type type;
-    struct i2c_adapter *virt_adaps[ACCTON_I2C_CPLD_MUX_MAX_NCHANS];
-    u8 last_chan;  /* last register value */
-
-    struct device      *hwmon_dev;
-    struct mutex        update_lock;
+struct accton_i2c_cpld_mux {
+	enum cpld_mux_type type;
+	struct i2c_adapter *virt_adaps[ACCTON_I2C_CPLD_MUX_MAX_NCHANS];
+	u8 last_chan;  /* last register value */
 };
 
 struct chip_desc {
@@ -93,289 +106,18 @@ static const struct chip_desc chips[] = {
 	}
 };
 
-static const struct i2c_device_id as6812_32x_cpld_mux_id[] = {
+static const struct i2c_device_id accton_i2c_cpld_mux_id[] = {
 	{ "as6812_32x_cpld1", as6812_32x_cpld1 },
 	{ "as6812_32x_cpld2", as6812_32x_cpld2 },
 	{ "as6812_32x_cpld3", as6812_32x_cpld3 },
 	{ }
 };
-MODULE_DEVICE_TABLE(i2c, as6812_32x_cpld_mux_id);
-
-#define TRANSCEIVER_PRESENT_ATTR_ID(index)   	MODULE_PRESENT_##index
-#define TRANSCEIVER_TXDISABLE_ATTR_ID(index)   	MODULE_TXDISABLE_##index
-#define TRANSCEIVER_RXLOS_ATTR_ID(index)   		MODULE_RXLOS_##index
-#define TRANSCEIVER_TXFAULT_ATTR_ID(index)   	MODULE_TXFAULT_##index
-
-enum as6812_32x_cpld_sysfs_attributes {
-	CPLD_VERSION,
-	ACCESS,
-	MODULE_PRESENT_ALL,
-	MODULE_RXLOS_ALL,
-	/* transceiver attributes */
-	TRANSCEIVER_PRESENT_ATTR_ID(1),
-	TRANSCEIVER_PRESENT_ATTR_ID(2),
-	TRANSCEIVER_PRESENT_ATTR_ID(3),
-	TRANSCEIVER_PRESENT_ATTR_ID(4),
-	TRANSCEIVER_PRESENT_ATTR_ID(5),
-	TRANSCEIVER_PRESENT_ATTR_ID(6),
-	TRANSCEIVER_PRESENT_ATTR_ID(7),
-	TRANSCEIVER_PRESENT_ATTR_ID(8),
-	TRANSCEIVER_PRESENT_ATTR_ID(9),
-	TRANSCEIVER_PRESENT_ATTR_ID(10),
-	TRANSCEIVER_PRESENT_ATTR_ID(11),
-	TRANSCEIVER_PRESENT_ATTR_ID(12),
-	TRANSCEIVER_PRESENT_ATTR_ID(13),
-	TRANSCEIVER_PRESENT_ATTR_ID(14),
-	TRANSCEIVER_PRESENT_ATTR_ID(15),
-	TRANSCEIVER_PRESENT_ATTR_ID(16),
-	TRANSCEIVER_PRESENT_ATTR_ID(17),
-	TRANSCEIVER_PRESENT_ATTR_ID(18),
-	TRANSCEIVER_PRESENT_ATTR_ID(19),
-	TRANSCEIVER_PRESENT_ATTR_ID(20),
-	TRANSCEIVER_PRESENT_ATTR_ID(21),
-	TRANSCEIVER_PRESENT_ATTR_ID(22),
-	TRANSCEIVER_PRESENT_ATTR_ID(23),
-	TRANSCEIVER_PRESENT_ATTR_ID(24),
-	TRANSCEIVER_PRESENT_ATTR_ID(25),
-	TRANSCEIVER_PRESENT_ATTR_ID(26),
-	TRANSCEIVER_PRESENT_ATTR_ID(27),
-	TRANSCEIVER_PRESENT_ATTR_ID(28),
-	TRANSCEIVER_PRESENT_ATTR_ID(29),
-	TRANSCEIVER_PRESENT_ATTR_ID(30),
-	TRANSCEIVER_PRESENT_ATTR_ID(31),
-	TRANSCEIVER_PRESENT_ATTR_ID(32),
-};
-
-/* sysfs attributes for hwmon 
- */
-static ssize_t show_status(struct device *dev, struct device_attribute *da,
-             char *buf);
-static ssize_t show_present_all(struct device *dev, struct device_attribute *da,
-             char *buf);
-static ssize_t access(struct device *dev, struct device_attribute *da,
-			const char *buf, size_t count);
-static ssize_t show_version(struct device *dev, struct device_attribute *da,
-             char *buf);
-static int as6812_32x_cpld_read_internal(struct i2c_client *client, u8 reg);
-static int as6812_32x_cpld_write_internal(struct i2c_client *client, u8 reg, u8 value);
-
-/* transceiver attributes */
-#define DECLARE_TRANSCEIVER_PRESENT_SENSOR_DEVICE_ATTR(index) \
-	static SENSOR_DEVICE_ATTR(module_present_##index, S_IRUGO, show_status, NULL, MODULE_PRESENT_##index)
-#define DECLARE_TRANSCEIVER_PRESENT_ATTR(index)  &sensor_dev_attr_module_present_##index.dev_attr.attr
-
-
-static SENSOR_DEVICE_ATTR(version, S_IRUGO, show_version, NULL, CPLD_VERSION);
-static SENSOR_DEVICE_ATTR(access, S_IWUSR, NULL, access, ACCESS);
-/* transceiver attributes */
-static SENSOR_DEVICE_ATTR(module_present_all, S_IRUGO, show_present_all, NULL, MODULE_PRESENT_ALL);
-DECLARE_TRANSCEIVER_PRESENT_SENSOR_DEVICE_ATTR(1);
-DECLARE_TRANSCEIVER_PRESENT_SENSOR_DEVICE_ATTR(2);
-DECLARE_TRANSCEIVER_PRESENT_SENSOR_DEVICE_ATTR(3);
-DECLARE_TRANSCEIVER_PRESENT_SENSOR_DEVICE_ATTR(4);
-DECLARE_TRANSCEIVER_PRESENT_SENSOR_DEVICE_ATTR(5);
-DECLARE_TRANSCEIVER_PRESENT_SENSOR_DEVICE_ATTR(6);
-DECLARE_TRANSCEIVER_PRESENT_SENSOR_DEVICE_ATTR(7);
-DECLARE_TRANSCEIVER_PRESENT_SENSOR_DEVICE_ATTR(8);
-DECLARE_TRANSCEIVER_PRESENT_SENSOR_DEVICE_ATTR(9);
-DECLARE_TRANSCEIVER_PRESENT_SENSOR_DEVICE_ATTR(10);
-DECLARE_TRANSCEIVER_PRESENT_SENSOR_DEVICE_ATTR(11);
-DECLARE_TRANSCEIVER_PRESENT_SENSOR_DEVICE_ATTR(12);
-DECLARE_TRANSCEIVER_PRESENT_SENSOR_DEVICE_ATTR(13);
-DECLARE_TRANSCEIVER_PRESENT_SENSOR_DEVICE_ATTR(14);
-DECLARE_TRANSCEIVER_PRESENT_SENSOR_DEVICE_ATTR(15);
-DECLARE_TRANSCEIVER_PRESENT_SENSOR_DEVICE_ATTR(16);
-DECLARE_TRANSCEIVER_PRESENT_SENSOR_DEVICE_ATTR(17);
-DECLARE_TRANSCEIVER_PRESENT_SENSOR_DEVICE_ATTR(18);
-DECLARE_TRANSCEIVER_PRESENT_SENSOR_DEVICE_ATTR(19);
-DECLARE_TRANSCEIVER_PRESENT_SENSOR_DEVICE_ATTR(20);
-DECLARE_TRANSCEIVER_PRESENT_SENSOR_DEVICE_ATTR(21);
-DECLARE_TRANSCEIVER_PRESENT_SENSOR_DEVICE_ATTR(22);
-DECLARE_TRANSCEIVER_PRESENT_SENSOR_DEVICE_ATTR(23);
-DECLARE_TRANSCEIVER_PRESENT_SENSOR_DEVICE_ATTR(24);
-DECLARE_TRANSCEIVER_PRESENT_SENSOR_DEVICE_ATTR(25);
-DECLARE_TRANSCEIVER_PRESENT_SENSOR_DEVICE_ATTR(26);
-DECLARE_TRANSCEIVER_PRESENT_SENSOR_DEVICE_ATTR(27);
-DECLARE_TRANSCEIVER_PRESENT_SENSOR_DEVICE_ATTR(28);
-DECLARE_TRANSCEIVER_PRESENT_SENSOR_DEVICE_ATTR(29);
-DECLARE_TRANSCEIVER_PRESENT_SENSOR_DEVICE_ATTR(30);
-DECLARE_TRANSCEIVER_PRESENT_SENSOR_DEVICE_ATTR(31);
-DECLARE_TRANSCEIVER_PRESENT_SENSOR_DEVICE_ATTR(32);
-
-static struct attribute *as6812_32x_cpld1_attributes[] = {
-    &sensor_dev_attr_version.dev_attr.attr,
-    &sensor_dev_attr_access.dev_attr.attr,
-	NULL
-};
-
-static const struct attribute_group as6812_32x_cpld1_group = {
-	.attrs = as6812_32x_cpld1_attributes,
-};
-
-static struct attribute *as6812_32x_cpld2_attributes[] = {
-    &sensor_dev_attr_version.dev_attr.attr,
-    &sensor_dev_attr_access.dev_attr.attr,
-	/* transceiver attributes */
-	&sensor_dev_attr_module_present_all.dev_attr.attr,
-	DECLARE_TRANSCEIVER_PRESENT_ATTR(1),
-	DECLARE_TRANSCEIVER_PRESENT_ATTR(2),
-	DECLARE_TRANSCEIVER_PRESENT_ATTR(3),
-	DECLARE_TRANSCEIVER_PRESENT_ATTR(4),
-	DECLARE_TRANSCEIVER_PRESENT_ATTR(5),
-	DECLARE_TRANSCEIVER_PRESENT_ATTR(6),
-	DECLARE_TRANSCEIVER_PRESENT_ATTR(7),
-	DECLARE_TRANSCEIVER_PRESENT_ATTR(8),
-	DECLARE_TRANSCEIVER_PRESENT_ATTR(9),
-	DECLARE_TRANSCEIVER_PRESENT_ATTR(10),
-	DECLARE_TRANSCEIVER_PRESENT_ATTR(11),
-	DECLARE_TRANSCEIVER_PRESENT_ATTR(12),
-	DECLARE_TRANSCEIVER_PRESENT_ATTR(13),
-	DECLARE_TRANSCEIVER_PRESENT_ATTR(14),
-	DECLARE_TRANSCEIVER_PRESENT_ATTR(15),
-	DECLARE_TRANSCEIVER_PRESENT_ATTR(16),
-	NULL
-};
-
-static const struct attribute_group as6812_32x_cpld2_group = {
-	.attrs = as6812_32x_cpld2_attributes,
-};
-
-static struct attribute *as6812_32x_cpld3_attributes[] = {
-    &sensor_dev_attr_version.dev_attr.attr,
-    &sensor_dev_attr_access.dev_attr.attr,
-	/* transceiver attributes */
-	&sensor_dev_attr_module_present_all.dev_attr.attr,
-	DECLARE_TRANSCEIVER_PRESENT_ATTR(17),
-	DECLARE_TRANSCEIVER_PRESENT_ATTR(18),
-	DECLARE_TRANSCEIVER_PRESENT_ATTR(19),
-	DECLARE_TRANSCEIVER_PRESENT_ATTR(20),
-	DECLARE_TRANSCEIVER_PRESENT_ATTR(21),
-	DECLARE_TRANSCEIVER_PRESENT_ATTR(22),
-	DECLARE_TRANSCEIVER_PRESENT_ATTR(23),
-	DECLARE_TRANSCEIVER_PRESENT_ATTR(24),
-	DECLARE_TRANSCEIVER_PRESENT_ATTR(25),
-	DECLARE_TRANSCEIVER_PRESENT_ATTR(26),
-	DECLARE_TRANSCEIVER_PRESENT_ATTR(27),
-	DECLARE_TRANSCEIVER_PRESENT_ATTR(28),
-	DECLARE_TRANSCEIVER_PRESENT_ATTR(29),
-	DECLARE_TRANSCEIVER_PRESENT_ATTR(30),
-	DECLARE_TRANSCEIVER_PRESENT_ATTR(31),
-	DECLARE_TRANSCEIVER_PRESENT_ATTR(32),
-	NULL
-};
-
-static const struct attribute_group as6812_32x_cpld3_group = {
-	.attrs = as6812_32x_cpld3_attributes,
-};
-
-static ssize_t show_present_all(struct device *dev, struct device_attribute *da,
-             char *buf)
-{
-	int i, status;
-	u8 values[2] = {0};
-	u8 regs[] = {0xA, 0xB};
-	struct i2c_client *client = to_i2c_client(dev);
-	struct as6812_32x_cpld_data *data = i2c_get_clientdata(client);
-
-	mutex_lock(&data->update_lock);
-
-    for (i = 0; i < ARRAY_SIZE(regs); i++) {
-        status = as6812_32x_cpld_read_internal(client, regs[i]);
-        
-        if (status < 0) {
-            goto exit;
-        }
-
-        values[i] = ~(u8)status;
-    }
-
-	mutex_unlock(&data->update_lock);
-
-    /* Return values 1 -> 32 in order */
-    return sprintf(buf, "%.2x %.2x\n", values[0], values[1]);
-
-exit:
-	mutex_unlock(&data->update_lock);
-	return status;
-}
-
-static ssize_t show_status(struct device *dev, struct device_attribute *da,
-             char *buf)
-{
-    struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
-    struct i2c_client *client = to_i2c_client(dev);
-    struct as6812_32x_cpld_data *data = i2c_get_clientdata(client);
-	int status = 0;
-	u8 reg = 0, mask = 0;
-
-	switch (attr->index) {
-	case MODULE_PRESENT_1 ... MODULE_PRESENT_8:
-		reg  = 0xA;
-		mask = 0x1 << (attr->index - MODULE_PRESENT_1);
-		break;
-	case MODULE_PRESENT_9 ... MODULE_PRESENT_16:
-		reg  = 0xB;
-		mask = 0x1 << (attr->index - MODULE_PRESENT_9);
-		break;
-	case MODULE_PRESENT_17 ... MODULE_PRESENT_24:
-		reg  = 0xA;
-		mask = 0x1 << (attr->index - MODULE_PRESENT_17);
-		break;
-	case MODULE_PRESENT_25 ... MODULE_PRESENT_32:
-		reg  = 0xB;
-		mask = 0x1 << (attr->index - MODULE_PRESENT_25);
-		break;
-	default:
-		return 0;
-	}
-
-    mutex_lock(&data->update_lock);
-	status = as6812_32x_cpld_read_internal(client, reg);
-	if (unlikely(status < 0)) {
-		goto exit;
-	}
-	mutex_unlock(&data->update_lock);
-
-	return sprintf(buf, "%d\n", !(status & mask));
-
-exit:
-	mutex_unlock(&data->update_lock);
-	return status;
-}
-
-static ssize_t access(struct device *dev, struct device_attribute *da,
-			const char *buf, size_t count)
-{
-	int status;
-	u32 addr, val;
-    struct i2c_client *client = to_i2c_client(dev);
-    struct as6812_32x_cpld_data *data = i2c_get_clientdata(client);
-
-	if (sscanf(buf, "0x%x 0x%x", &addr, &val) != 2) {
-		return -EINVAL;
-	}
-
-	if (addr > 0xFF || val > 0xFF) {
-		return -EINVAL;
-	}
-
-	mutex_lock(&data->update_lock);
-	status = as6812_32x_cpld_write_internal(client, addr, val);
-	if (unlikely(status < 0)) {
-		goto exit;
-	}
-	mutex_unlock(&data->update_lock);
-	return count;
-
-exit:
-	mutex_unlock(&data->update_lock);
-	return status;
-}
+MODULE_DEVICE_TABLE(i2c, accton_i2c_cpld_mux_id);
 
 /* Write to mux register. Don't use i2c_transfer()/i2c_smbus_xfer()
    for this as they will try to lock adapter a second time */
-static int as6812_32x_cpld_mux_reg_write(struct i2c_adapter *adap,
-			     struct i2c_client *client, u8 val)
+static int accton_i2c_cpld_mux_reg_write(struct i2c_adapter *adap,
+				 struct i2c_client *client, u8 val)
 {
 	unsigned long orig_jiffies;
 	unsigned short flags;
@@ -392,8 +134,8 @@ static int as6812_32x_cpld_mux_reg_write(struct i2c_adapter *adap,
 		orig_jiffies = jiffies;
 		for (res = 0, try = 0; try <= adap->retries; try++) {
 			res = adap->algo->smbus_xfer(adap, client->addr, flags,
-                             I2C_SMBUS_WRITE, CPLD_CHANNEL_SELECT_REG,
-                             I2C_SMBUS_BYTE_DATA, &data);
+													 I2C_SMBUS_WRITE, 0x2,
+													 I2C_SMBUS_BYTE_DATA, &data);
 			if (res != -EAGAIN)
 				break;
 			if (time_after(jiffies,
@@ -405,35 +147,35 @@ static int as6812_32x_cpld_mux_reg_write(struct i2c_adapter *adap,
 	return res;
 }
 
-static int as6812_32x_cpld_mux_select_chan(struct i2c_adapter *adap,
-			       void *client, u32 chan)
+static int accton_i2c_cpld_mux_select_chan(struct i2c_adapter *adap,
+				   void *client, u32 chan)
 {
-	struct as6812_32x_cpld_data *data = i2c_get_clientdata(client);
+	struct accton_i2c_cpld_mux *data = i2c_get_clientdata(client);
 	u8 regval;
 	int ret = 0;
 	regval = chan;
 
 	/* Only select the channel if its different from the last channel */
 	if (data->last_chan != regval) {
-		ret = as6812_32x_cpld_mux_reg_write(adap, client, regval);
+		ret = accton_i2c_cpld_mux_reg_write(adap, client, regval);
 		data->last_chan = regval;
 	}
 
 	return ret;
 }
 
-static int as6812_32x_cpld_mux_deselect_mux(struct i2c_adapter *adap,
+static int accton_i2c_cpld_mux_deselect_mux(struct i2c_adapter *adap,
 				void *client, u32 chan)
 {
-	struct as6812_32x_cpld_data *data = i2c_get_clientdata(client);
+	struct accton_i2c_cpld_mux *data = i2c_get_clientdata(client);
 
 	/* Deselect active channel */
 	data->last_chan = chips[data->type].deselectChan;
 
-	return as6812_32x_cpld_mux_reg_write(adap, client, data->last_chan);
+	return accton_i2c_cpld_mux_reg_write(adap, client, data->last_chan);
 }
 
-static void as6812_32x_cpld_add_client(struct i2c_client *client)
+static void accton_i2c_cpld_add_client(struct i2c_client *client)
 {
 	struct cpld_client_node *node = kzalloc(sizeof(struct cpld_client_node), GFP_KERNEL);
 
@@ -449,7 +191,7 @@ static void as6812_32x_cpld_add_client(struct i2c_client *client)
 	mutex_unlock(&list_lock);
 }
 
-static void as6812_32x_cpld_remove_client(struct i2c_client *client)
+static void accton_i2c_cpld_remove_client(struct i2c_client *client)
 {
 	struct list_head		*list_node = NULL;
 	struct cpld_client_node *cpld_node = NULL;
@@ -475,250 +217,177 @@ static void as6812_32x_cpld_remove_client(struct i2c_client *client)
 	mutex_unlock(&list_lock);
 }
 
-static ssize_t show_version(struct device *dev, struct device_attribute *attr, char *buf)
+static ssize_t show_cpld_version(struct device *dev, struct device_attribute *attr, char *buf)
 {
-    int val = 0;
-    struct i2c_client *client = to_i2c_client(dev);
-	
-	val = i2c_smbus_read_byte_data(client, 0x1);
+	u8 reg = 0x1;
+	struct i2c_client *client;
+	int len;
 
-    if (val < 0) {
-        dev_dbg(&client->dev, "cpld(0x%x) reg(0x1) err %d\n", client->addr, val);
-    }
-	
-    return sprintf(buf, "%d", val);
+	client = to_i2c_client(dev);
+	len = sprintf(buf, "%d", i2c_smbus_read_byte_data(client, reg));
+
+	return len;
 }
+
+static struct device_attribute ver = __ATTR(version, 0600, show_cpld_version, NULL);
 
 /*
  * I2C init/probing/exit functions
  */
-static int as6812_32x_cpld_mux_probe(struct i2c_client *client,
+static int accton_i2c_cpld_mux_probe(struct i2c_client *client,
 			 const struct i2c_device_id *id)
 {
 	struct i2c_adapter *adap = to_i2c_adapter(client->dev.parent);
 	int chan=0;
-	struct as6812_32x_cpld_data *data;
+	struct accton_i2c_cpld_mux *data;
 	int ret = -ENODEV;
-	const struct attribute_group *group = NULL;
 
 	if (!i2c_check_functionality(adap, I2C_FUNC_SMBUS_BYTE))
-		goto exit;
+		goto err;
 
-	data = kzalloc(sizeof(struct as6812_32x_cpld_data), GFP_KERNEL);
+	data = kzalloc(sizeof(struct accton_i2c_cpld_mux), GFP_KERNEL);
 	if (!data) {
 		ret = -ENOMEM;
-		goto exit;
+		goto err;
 	}
 
 	i2c_set_clientdata(client, data);
-    mutex_init(&data->update_lock);
+
 	data->type = id->driver_data;
 
-    if (data->type == as6812_32x_cpld2 || data->type == as6812_32x_cpld3) {
-    	data->last_chan = chips[data->type].deselectChan; /* force the first selection */
+	if (data->type == as6812_32x_cpld2 || data->type == as6812_32x_cpld3) {
+		data->last_chan = chips[data->type].deselectChan; /* force the first selection */
 
-	    /* Now create an adapter for each channel */
-        for (chan = 0; chan < chips[data->type].nchans; chan++) {
-            data->virt_adaps[chan] = i2c_add_mux_adapter(adap, &client->dev, client, 0, chan, 0,
-                                                         as6812_32x_cpld_mux_select_chan,
-                                                         as6812_32x_cpld_mux_deselect_mux);
+		/* Now create an adapter for each channel */
+		for (chan = 0; chan < chips[data->type].nchans; chan++) {
+			data->virt_adaps[chan] = i2c_add_mux_adapter(adap, &client->dev, client, 0, chan,
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,7,0)
+                                                                     I2C_CLASS_HWMON | I2C_CLASS_SPD,
+#endif
+                                                                     accton_i2c_cpld_mux_select_chan,
+                                                                     accton_i2c_cpld_mux_deselect_mux);
 
-            if (data->virt_adaps[chan] == NULL) {
-                ret = -ENODEV;
-                dev_err(&client->dev, "failed to register multiplexed adapter %d\n", chan);
-                goto exit_mux_register;
-            }
-        }
+			if (data->virt_adaps[chan] == NULL) {
+				ret = -ENODEV;
+				dev_err(&client->dev, "failed to register multiplexed adapter %d\n", chan);
+				goto virt_reg_failed;
+			}
+		}
 
-        dev_info(&client->dev, "registered %d multiplexed busses for I2C mux %s\n", 
-                                chan, client->name);
-    }
+		dev_info(&client->dev, "registered %d multiplexed busses for I2C mux %s\n",
+					chan, client->name);
+	}
 
-    /* Register sysfs hooks */
-    switch (data->type) {
-    case as6812_32x_cpld1:
-        group = &as6812_32x_cpld1_group;
-        break;
-    case as6812_32x_cpld2:
-        group = &as6812_32x_cpld2_group;
-        break;
-	case as6812_32x_cpld3:
-        group = &as6812_32x_cpld3_group;
-        break;
-    default:
-        break;
-    }
+	accton_i2c_cpld_add_client(client);
 
-	
-    if (group) {
-        ret = sysfs_create_group(&client->dev.kobj, group);
-        if (ret) {
-            goto exit_mux_register;
-        }
-    }
+	ret = sysfs_create_file(&client->dev.kobj, &ver.attr);
+	if (ret)
+		 goto virt_reg_failed;
 
-    as6812_32x_cpld_add_client(client);
+	return 0;
 
-    return 0;
-
-exit_mux_register:
+virt_reg_failed:
 	for (chan--; chan >= 0; chan--) {
 		i2c_del_mux_adapter(data->virt_adaps[chan]);
-    }
-    kfree(data);
-exit:
+	}
+	kfree(data);
+err:
 	return ret;
-} 
-
-static int as6812_32x_cpld_mux_remove(struct i2c_client *client)
-{
-    struct as6812_32x_cpld_data *data = i2c_get_clientdata(client);
-    const struct chip_desc *chip = &chips[data->type];
-    int chan;
-    const struct attribute_group *group = NULL;
-
-    as6812_32x_cpld_remove_client(client);
-
-    /* Remove sysfs hooks */
-    switch (data->type) {
-    case as6812_32x_cpld1:
-        group = &as6812_32x_cpld1_group;
-        break;
-    case as6812_32x_cpld2:
-        group = &as6812_32x_cpld2_group;
-        break;
-	case as6812_32x_cpld3:
-        group = &as6812_32x_cpld3_group;
-        break;
-    default:
-        break;
-    }
-
-    if (group) {
-        sysfs_remove_group(&client->dev.kobj, group);
-    }
-
-    for (chan = 0; chan < chip->nchans; ++chan) {
-        if (data->virt_adaps[chan]) {
-            i2c_del_mux_adapter(data->virt_adaps[chan]);
-            data->virt_adaps[chan] = NULL;
-        }
-    }
-
-    kfree(data);
-
-    return 0;
 }
 
-static int as6812_32x_cpld_read_internal(struct i2c_client *client, u8 reg)
+static int accton_i2c_cpld_mux_remove(struct i2c_client *client)
 {
-	int status = 0, retry = I2C_RW_RETRY_COUNT;
+	struct accton_i2c_cpld_mux *data = i2c_get_clientdata(client);
+	const struct chip_desc *chip = &chips[data->type];
+	int chan;
 
-	while (retry) {
-		status = i2c_smbus_read_byte_data(client, reg);
-		if (unlikely(status < 0)) {
-			msleep(I2C_RW_RETRY_INTERVAL);
-			retry--;
-			continue;
+	sysfs_remove_file(&client->dev.kobj, &ver.attr);
+
+	for (chan = 0; chan < chip->nchans; ++chan) {
+		if (data->virt_adaps[chan]) {
+			i2c_del_mux_adapter(data->virt_adaps[chan]);
+			data->virt_adaps[chan] = NULL;
 		}
-
-		break;
 	}
 
-    return status;
+	kfree(data);
+	accton_i2c_cpld_remove_client(client);
+
+	return 0;
 }
 
-static int as6812_32x_cpld_write_internal(struct i2c_client *client, u8 reg, u8 value)
+int as6812_32x_i2c_cpld_read(unsigned short cpld_addr, u8 reg)
 {
-	int status = 0, retry = I2C_RW_RETRY_COUNT;
-
-	while (retry) {
-		status = i2c_smbus_write_byte_data(client, reg, value);
-		if (unlikely(status < 0)) {
-			msleep(I2C_RW_RETRY_INTERVAL);
-			retry--;
-			continue;
-		}
-
-		break;
-	}
-
-    return status;
-}
-
-int as6812_32x_cpld_read(unsigned short cpld_addr, u8 reg)
-{
-    struct list_head   *list_node = NULL;
-    struct cpld_client_node *cpld_node = NULL;
-    int ret = -EPERM;
-
-    mutex_lock(&list_lock);
-
-    list_for_each(list_node, &cpld_client_list)
-    {
-        cpld_node = list_entry(list_node, struct cpld_client_node, list);
-
-        if (cpld_node->client->addr == cpld_addr) {
-            ret = as6812_32x_cpld_read_internal(cpld_node->client, reg);
-    		break;
-        }
-    }
-
-	mutex_unlock(&list_lock);
-
-    return ret;
-}
-EXPORT_SYMBOL(as6812_32x_cpld_read);
-
-int as6812_32x_cpld_write(unsigned short cpld_addr, u8 reg, u8 value)
-{
-    struct list_head   *list_node = NULL;
-    struct cpld_client_node *cpld_node = NULL;
-    int ret = -EIO;
+	struct list_head   *list_node = NULL;
+	struct cpld_client_node *cpld_node = NULL;
+	int ret = -EPERM;
 
 	mutex_lock(&list_lock);
 
-    list_for_each(list_node, &cpld_client_list)
-    {
-        cpld_node = list_entry(list_node, struct cpld_client_node, list);
+	list_for_each(list_node, &cpld_client_list)
+	{
+		cpld_node = list_entry(list_node, struct cpld_client_node, list);
 
-        if (cpld_node->client->addr == cpld_addr) {
-            ret = as6812_32x_cpld_write_internal(cpld_node->client, reg, value);
-            break;
-        }
-    }
+		if (cpld_node->client->addr == cpld_addr) {
+			ret = i2c_smbus_read_byte_data(cpld_node->client, reg);
+			break;
+		}
+	}
 
 	mutex_unlock(&list_lock);
 
-    return ret;
+	return ret;
 }
-EXPORT_SYMBOL(as6812_32x_cpld_write);
+EXPORT_SYMBOL(as6812_32x_i2c_cpld_read);
 
-static struct i2c_driver as6812_32x_cpld_mux_driver = {
+int as6812_32x_i2c_cpld_write(unsigned short cpld_addr, u8 reg, u8 value)
+{
+	struct list_head   *list_node = NULL;
+	struct cpld_client_node *cpld_node = NULL;
+	int ret = -EIO;
+
+	mutex_lock(&list_lock);
+
+	list_for_each(list_node, &cpld_client_list)
+	{
+		cpld_node = list_entry(list_node, struct cpld_client_node, list);
+
+		if (cpld_node->client->addr == cpld_addr) {
+			ret = i2c_smbus_write_byte_data(cpld_node->client, reg, value);
+			break;
+		}
+	}
+
+	mutex_unlock(&list_lock);
+
+	return ret;
+}
+EXPORT_SYMBOL(as6812_32x_i2c_cpld_write);
+
+static struct i2c_driver accton_i2c_cpld_mux_driver = {
 	.driver		= {
 		.name	= "as6812_32x_cpld",
 		.owner	= THIS_MODULE,
 	},
-	.probe		= as6812_32x_cpld_mux_probe,
-	.remove		= as6812_32x_cpld_mux_remove,
-	.id_table	= as6812_32x_cpld_mux_id,
+	.probe		= accton_i2c_cpld_mux_probe,
+	.remove		= accton_i2c_cpld_mux_remove,
+	.id_table	= accton_i2c_cpld_mux_id,
 };
 
-static int __init as6812_32x_cpld_mux_init(void)
+static int __init accton_i2c_cpld_mux_init(void)
 {
-    mutex_init(&list_lock);
-    return i2c_add_driver(&as6812_32x_cpld_mux_driver);
+	mutex_init(&list_lock);
+	return i2c_add_driver(&accton_i2c_cpld_mux_driver);
 }
 
-static void __exit as6812_32x_cpld_mux_exit(void)
+static void __exit accton_i2c_cpld_mux_exit(void)
 {
-    i2c_del_driver(&as6812_32x_cpld_mux_driver);
+	i2c_del_driver(&accton_i2c_cpld_mux_driver);
 }
 
 MODULE_AUTHOR("Brandon Chuang <brandon_chuang@accton.com.tw>");
 MODULE_DESCRIPTION("Accton I2C CPLD mux driver");
 MODULE_LICENSE("GPL");
 
-module_init(as6812_32x_cpld_mux_init);
-module_exit(as6812_32x_cpld_mux_exit);
-
+module_init(accton_i2c_cpld_mux_init);
+module_exit(accton_i2c_cpld_mux_exit);

--- a/packages/platforms/accton/x86-64/x86-64-accton-as6812-32x/modules/builds/x86-64-accton-as6812-32x-fan.c
+++ b/packages/platforms/accton/x86-64/x86-64-accton-as6812-32x/modules/builds/x86-64-accton-as6812-32x-fan.c
@@ -137,8 +137,8 @@ static ssize_t fan_set_duty_cycle(struct device *dev,
 static ssize_t fan_show_value(struct device *dev, 
                     struct device_attribute *da, char *buf);
 
-extern int as6812_32x_cpld_read(unsigned short cpld_addr, u8 reg);
-extern int as6812_32x_cpld_write(unsigned short cpld_addr, u8 reg, u8 value);
+extern int as6812_32x_i2c_cpld_read(unsigned short cpld_addr, u8 reg);
+extern int as6812_32x_i2c_cpld_write(unsigned short cpld_addr, u8 reg, u8 value);
 
                     
 /*******************/
@@ -257,12 +257,12 @@ static const struct attribute_group accton_as6812_32x_fan_group = {
 
 static int accton_as6812_32x_fan_read_value(u8 reg)
 {
-    return as6812_32x_cpld_read(0x60, reg);
+    return as6812_32x_i2c_cpld_read(0x60, reg);
 }
 
 static int accton_as6812_32x_fan_write_value(u8 reg, u8 value)
 {
-    return as6812_32x_cpld_write(0x60, reg, value);
+    return as6812_32x_i2c_cpld_write(0x60, reg, value);
 }
 
 static void accton_as6812_32x_fan_update_device(struct device *dev)
@@ -385,6 +385,11 @@ static struct platform_driver accton_as6812_32x_fan_driver = {
 static int __init accton_as6812_32x_fan_init(void)
 {
     int ret;
+    
+    extern int platform_accton_as6812_32x(void);
+    if(!platform_accton_as6812_32x()) { 
+      return -ENODEV;
+    }
 
     ret = platform_driver_register(&accton_as6812_32x_fan_driver);
     if (ret < 0) {

--- a/packages/platforms/accton/x86-64/x86-64-accton-as6812-32x/modules/builds/x86-64-accton-as6812-32x-leds.c
+++ b/packages/platforms/accton/x86-64/x86-64-accton-as6812-32x/modules/builds/x86-64-accton-as6812-32x-leds.c
@@ -29,8 +29,8 @@
 #include <linux/leds.h>
 #include <linux/slab.h>
 
-extern int as6812_32x_cpld_read (unsigned short cpld_addr, u8 reg);
-extern int as6812_32x_cpld_write(unsigned short cpld_addr, u8 reg, u8 value);
+extern int as6812_32x_i2c_cpld_read (unsigned short cpld_addr, u8 reg);
+extern int as6812_32x_i2c_cpld_write(unsigned short cpld_addr, u8 reg, u8 value);
 
 extern void led_classdev_unregister(struct led_classdev *led_cdev);
 extern int led_classdev_register(struct device *parent, struct led_classdev *led_cdev);
@@ -239,12 +239,12 @@ static u8 led_light_mode_to_reg_val(enum led_type type,
 
 static int accton_as6812_32x_led_read_value(u8 reg)
 {
-    return as6812_32x_cpld_read(0x60, reg);
+    return as6812_32x_i2c_cpld_read(0x60, reg);
 }
 
 static int accton_as6812_32x_led_write_value(u8 reg, u8 value)
 {
-    return as6812_32x_cpld_write(0x60, reg, value);
+    return as6812_32x_i2c_cpld_write(0x60, reg, value);
 }
 
 static void accton_as6812_32x_led_update(void)
@@ -570,6 +570,11 @@ static struct platform_driver accton_as6812_32x_led_driver = {
 static int __init accton_as6812_32x_led_init(void)
 {
     int ret;
+
+    extern int platform_accton_as6812_32x(void);
+    if(!platform_accton_as6812_32x()) { 
+      return -ENODEV;
+    }
 
     ret = platform_driver_register(&accton_as6812_32x_led_driver);
     if (ret < 0) {

--- a/packages/platforms/accton/x86-64/x86-64-accton-as6812-32x/modules/builds/x86-64-accton-as6812-32x-psu.c
+++ b/packages/platforms/accton/x86-64/x86-64-accton-as6812-32x/modules/builds/x86-64-accton-as6812-32x-psu.c
@@ -44,7 +44,7 @@ static ssize_t show_status(struct device *dev, struct device_attribute *da, char
 static ssize_t show_model_name(struct device *dev, struct device_attribute *da, char *buf);
 static ssize_t show_serial_number(struct device *dev, struct device_attribute *da,char *buf);
 static int as6812_32x_psu_read_block(struct i2c_client *client, u8 command, u8 *data,int data_len);
-extern int as6812_32x_cpld_read(unsigned short cpld_addr, u8 reg);
+extern int as6812_32x_i2c_cpld_read(unsigned short cpld_addr, u8 reg);
 static int as6812_32x_psu_model_name_get(struct device *dev, int get_serial);
 
 /* Addresses scanned 
@@ -415,7 +415,7 @@ static struct as6812_32x_psu_data *as6812_32x_psu_update_device(struct device *d
         data->valid = 0;
 
         /* Read psu status */
-        status = as6812_32x_cpld_read(PSU_STATUS_I2C_ADDR, PSU_STATUS_I2C_REG_OFFSET);
+        status = as6812_32x_i2c_cpld_read(PSU_STATUS_I2C_ADDR, PSU_STATUS_I2C_REG_OFFSET);
         
         if (status < 0) {
             dev_dbg(&client->dev, "cpld reg (0x%x) err %d\n", PSU_STATUS_I2C_ADDR, status);
@@ -435,9 +435,19 @@ exit:
     return data;
 }
 
-module_i2c_driver(as6812_32x_psu_driver);
+static int __init as6812_32x_psu_init(void)
+{   
+    return i2c_add_driver(&as6812_32x_psu_driver);
+}
+
+static void __exit as6812_32x_psu_exit(void)
+{
+    i2c_del_driver(&as6812_32x_psu_driver);
+}
 
 MODULE_AUTHOR("Brandon Chuang <brandon_chuang@accton.com.tw>");
 MODULE_DESCRIPTION("as6812_32x_psu driver");
 MODULE_LICENSE("GPL");
 
+module_init(as6812_32x_psu_init);
+module_exit(as6812_32x_psu_exit);

--- a/packages/platforms/accton/x86-64/x86-64-accton-as6812-32x/modules/builds/x86-64-accton-as6812-32x-sfp.c
+++ b/packages/platforms/accton/x86-64/x86-64-accton-as6812-32x/modules/builds/x86-64-accton-as6812-32x-sfp.c
@@ -1,0 +1,1532 @@
+/*
+ * SFP driver for accton as6812_32x sfp
+ *
+ * Copyright (C)  Brandon Chuang <brandon_chuang@accton.com.tw>
+ *
+ * Based on ad7414.c
+ * Copyright 2006 Stefan Roese <sr at denx.de>, DENX Software Engineering
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+#include <linux/module.h>
+#include <linux/jiffies.h>
+#include <linux/i2c.h>
+#include <linux/hwmon.h>
+#include <linux/hwmon-sysfs.h>
+#include <linux/err.h>
+#include <linux/mutex.h>
+#include <linux/sysfs.h>
+#include <linux/slab.h>
+#include <linux/delay.h>
+
+#define DRIVER_NAME 	"as6812_32x_sfp"
+
+#define DEBUG_MODE 0
+
+#if (DEBUG_MODE == 1)
+	#define DEBUG_PRINT(fmt, args...)                                        \
+		printk (KERN_INFO "%s:%s[%d]: " fmt "\r\n", __FILE__, __FUNCTION__, __LINE__, ##args)
+#else
+	#define DEBUG_PRINT(fmt, args...)
+#endif
+
+#define NUM_OF_SFP_PORT			32
+#define EEPROM_NAME				"sfp_eeprom"
+#define EEPROM_SIZE				256	/*	256 byte eeprom */
+#define BIT_INDEX(i)			(1ULL << (i))
+#define USE_I2C_BLOCK_READ 		1 /* Platform dependent */
+#define I2C_RW_RETRY_COUNT		10
+#define I2C_RW_RETRY_INTERVAL	60 /* ms */
+
+#define SFP_EEPROM_A0_I2C_ADDR (0xA0 >> 1)
+
+#define SFF8024_PHYSICAL_DEVICE_ID_ADDR		0x0
+#define SFF8024_DEVICE_ID_SFP				0x3
+#define SFF8024_DEVICE_ID_QSFP				0xC
+#define SFF8024_DEVICE_ID_QSFP_PLUS			0xD
+#define SFF8024_DEVICE_ID_QSFP28			0x11
+
+#define SFF8436_RX_LOS_ADDR					3
+#define SFF8436_TX_FAULT_ADDR				4
+#define SFF8436_TX_DISABLE_ADDR				86
+
+#define MULTIPAGE_SUPPORT		1
+
+#if (MULTIPAGE_SUPPORT == 1)
+/* fundamental unit of addressing for SFF_8472/SFF_8436 */
+#define SFF_8436_PAGE_SIZE 128
+/* 
+ * The current 8436 (QSFP) spec provides for only 4 supported
+ * pages (pages 0-3).  
+ * This driver is prepared to support more, but needs a register in the 
+ * EEPROM to indicate how many pages are supported before it is safe
+ * to implement more pages in the driver.
+ */
+#define SFF_8436_SPECED_PAGES 4
+#define SFF_8436_EEPROM_SIZE ((1 + SFF_8436_SPECED_PAGES) * SFF_8436_PAGE_SIZE)
+#define SFF_8436_EEPROM_UNPAGED_SIZE (2 * SFF_8436_PAGE_SIZE)
+/* 
+ * The current 8472 (SFP) spec provides for only 3 supported 
+ * pages (pages 0-2).
+ * This driver is prepared to support more, but needs a register in the 
+ * EEPROM to indicate how many pages are supported before it is safe
+ * to implement more pages in the driver.
+ */
+#define SFF_8472_SPECED_PAGES 3
+#define SFF_8472_EEPROM_SIZE ((3 + SFF_8472_SPECED_PAGES) * SFF_8436_PAGE_SIZE)
+#define SFF_8472_EEPROM_UNPAGED_SIZE (4 * SFF_8436_PAGE_SIZE)
+
+/* a few constants to find our way around the EEPROM */
+#define SFF_8436_PAGE_SELECT_REG   0x7F
+#define SFF_8436_PAGEABLE_REG 0x02
+#define SFF_8436_NOT_PAGEABLE (1<<2)
+#define SFF_8472_PAGEABLE_REG 0x40
+#define SFF_8472_PAGEABLE (1<<4)
+
+/*
+ * This parameter is to help this driver avoid blocking other drivers out
+ * of I2C for potentially troublesome amounts of time. With a 100 kHz I2C
+ * clock, one 256 byte read takes about 1/43 second which is excessive;
+ * but the 1/170 second it takes at 400 kHz may be quite reasonable; and
+ * at 1 MHz (Fm+) a 1/430 second delay could easily be invisible.
+ *
+ * This value is forced to be a power of two so that writes align on pages.
+ */
+static unsigned io_limit = SFF_8436_PAGE_SIZE;
+
+/*
+ * specs often allow 5 msec for a page write, sometimes 20 msec;
+ * it's important to recover from write timeouts.
+ */
+static unsigned write_timeout = 25;
+
+typedef enum qsfp_opcode {
+	QSFP_READ_OP = 0,
+	QSFP_WRITE_OP = 1
+} qsfp_opcode_e;
+#endif
+
+static ssize_t show_port_number(struct device *dev, struct device_attribute *da, char *buf);
+static ssize_t show_present(struct device *dev, struct device_attribute *da, char *buf);
+static ssize_t qsfp_show_tx_rx_status(struct device *dev, struct device_attribute *da, char *buf);
+static ssize_t qsfp_set_tx_disable(struct device *dev, struct device_attribute *da, const char *buf, size_t count);;
+static ssize_t sfp_eeprom_read(struct i2c_client *, u8, u8 *,int);
+static ssize_t sfp_eeprom_write(struct i2c_client *, u8 , const char *,int);
+extern int as6812_32x_i2c_cpld_read (unsigned short cpld_addr, u8 reg);
+
+enum sfp_sysfs_attributes {
+	PRESENT,
+	PRESENT_ALL,
+	PORT_NUMBER,
+	PORT_TYPE,
+	DDM_IMPLEMENTED,
+	TX_FAULT,
+	TX_FAULT1,
+	TX_FAULT2,
+	TX_FAULT3,
+	TX_FAULT4,
+	TX_DISABLE,
+	TX_DISABLE1,
+	TX_DISABLE2,
+	TX_DISABLE3,
+	TX_DISABLE4,
+	RX_LOS,
+	RX_LOS1,
+	RX_LOS2,
+	RX_LOS3,
+	RX_LOS4,
+	RX_LOS_ALL
+};
+
+/* SFP/QSFP common attributes for sysfs */
+static SENSOR_DEVICE_ATTR(sfp_port_number, S_IRUGO, show_port_number, NULL, PORT_NUMBER);
+static SENSOR_DEVICE_ATTR(sfp_is_present,  S_IRUGO, show_present, NULL, PRESENT);
+static SENSOR_DEVICE_ATTR(sfp_is_present_all,  S_IRUGO, show_present, NULL, PRESENT_ALL);
+static SENSOR_DEVICE_ATTR(sfp_tx_disable,  S_IWUSR | S_IRUGO, qsfp_show_tx_rx_status, qsfp_set_tx_disable, TX_DISABLE);
+static SENSOR_DEVICE_ATTR(sfp_tx_fault,	 S_IRUGO, qsfp_show_tx_rx_status, NULL, TX_FAULT);
+
+/* QSFP attributes for sysfs */
+static SENSOR_DEVICE_ATTR(sfp_rx_los,  S_IRUGO, qsfp_show_tx_rx_status, NULL, RX_LOS);
+static SENSOR_DEVICE_ATTR(sfp_rx_los1, S_IRUGO, qsfp_show_tx_rx_status, NULL, RX_LOS1);
+static SENSOR_DEVICE_ATTR(sfp_rx_los2, S_IRUGO, qsfp_show_tx_rx_status, NULL, RX_LOS2);
+static SENSOR_DEVICE_ATTR(sfp_rx_los3, S_IRUGO, qsfp_show_tx_rx_status, NULL, RX_LOS3);
+static SENSOR_DEVICE_ATTR(sfp_rx_los4, S_IRUGO, qsfp_show_tx_rx_status, NULL, RX_LOS4);
+static SENSOR_DEVICE_ATTR(sfp_tx_disable1, S_IWUSR | S_IRUGO, qsfp_show_tx_rx_status, qsfp_set_tx_disable, TX_DISABLE1);
+static SENSOR_DEVICE_ATTR(sfp_tx_disable2, S_IWUSR | S_IRUGO, qsfp_show_tx_rx_status, qsfp_set_tx_disable, TX_DISABLE2);
+static SENSOR_DEVICE_ATTR(sfp_tx_disable3, S_IWUSR | S_IRUGO, qsfp_show_tx_rx_status, qsfp_set_tx_disable, TX_DISABLE3);
+static SENSOR_DEVICE_ATTR(sfp_tx_disable4, S_IWUSR | S_IRUGO, qsfp_show_tx_rx_status, qsfp_set_tx_disable, TX_DISABLE4);
+static SENSOR_DEVICE_ATTR(sfp_tx_fault1, S_IRUGO, qsfp_show_tx_rx_status, NULL, TX_FAULT1);
+static SENSOR_DEVICE_ATTR(sfp_tx_fault2, S_IRUGO, qsfp_show_tx_rx_status, NULL, TX_FAULT2);
+static SENSOR_DEVICE_ATTR(sfp_tx_fault3, S_IRUGO, qsfp_show_tx_rx_status, NULL, TX_FAULT3);
+static SENSOR_DEVICE_ATTR(sfp_tx_fault4, S_IRUGO, qsfp_show_tx_rx_status, NULL, TX_FAULT4);
+static struct attribute *qsfp_attributes[] = {
+	&sensor_dev_attr_sfp_port_number.dev_attr.attr,
+	&sensor_dev_attr_sfp_is_present.dev_attr.attr,
+	&sensor_dev_attr_sfp_is_present_all.dev_attr.attr,
+	&sensor_dev_attr_sfp_rx_los.dev_attr.attr,
+	&sensor_dev_attr_sfp_rx_los1.dev_attr.attr,
+	&sensor_dev_attr_sfp_rx_los2.dev_attr.attr,
+	&sensor_dev_attr_sfp_rx_los3.dev_attr.attr,
+	&sensor_dev_attr_sfp_rx_los4.dev_attr.attr,
+	&sensor_dev_attr_sfp_tx_disable.dev_attr.attr,
+	&sensor_dev_attr_sfp_tx_disable1.dev_attr.attr,
+	&sensor_dev_attr_sfp_tx_disable2.dev_attr.attr,
+	&sensor_dev_attr_sfp_tx_disable3.dev_attr.attr,
+	&sensor_dev_attr_sfp_tx_disable4.dev_attr.attr,
+	&sensor_dev_attr_sfp_tx_fault.dev_attr.attr,
+	&sensor_dev_attr_sfp_tx_fault1.dev_attr.attr,
+	&sensor_dev_attr_sfp_tx_fault2.dev_attr.attr,
+	&sensor_dev_attr_sfp_tx_fault3.dev_attr.attr,
+	&sensor_dev_attr_sfp_tx_fault4.dev_attr.attr,
+	NULL
+};
+
+/* Platform dependent +++ */
+#define CPLD_PORT_TO_FRONT_PORT(port)  (port+1)
+
+enum port_numbers {
+as6812_32x_port1,  as6812_32x_port2,  as6812_32x_port3,  as6812_32x_port4,  as6812_32x_port5,  as6812_32x_port6,  as6812_32x_port7,  as6812_32x_port8, 
+as6812_32x_port9,  as6812_32x_port10, as6812_32x_port11, as6812_32x_port12, as6812_32x_port13, as6812_32x_port14, as6812_32x_port15, as6812_32x_port16,
+as6812_32x_port17, as6812_32x_port18, as6812_32x_port19, as6812_32x_port20, as6812_32x_port21, as6812_32x_port22, as6812_32x_port23, as6812_32x_port24,
+as6812_32x_port25, as6812_32x_port26, as6812_32x_port27, as6812_32x_port28, as6812_32x_port29, as6812_32x_port30, as6812_32x_port31, as6812_32x_port32
+};
+
+#define I2C_DEV_ID(x) { #x, x}
+
+static const struct i2c_device_id sfp_device_id[] = {
+I2C_DEV_ID(as6812_32x_port1),
+I2C_DEV_ID(as6812_32x_port2),
+I2C_DEV_ID(as6812_32x_port3),
+I2C_DEV_ID(as6812_32x_port4),
+I2C_DEV_ID(as6812_32x_port5),
+I2C_DEV_ID(as6812_32x_port6),
+I2C_DEV_ID(as6812_32x_port7),
+I2C_DEV_ID(as6812_32x_port8),
+I2C_DEV_ID(as6812_32x_port9),
+I2C_DEV_ID(as6812_32x_port10),
+I2C_DEV_ID(as6812_32x_port11),
+I2C_DEV_ID(as6812_32x_port12),
+I2C_DEV_ID(as6812_32x_port13),
+I2C_DEV_ID(as6812_32x_port14),
+I2C_DEV_ID(as6812_32x_port15),
+I2C_DEV_ID(as6812_32x_port16),
+I2C_DEV_ID(as6812_32x_port17),
+I2C_DEV_ID(as6812_32x_port18),
+I2C_DEV_ID(as6812_32x_port19),
+I2C_DEV_ID(as6812_32x_port20),
+I2C_DEV_ID(as6812_32x_port21),
+I2C_DEV_ID(as6812_32x_port22),
+I2C_DEV_ID(as6812_32x_port23),
+I2C_DEV_ID(as6812_32x_port24),
+I2C_DEV_ID(as6812_32x_port25),
+I2C_DEV_ID(as6812_32x_port26),
+I2C_DEV_ID(as6812_32x_port27),
+I2C_DEV_ID(as6812_32x_port28),
+I2C_DEV_ID(as6812_32x_port29),
+I2C_DEV_ID(as6812_32x_port30),
+I2C_DEV_ID(as6812_32x_port31),
+I2C_DEV_ID(as6812_32x_port32),
+{ /* LIST END */ }
+};
+MODULE_DEVICE_TABLE(i2c, sfp_device_id);
+/* Platform dependent --- */
+
+enum driver_type_e {
+	DRIVER_TYPE_SFP_MSA,
+	DRIVER_TYPE_SFP_DDM,
+	DRIVER_TYPE_QSFP
+};
+
+/* Each client has this additional data
+ */
+struct eeprom_data {
+	char				 valid;			/* !=0 if registers are valid */
+	unsigned long		 last_updated;	/* In jiffies */
+	struct bin_attribute bin;			/* eeprom data */
+};
+
+struct qsfp_data {
+	char			valid;			/* !=0 if registers are valid */
+	unsigned long	last_updated;	/* In jiffies */
+	u8				status[3];		/* bit0:port0, bit1:port1 and so on */
+									/* index 0 => tx_fail
+											 1 => tx_disable
+											 2 => rx_loss */
+	u8					device_id;
+	struct eeprom_data	eeprom;
+};
+
+struct sfp_port_data {
+	struct mutex		   update_lock;
+	enum driver_type_e	   driver_type;
+	int					   port;		/* CPLD port index */
+	u64					   present;		/* present status, bit0:port0, bit1:port1 and so on */
+
+	struct qsfp_data	  *qsfp;
+
+	struct i2c_client	  *client;
+#if (MULTIPAGE_SUPPORT == 1)
+	int use_smbus;
+	u8 *writebuf;
+	unsigned write_max;
+#endif
+};
+
+#if (MULTIPAGE_SUPPORT == 1)
+static ssize_t sfp_port_read_write(struct sfp_port_data *port_data,
+		char *buf, loff_t off, size_t len, qsfp_opcode_e opcode);
+#endif
+static ssize_t show_port_number(struct device *dev, struct device_attribute *da,
+			 char *buf)
+{
+	struct i2c_client *client = to_i2c_client(dev);
+	struct sfp_port_data *data = i2c_get_clientdata(client);
+	return sprintf(buf, "%d\n", CPLD_PORT_TO_FRONT_PORT(data->port));
+}
+/* Platform dependent +++ */
+static struct sfp_port_data *sfp_update_present(struct i2c_client *client)
+{
+	struct sfp_port_data *data = i2c_get_clientdata(client);
+	int i = 0, j = 0;
+	int status = -1;
+
+	DEBUG_PRINT("Starting sfp present status update");
+	mutex_lock(&data->update_lock);
+
+	/* Read present status of port 1~32 */
+    data->present = 0;
+	
+    for (i = 0; i < 2; i++) {
+        for (j = 0; j < 2; j++) {
+            status = as6812_32x_i2c_cpld_read(0x62+i*2, 0xA+j);
+            
+            if (status < 0) {
+                DEBUG_PRINT("cpld(0x%x) reg(0x%x) err %d", 0x62+i*2, 0xA+j, status);
+                goto exit;
+            }
+            
+			DEBUG_PRINT("Present status = 0x%lx", data->present);		
+            data->present |= (u64)status << ((i*16) + (j*8));
+        }
+    }
+
+	DEBUG_PRINT("Present status = 0x%lx", data->present);
+exit:
+	mutex_unlock(&data->update_lock);
+	return (status < 0) ? ERR_PTR(status) : data;
+}
+
+/* Platform dependent --- */
+
+static int sfp_is_port_present(struct i2c_client *client, int port)
+{
+	struct sfp_port_data *data = i2c_get_clientdata(client);
+
+	data = sfp_update_present(client);
+	if (IS_ERR(data)) {
+		return PTR_ERR(data);
+	}
+
+	return (data->present & BIT_INDEX(data->port)) ? 0 : 1; /* Platform dependent */
+}
+
+/* Platform dependent +++ */
+static ssize_t show_present(struct device *dev, struct device_attribute *da,
+			 char *buf)
+{
+	struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
+	struct i2c_client *client = to_i2c_client(dev);
+
+	if (PRESENT_ALL == attr->index) {
+		int i;
+		u8 values[4]  = {0};
+		struct sfp_port_data *data = sfp_update_present(client);
+		
+		if (IS_ERR(data)) {
+			return PTR_ERR(data);
+		}
+
+		for (i = 0; i < ARRAY_SIZE(values); i++) {
+			values[i] = ~(u8)(data->present >> (i * 8));
+		}
+
+        /* Return values 1 -> 32 in order */
+        return sprintf(buf, "%.2x %.2x %.2x %.2x\n",
+                       values[0], values[1], values[2],
+                       values[3]);
+	}
+	else {
+		struct sfp_port_data *data = i2c_get_clientdata(client);
+		int present = sfp_is_port_present(client, data->port);
+
+		if (IS_ERR_VALUE(present)) {
+			return present;
+		}
+
+		/* PRESENT */
+		return sprintf(buf, "%d", present);
+	}
+}
+/* Platform dependent --- */
+
+static struct sfp_port_data *qsfp_update_tx_rx_status(struct device *dev)
+{
+	struct i2c_client *client = to_i2c_client(dev);
+	struct sfp_port_data *data = i2c_get_clientdata(client);
+	int i, status = -1;
+	u8 buf = 0;
+	u8 reg[] = {SFF8436_TX_FAULT_ADDR, SFF8436_TX_DISABLE_ADDR, SFF8436_RX_LOS_ADDR};
+
+	if (time_before(jiffies, data->qsfp->last_updated + HZ + HZ / 2) && data->qsfp->valid) {
+		return data;
+	}
+
+	DEBUG_PRINT("Starting sfp tx rx status update");
+	mutex_lock(&data->update_lock);
+	data->qsfp->valid = 0;
+	memset(data->qsfp->status, 0, sizeof(data->qsfp->status));
+
+	/* Notify device to update tx fault/ tx disable/ rx los status */
+	for (i = 0; i < ARRAY_SIZE(reg); i++) {
+		status = sfp_eeprom_read(client, reg[i], &buf, sizeof(buf));
+		if (unlikely(status < 0)) {
+			goto exit;
+		}
+	}
+	msleep(200);
+
+	/* Read actual tx fault/ tx disable/ rx los status */
+	for (i = 0; i < ARRAY_SIZE(reg); i++) {
+		status = sfp_eeprom_read(client, reg[i], &buf, sizeof(buf));
+		if (unlikely(status < 0)) {
+			goto exit;
+		}
+
+		DEBUG_PRINT("qsfp reg(0x%x) status = (0x%x)", reg[i], data->qsfp->status[i]);
+		data->qsfp->status[i] = (buf & 0xF);
+	}
+
+	data->qsfp->valid = 1;
+	data->qsfp->last_updated = jiffies;
+
+exit:
+	mutex_unlock(&data->update_lock);
+	return (status < 0) ? ERR_PTR(status) : data;
+}
+
+static ssize_t qsfp_show_tx_rx_status(struct device *dev, struct device_attribute *da,
+			 char *buf)
+{
+	int present;
+	u8 val = 0;
+	struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
+	struct i2c_client *client = to_i2c_client(dev);
+	struct sfp_port_data *data = i2c_get_clientdata(client);
+
+	present = sfp_is_port_present(client, data->port);
+	if (IS_ERR_VALUE(present)) {
+		return present;
+	}
+
+	if (present == 0) {
+		/* port is not present */
+		return -ENXIO;
+	}
+
+	data = qsfp_update_tx_rx_status(dev);
+	if (IS_ERR(data)) {
+		return PTR_ERR(data);
+	}
+
+	switch (attr->index) {
+	case TX_FAULT:
+		val = !!(data->qsfp->status[2] & 0xF);
+		break;
+	case TX_FAULT1:
+	case TX_FAULT2:
+	case TX_FAULT3:
+	case TX_FAULT4:
+		val = !!(data->qsfp->status[2] & BIT_INDEX(attr->index - TX_FAULT1));
+		break;
+	case TX_DISABLE:
+		val = data->qsfp->status[1] & 0xF;
+		break;
+	case TX_DISABLE1:
+	case TX_DISABLE2:
+	case TX_DISABLE3:
+	case TX_DISABLE4:
+		val = !!(data->qsfp->status[1] & BIT_INDEX(attr->index - TX_DISABLE1));
+		break;
+	case RX_LOS:
+		val = !!(data->qsfp->status[0] & 0xF);
+		break;
+	case RX_LOS1:
+	case RX_LOS2:
+	case RX_LOS3:
+	case RX_LOS4:
+		val = !!(data->qsfp->status[0] & BIT_INDEX(attr->index - RX_LOS1));
+		break;
+	default:
+		break;
+	}
+
+	return sprintf(buf, "%d\n", val);
+}
+
+static ssize_t qsfp_set_tx_disable(struct device *dev, struct device_attribute *da,
+			const char *buf, size_t count)
+{
+	long disable;
+	int status;
+	struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
+	struct i2c_client *client = to_i2c_client(dev);
+	struct sfp_port_data *data = i2c_get_clientdata(client);	
+
+	status = sfp_is_port_present(client, data->port);
+	if (IS_ERR_VALUE(status)) {
+		return status;
+	}
+
+	if (!status) {
+		/* port is not present */
+		return -ENXIO;
+	}
+
+	status = kstrtol(buf, 10, &disable);
+	if (status) {
+		return status;
+	}
+
+	data = qsfp_update_tx_rx_status(dev);
+	if (IS_ERR(data)) {
+		return PTR_ERR(data);
+	}
+
+	mutex_lock(&data->update_lock);
+
+	if (attr->index == TX_DISABLE) {
+		if (disable) {
+			data->qsfp->status[1] |= 0xF;
+		}
+		else {
+			data->qsfp->status[1] &= ~0xF;
+		}
+	}
+	else {/* TX_DISABLE1 ~ TX_DISABLE4*/
+		if (disable) {
+			data->qsfp->status[1] |= (1 << (attr->index - TX_DISABLE1));
+		}
+		else {
+			data->qsfp->status[1] &= ~(1 << (attr->index - TX_DISABLE1));
+		}
+	}
+
+	DEBUG_PRINT("index = (%d), status = (0x%x)", attr->index, data->qsfp->status[1]);
+	status = sfp_eeprom_write(data->client, SFF8436_TX_DISABLE_ADDR, &data->qsfp->status[1], sizeof(data->qsfp->status[1]));
+	if (unlikely(status < 0)) {
+		count = status;
+	}
+
+	mutex_unlock(&data->update_lock);
+	return count;
+}
+
+static ssize_t sfp_eeprom_write(struct i2c_client *client, u8 command, const char *data,
+			  int data_len)
+{
+#if USE_I2C_BLOCK_READ
+	int status, retry = I2C_RW_RETRY_COUNT;
+
+	if (data_len > I2C_SMBUS_BLOCK_MAX) {
+		data_len = I2C_SMBUS_BLOCK_MAX;
+	}
+
+	while (retry) {
+		status = i2c_smbus_write_i2c_block_data(client, command, data_len, data);
+		if (unlikely(status < 0)) {
+			msleep(I2C_RW_RETRY_INTERVAL);
+			retry--;
+			continue;
+		}
+
+		break;
+	}
+
+	if (unlikely(status < 0)) {
+		return status;
+	}
+
+	return data_len;
+#else
+	int status, retry = I2C_RW_RETRY_COUNT;
+
+	while (retry) {
+		status = i2c_smbus_write_byte_data(client, command, *data);
+		if (unlikely(status < 0)) {
+			msleep(I2C_RW_RETRY_INTERVAL);
+			retry--;
+			continue;
+		}
+
+		break;
+	}
+
+	if (unlikely(status < 0)) {
+		return status;
+	}
+
+	return 1;
+#endif
+
+
+}
+
+#if (MULTIPAGE_SUPPORT == 0)
+static ssize_t sfp_port_write(struct sfp_port_data *data,
+						  const char *buf, loff_t off, size_t count)
+{
+	ssize_t retval = 0;
+	
+	if (unlikely(!count)) {
+		return count;
+	}
+	
+	/*
+	 * Write data to chip, protecting against concurrent updates
+	 * from this host, but not from other I2C masters.
+	 */
+	mutex_lock(&data->update_lock);
+	
+	while (count) {
+		ssize_t status;
+	
+		status = sfp_eeprom_write(data->client, off, buf, count);
+		if (status <= 0) {
+			if (retval == 0) {
+				retval = status;
+			}
+			break;
+		}
+		buf += status;
+		off += status;
+		count -= status;
+		retval += status;
+	}
+	
+	mutex_unlock(&data->update_lock);
+	return retval;
+}
+#endif
+
+static ssize_t sfp_bin_write(struct file *filp, struct kobject *kobj,
+				struct bin_attribute *attr,
+				char *buf, loff_t off, size_t count)
+{
+	int present;
+	struct sfp_port_data *data;
+	DEBUG_PRINT("%s(%d) offset = (%d), count = (%d)", off, count);
+	data = dev_get_drvdata(container_of(kobj, struct device, kobj));
+
+	present = sfp_is_port_present(data->client, data->port);
+	if (IS_ERR_VALUE(present)) {
+		return present;
+	}
+
+	if (present == 0) {
+		/* port is not present */
+		return -ENODEV;
+	}
+
+#if (MULTIPAGE_SUPPORT == 1)
+	return sfp_port_read_write(data, buf, off, count, QSFP_WRITE_OP);
+#else
+	return sfp_port_write(data, buf, off, count);
+#endif
+}
+
+static ssize_t sfp_eeprom_read(struct i2c_client *client, u8 command, u8 *data,
+			  int data_len)
+{
+#if USE_I2C_BLOCK_READ
+	int status, retry = I2C_RW_RETRY_COUNT;
+
+	if (data_len > I2C_SMBUS_BLOCK_MAX) {
+		data_len = I2C_SMBUS_BLOCK_MAX;
+	}
+
+	while (retry) {
+		status = i2c_smbus_read_i2c_block_data(client, command, data_len, data);
+		if (unlikely(status < 0)) {
+			msleep(I2C_RW_RETRY_INTERVAL);
+			retry--;
+			continue;
+		}
+
+		break;
+	}
+
+	if (unlikely(status < 0)) {
+		goto abort;
+	}
+	if (unlikely(status != data_len)) {
+		status = -EIO;
+		goto abort;
+	}
+	
+	//result = data_len;
+	
+abort:
+	return status;
+#else
+	int status, retry = I2C_RW_RETRY_COUNT;
+
+	while (retry) {
+		status = i2c_smbus_read_byte_data(client, command);
+		if (unlikely(status < 0)) {
+			msleep(I2C_RW_RETRY_INTERVAL);
+			retry--;
+			continue;
+		}
+ 
+		break;
+	}
+
+	if (unlikely(status < 0)) {
+		dev_dbg(&client->dev, "sfp read byte data failed, command(0x%2x), data(0x%2x)\r\n", command, status);
+		goto abort;
+	}
+
+	*data  = (u8)status;
+	status = 1;
+
+abort:
+	return status;
+#endif
+}
+
+#if (MULTIPAGE_SUPPORT == 1)
+/*-------------------------------------------------------------------------*/
+/*
+ * This routine computes the addressing information to be used for
+ * a given r/w request.
+ *
+ * Task is to calculate the client (0 = i2c addr 50, 1 = i2c addr 51),
+ * the page, and the offset.
+ *
+ * Handles both SFP and QSFP.  
+ *     For SFP, offset 0-255 are on client[0], >255 is on client[1]
+ *     Offset 256-383 are on the lower half of client[1]
+ *     Pages are accessible on the upper half of client[1].
+ *     Offset >383 are in 128 byte pages mapped into the upper half
+ *
+ *     For QSFP, all offsets are on client[0]
+ *     offset 0-127 are on the lower half of client[0] (no paging)
+ *     Pages are accessible on the upper half of client[1].
+ *     Offset >127 are in 128 byte pages mapped into the upper half
+ *
+ *     Callers must not read/write beyond the end of a client or a page
+ *     without recomputing the client/page.  Hence offset (within page)
+ *     plus length must be less than or equal to 128.  (Note that this
+ *     routine does not have access to the length of the call, hence 
+ *     cannot do the validity check.)
+ *
+ * Offset within Lower Page 00h and Upper Page 00h are not recomputed
+ */
+static uint8_t sff_8436_translate_offset(struct sfp_port_data *port_data,
+		loff_t *offset, struct i2c_client **client)
+{
+	unsigned page = 0;
+
+	*client = port_data->client;
+
+	/*
+	 * if offset is in the range 0-128...
+	 * page doesn't matter (using lower half), return 0.
+	 * offset is already correct (don't add 128 to get to paged area)
+	 */
+	if (*offset < SFF_8436_PAGE_SIZE)
+		return page;
+
+	/* note, page will always be positive since *offset >= 128 */
+	page = (*offset >> 7)-1;
+	/* 0x80 places the offset in the top half, offset is last 7 bits */
+	*offset = SFF_8436_PAGE_SIZE + (*offset & 0x7f);
+
+	return page;  /* note also returning client and offset */
+}
+
+static ssize_t sff_8436_eeprom_read(struct sfp_port_data *port_data,
+		    struct i2c_client *client,
+		    char *buf, unsigned offset, size_t count)
+{
+	struct i2c_msg msg[2];
+	u8 msgbuf[2];
+	unsigned long timeout, read_time;
+	int status, i;
+
+	memset(msg, 0, sizeof(msg));
+
+	switch (port_data->use_smbus) {
+	case I2C_SMBUS_I2C_BLOCK_DATA:
+		/*smaller eeproms can work given some SMBus extension calls */
+		if (count > I2C_SMBUS_BLOCK_MAX)
+			count = I2C_SMBUS_BLOCK_MAX;
+		break;
+	case I2C_SMBUS_WORD_DATA:
+		/* Check for odd length transaction */
+		count = (count == 1) ? 1 : 2;
+		break;
+	case I2C_SMBUS_BYTE_DATA:
+		count = 1;
+		break;
+	default:
+		/*
+		 * When we have a better choice than SMBus calls, use a
+		 * combined I2C message. Write address; then read up to
+		 * io_limit data bytes.  msgbuf is u8 and will cast to our
+		 * needs.
+		 */
+		i = 0;
+		msgbuf[i++] = offset;
+
+		msg[0].addr = client->addr;
+		msg[0].buf = msgbuf;
+		msg[0].len = i;
+
+		msg[1].addr = client->addr;
+		msg[1].flags = I2C_M_RD;
+		msg[1].buf = buf;
+		msg[1].len = count;
+	}
+
+	/*
+	 * Reads fail if the previous write didn't complete yet. We may
+	 * loop a few times until this one succeeds, waiting at least
+	 * long enough for one entire page write to work.
+	 */
+	timeout = jiffies + msecs_to_jiffies(write_timeout);
+	do {
+		read_time = jiffies;
+
+		switch (port_data->use_smbus) {
+		case I2C_SMBUS_I2C_BLOCK_DATA:
+			status = i2c_smbus_read_i2c_block_data(client, offset,
+					count, buf);
+			break;
+		case I2C_SMBUS_WORD_DATA:
+			status = i2c_smbus_read_word_data(client, offset);
+			if (status >= 0) {
+				buf[0] = status & 0xff;
+				if (count == 2)
+					buf[1] = status >> 8;
+				status = count;
+			}
+			break;
+		case I2C_SMBUS_BYTE_DATA:
+			status = i2c_smbus_read_byte_data(client, offset);
+			if (status >= 0) {
+				buf[0] = status;
+				status = count;
+			}
+			break;
+		default:
+			status = i2c_transfer(client->adapter, msg, 2);
+			if (status == 2)
+				status = count;
+		}
+
+		dev_dbg(&client->dev, "eeprom read %zu@%d --> %d (%ld)\n",
+				count, offset, status, jiffies);
+
+		if (status == count)  /* happy path */
+			return count;
+
+		if (status == -ENXIO) /* no module present */
+			return status;
+
+		/* REVISIT: at HZ=100, this is sloooow */
+		msleep(1);
+	} while (time_before(read_time, timeout));
+
+	return -ETIMEDOUT;
+}
+
+static ssize_t sff_8436_eeprom_write(struct sfp_port_data *port_data,
+		    		struct i2c_client *client,
+				const char *buf,
+				unsigned offset, size_t count)
+{
+	struct i2c_msg msg;
+	ssize_t status;
+	unsigned long timeout, write_time;
+	unsigned next_page_start;
+	int i = 0;
+
+	/* write max is at most a page
+	 * (In this driver, write_max is actually one byte!)
+	 */
+	if (count > port_data->write_max)
+		count = port_data->write_max;
+
+	/* shorten count if necessary to avoid crossing page boundary */
+	next_page_start = roundup(offset + 1, SFF_8436_PAGE_SIZE);
+	if (offset + count > next_page_start)
+		count = next_page_start - offset;
+
+	switch (port_data->use_smbus) {
+	case I2C_SMBUS_I2C_BLOCK_DATA:
+		/*smaller eeproms can work given some SMBus extension calls */
+		if (count > I2C_SMBUS_BLOCK_MAX)
+			count = I2C_SMBUS_BLOCK_MAX;
+		break;
+	case I2C_SMBUS_WORD_DATA:
+		/* Check for odd length transaction */
+		count = (count == 1) ? 1 : 2;
+		break;
+	case I2C_SMBUS_BYTE_DATA:
+		count = 1;
+		break;
+	default:
+		/* If we'll use I2C calls for I/O, set up the message */
+		msg.addr = client->addr;
+		msg.flags = 0;
+
+		/* msg.buf is u8 and casts will mask the values */
+		msg.buf = port_data->writebuf;
+
+		msg.buf[i++] = offset;
+		memcpy(&msg.buf[i], buf, count);
+		msg.len = i + count;
+		break;
+	}
+
+	/*
+	 * Reads fail if the previous write didn't complete yet. We may
+	 * loop a few times until this one succeeds, waiting at least
+	 * long enough for one entire page write to work.
+	 */
+	timeout = jiffies + msecs_to_jiffies(write_timeout);
+	do {
+		write_time = jiffies;
+
+		switch (port_data->use_smbus) {
+		case I2C_SMBUS_I2C_BLOCK_DATA:
+			status = i2c_smbus_write_i2c_block_data(client,
+						offset, count, buf);
+			if (status == 0)
+				status = count;
+			break;
+		case I2C_SMBUS_WORD_DATA:
+			if (count == 2) {
+				status = i2c_smbus_write_word_data(client,
+					offset, (u16)((buf[0])|(buf[1] << 8)));
+			} else {
+				/* count = 1 */
+				status = i2c_smbus_write_byte_data(client,
+					offset, buf[0]);
+			}
+			if (status == 0)
+				status = count;
+			break;
+		case I2C_SMBUS_BYTE_DATA:
+			status = i2c_smbus_write_byte_data(client, offset,
+						buf[0]);
+			if (status == 0)
+				status = count;
+			break;
+		default:
+			status = i2c_transfer(client->adapter, &msg, 1);
+			if (status == 1)
+				status = count;
+			break;
+		}
+
+		dev_dbg(&client->dev, "eeprom write %zu@%d --> %ld (%lu)\n",
+				count, offset, (long int) status, jiffies);
+
+		if (status == count)
+			return count;
+
+		/* REVISIT: at HZ=100, this is sloooow */
+		msleep(1);
+	} while (time_before(write_time, timeout));
+
+	return -ETIMEDOUT;
+}
+
+
+static ssize_t sff_8436_eeprom_update_client(struct sfp_port_data *port_data,
+				char *buf, loff_t off, 
+				size_t count, qsfp_opcode_e opcode)
+{
+	struct i2c_client *client;
+	ssize_t retval = 0;
+	u8 page = 0;
+	loff_t phy_offset = off;
+	int ret = 0;
+
+	page = sff_8436_translate_offset(port_data, &phy_offset, &client);
+
+	dev_dbg(&client->dev,
+			"sff_8436_eeprom_update_client off %lld  page:%d phy_offset:%lld, count:%ld, opcode:%d\n",
+			off, page, phy_offset, (long int) count, opcode);
+	if (page > 0) {
+		ret = sff_8436_eeprom_write(port_data, client, &page, 
+			SFF_8436_PAGE_SELECT_REG, 1);
+		if (ret < 0) {
+			dev_dbg(&client->dev,
+				"Write page register for page %d failed ret:%d!\n",
+					page, ret);
+			return ret;
+		}
+	}
+
+	while (count) {
+		ssize_t	status;
+
+		if (opcode == QSFP_READ_OP) {
+			status =  sff_8436_eeprom_read(port_data, client,
+				buf, phy_offset, count);
+		} else {
+			status =  sff_8436_eeprom_write(port_data, client,
+				buf, phy_offset, count);
+		}
+		if (status <= 0) {
+			if (retval == 0)
+				retval = status;
+			break;
+		}
+		buf += status;
+		phy_offset += status;
+		count -= status;
+		retval += status;
+	}
+
+
+	if (page > 0) {
+		/* return the page register to page 0 (why?) */
+		page = 0;
+		ret = sff_8436_eeprom_write(port_data, client, &page, 
+			SFF_8436_PAGE_SELECT_REG, 1);
+		if (ret < 0) {
+			dev_err(&client->dev,
+				"Restore page register to page %d failed ret:%d!\n",
+					page, ret);
+			return ret;
+		}
+	}
+	return retval;
+}
+
+
+/*
+ * Figure out if this access is within the range of supported pages.
+ * Note this is called on every access because we don't know if the
+ * module has been replaced since the last call.
+ * If/when modules support more pages, this is the routine to update
+ * to validate and allow access to additional pages.
+ *
+ * Returns updated len for this access:
+ *     - entire access is legal, original len is returned.
+ *     - access begins legal but is too long, len is truncated to fit.
+ *     - initial offset exceeds supported pages, return -EINVAL
+ */
+static ssize_t sff_8436_page_legal(struct sfp_port_data *port_data, 
+		loff_t off, size_t len)
+{
+	struct i2c_client *client = port_data->client;
+	u8 regval;
+	int status;
+	size_t maxlen;
+
+	if (off < 0) return -EINVAL;
+	if (port_data->driver_type == DRIVER_TYPE_SFP_MSA) {
+		/* SFP case */
+		/* if no pages needed, we're good */
+		if ((off + len) <= SFF_8472_EEPROM_UNPAGED_SIZE) return len;
+		/* if offset exceeds possible pages, we're not good */
+		if (off >= SFF_8472_EEPROM_SIZE) return -EINVAL;
+		/* in between, are pages supported? */
+		status = sff_8436_eeprom_read(port_data, client, &regval, 
+				SFF_8472_PAGEABLE_REG, 1);
+		if (status < 0) return status;  /* error out (no module?) */
+		if (regval & SFF_8472_PAGEABLE) {
+			/* Pages supported, trim len to the end of pages */
+			maxlen = SFF_8472_EEPROM_SIZE - off;
+		} else {
+			/* pages not supported, trim len to unpaged size */
+			maxlen = SFF_8472_EEPROM_UNPAGED_SIZE - off;
+		}
+		len = (len > maxlen) ? maxlen : len;
+		dev_dbg(&client->dev,
+			"page_legal, SFP, off %lld len %ld\n",
+			off, (long int) len);
+	} 
+	else if (port_data->driver_type == DRIVER_TYPE_QSFP) {
+		/* QSFP case */
+		/* if no pages needed, we're good */
+		if ((off + len) <= SFF_8436_EEPROM_UNPAGED_SIZE) return len;
+		/* if offset exceeds possible pages, we're not good */
+		if (off >= SFF_8436_EEPROM_SIZE) return -EINVAL;
+		/* in between, are pages supported? */
+		status = sff_8436_eeprom_read(port_data, client, &regval, 
+				SFF_8436_PAGEABLE_REG, 1);
+		if (status < 0) return status;  /* error out (no module?) */
+		if (regval & SFF_8436_NOT_PAGEABLE) {
+			/* pages not supported, trim len to unpaged size */
+			maxlen = SFF_8436_EEPROM_UNPAGED_SIZE - off;
+		} else {
+			/* Pages supported, trim len to the end of pages */
+			maxlen = SFF_8436_EEPROM_SIZE - off;
+		}
+		len = (len > maxlen) ? maxlen : len;
+		dev_dbg(&client->dev,
+			"page_legal, QSFP, off %lld len %ld\n",
+			off, (long int) len);
+	}
+	else {
+		return -EINVAL;
+	}
+	return len;
+}
+
+
+static ssize_t sfp_port_read_write(struct sfp_port_data *port_data,
+		char *buf, loff_t off, size_t len, qsfp_opcode_e opcode)
+{
+	struct i2c_client *client = port_data->client;
+	int chunk;
+	int status = 0;
+	ssize_t retval;
+	size_t pending_len = 0, chunk_len = 0;
+	loff_t chunk_offset = 0, chunk_start_offset = 0;
+
+	if (unlikely(!len))
+		return len;
+
+	/*
+	 * Read data from chip, protecting against concurrent updates
+	 * from this host, but not from other I2C masters.
+	 */
+	mutex_lock(&port_data->update_lock);
+	
+	/*
+	 * Confirm this access fits within the device suppored addr range 
+	 */
+	len = sff_8436_page_legal(port_data, off, len);
+	if (len < 0) {
+		status = len;
+		goto err;
+	}
+
+	/*
+	 * For each (128 byte) chunk involved in this request, issue a
+	 * separate call to sff_eeprom_update_client(), to
+	 * ensure that each access recalculates the client/page
+	 * and writes the page register as needed.
+	 * Note that chunk to page mapping is confusing, is different for 
+	 * QSFP and SFP, and never needs to be done.  Don't try!
+	 */
+	pending_len = len; /* amount remaining to transfer */
+	retval = 0;  /* amount transferred */
+	for (chunk = off >> 7; chunk <= (off + len - 1) >> 7; chunk++) {
+
+		/*
+		 * Compute the offset and number of bytes to be read/write
+		 *
+		 * 1. start at offset 0 (within the chunk), and read/write
+		 *    the entire chunk
+		 * 2. start at offset 0 (within the chunk) and read/write less
+		 *    than entire chunk
+		 * 3. start at an offset not equal to 0 and read/write the rest
+		 *    of the chunk
+		 * 4. start at an offset not equal to 0 and read/write less than
+		 *    (end of chunk - offset)
+		 */
+		chunk_start_offset = chunk * SFF_8436_PAGE_SIZE;
+
+		if (chunk_start_offset < off) {
+			chunk_offset = off;
+			if ((off + pending_len) < (chunk_start_offset +
+					SFF_8436_PAGE_SIZE))
+				chunk_len = pending_len;
+			else
+				chunk_len = (chunk+1)*SFF_8436_PAGE_SIZE - off;/*SFF_8436_PAGE_SIZE - off;*/
+		} else {
+			chunk_offset = chunk_start_offset;
+			if (pending_len > SFF_8436_PAGE_SIZE)
+				chunk_len = SFF_8436_PAGE_SIZE;
+			else
+				chunk_len = pending_len;
+		}
+
+		dev_dbg(&client->dev,
+			"sff_r/w: off %lld, len %ld, chunk_start_offset %lld, chunk_offset %lld, chunk_len %ld, pending_len %ld\n",
+			off, (long int) len, chunk_start_offset, chunk_offset,
+			(long int) chunk_len, (long int) pending_len);
+
+		/* 
+		 * note: chunk_offset is from the start of the EEPROM, 
+		 * not the start of the chunk 
+		 */
+		status = sff_8436_eeprom_update_client(port_data, buf, 
+				chunk_offset, chunk_len, opcode);
+		if (status != chunk_len) {
+			/* This is another 'no device present' path */
+			dev_dbg(&client->dev, 
+	"sff_8436_update_client for chunk %d chunk_offset %lld chunk_len %ld failed %d!\n",
+				chunk, chunk_offset, (long int) chunk_len, status);
+			goto err;
+		}
+		buf += status;
+		pending_len -= status;
+		retval += status;
+	}
+	mutex_unlock(&port_data->update_lock);
+
+	return retval;
+
+err:
+	mutex_unlock(&port_data->update_lock);
+
+	return status;
+}
+
+#else
+static ssize_t sfp_port_read(struct sfp_port_data *data,
+				char *buf, loff_t off, size_t count)
+{
+	ssize_t retval = 0;
+	
+	if (unlikely(!count)) {
+		DEBUG_PRINT("Count = 0, return");
+		return count;
+	}
+	
+	/*
+	 * Read data from chip, protecting against concurrent updates
+	 * from this host, but not from other I2C masters.
+	 */
+	mutex_lock(&data->update_lock);
+
+	while (count) {
+		ssize_t status;
+	
+		status = sfp_eeprom_read(data->client, off, buf, count);
+		if (status <= 0) {
+			if (retval == 0) {
+				retval = status;
+			}
+			break;
+		}
+		
+		buf += status;
+		off += status;
+		count -= status;
+		retval += status;
+	}
+	
+	mutex_unlock(&data->update_lock);
+	return retval;
+
+}
+#endif
+
+static ssize_t sfp_bin_read(struct file *filp, struct kobject *kobj,
+		struct bin_attribute *attr,
+		char *buf, loff_t off, size_t count)
+{
+	int present;
+	struct sfp_port_data *data;
+	DEBUG_PRINT("offset = (%d), count = (%d)", off, count);
+	data = dev_get_drvdata(container_of(kobj, struct device, kobj));
+	present = sfp_is_port_present(data->client, data->port);
+	if (IS_ERR_VALUE(present)) {
+		return present;
+	}
+
+	if (present == 0) {
+		/* port is not present */
+		return -ENODEV;
+	}
+
+#if (MULTIPAGE_SUPPORT == 1)
+	return sfp_port_read_write(data, buf, off, count, QSFP_READ_OP);
+#else
+	return sfp_port_read(data, buf, off, count);
+#endif
+}
+
+#if (MULTIPAGE_SUPPORT == 1)
+static int sfp_sysfs_eeprom_init(struct kobject *kobj, struct bin_attribute *eeprom, size_t size)
+#else
+static int sfp_sysfs_eeprom_init(struct kobject *kobj, struct bin_attribute *eeprom)
+#endif
+{
+	int err;
+
+	sysfs_bin_attr_init(eeprom);
+	eeprom->attr.name = EEPROM_NAME;
+	eeprom->attr.mode = S_IWUSR | S_IRUGO;
+	eeprom->read	  = sfp_bin_read;
+	eeprom->write	  = sfp_bin_write;
+#if (MULTIPAGE_SUPPORT == 1)
+	eeprom->size	  = size;
+#else
+	eeprom->size	  = EEPROM_SIZE;
+#endif
+
+	/* Create eeprom file */
+	err = sysfs_create_bin_file(kobj, eeprom);
+	if (err) {
+		return err;
+	}
+	
+	return 0;
+}
+
+static int sfp_sysfs_eeprom_cleanup(struct kobject *kobj, struct bin_attribute *eeprom)
+{
+	sysfs_remove_bin_file(kobj, eeprom);
+	return 0;
+}
+
+
+#if (MULTIPAGE_SUPPORT == 0)
+static int sfp_i2c_check_functionality(struct i2c_client *client)
+{
+#if USE_I2C_BLOCK_READ
+	return i2c_check_functionality(client->adapter, I2C_FUNC_SMBUS_I2C_BLOCK);
+#else
+	return i2c_check_functionality(client->adapter, I2C_FUNC_SMBUS_BYTE_DATA);
+#endif
+}
+#endif
+
+
+static const struct attribute_group qsfp_group = {
+	.attrs = qsfp_attributes,
+};
+
+static int qsfp_probe(struct i2c_client *client, const struct i2c_device_id *dev_id,
+						  struct qsfp_data **data)
+{
+	int status;
+	struct qsfp_data *qsfp;
+
+#if (MULTIPAGE_SUPPORT == 0)
+	if (!sfp_i2c_check_functionality(client)) {
+		status = -EIO;
+		goto exit;
+	}
+#endif
+
+	qsfp = kzalloc(sizeof(struct qsfp_data), GFP_KERNEL);
+	if (!qsfp) {
+		status = -ENOMEM;
+		goto exit;
+	}
+
+	/* Register sysfs hooks */
+	status = sysfs_create_group(&client->dev.kobj, &qsfp_group);
+	if (status) {
+		goto exit_free;
+	}
+
+	/* init eeprom */
+#if (MULTIPAGE_SUPPORT == 1)
+	status = sfp_sysfs_eeprom_init(&client->dev.kobj, &qsfp->eeprom.bin, SFF_8436_EEPROM_SIZE);
+#else
+	status = sfp_sysfs_eeprom_init(&client->dev.kobj, &qsfp->eeprom.bin);
+#endif
+	if (status) {
+		goto exit_remove;
+	}
+
+	*data = qsfp;
+	dev_info(&client->dev, "qsfp '%s'\n", client->name);
+
+	return 0;
+
+exit_remove:
+	sysfs_remove_group(&client->dev.kobj, &qsfp_group);
+exit_free:
+	kfree(qsfp);
+exit:
+
+	return status;
+}
+
+/* Platform dependent +++ */
+static int sfp_device_probe(struct i2c_client *client,
+			const struct i2c_device_id *dev_id)
+{
+	int ret = 0;
+	struct sfp_port_data *data = NULL;
+
+	if (client->addr != SFP_EEPROM_A0_I2C_ADDR) {
+		return -ENODEV;
+	}
+
+	if (dev_id->driver_data < as6812_32x_port1 || dev_id->driver_data > as6812_32x_port32) {
+		return -ENXIO;
+	}
+
+	data = kzalloc(sizeof(struct sfp_port_data), GFP_KERNEL);
+	if (!data) {
+		return -ENOMEM;
+	}
+
+#if (MULTIPAGE_SUPPORT == 1)
+	data->use_smbus = 0;
+
+	/* Use I2C operations unless we're stuck with SMBus extensions. */
+	if (!i2c_check_functionality(client->adapter, I2C_FUNC_I2C)) {
+		if (i2c_check_functionality(client->adapter,
+				I2C_FUNC_SMBUS_READ_I2C_BLOCK)) {
+			data->use_smbus = I2C_SMBUS_I2C_BLOCK_DATA;
+		} else if (i2c_check_functionality(client->adapter,
+				I2C_FUNC_SMBUS_READ_WORD_DATA)) {
+			data->use_smbus = I2C_SMBUS_WORD_DATA;
+		} else if (i2c_check_functionality(client->adapter,
+				I2C_FUNC_SMBUS_READ_BYTE_DATA)) {
+			data->use_smbus = I2C_SMBUS_BYTE_DATA;
+		} else {
+			ret = -EPFNOSUPPORT;
+			goto exit_kfree;
+		}
+	}
+
+	if (!data->use_smbus ||
+			(i2c_check_functionality(client->adapter,
+				I2C_FUNC_SMBUS_WRITE_I2C_BLOCK)) ||
+			i2c_check_functionality(client->adapter,
+				I2C_FUNC_SMBUS_WRITE_WORD_DATA) ||
+			i2c_check_functionality(client->adapter,
+				I2C_FUNC_SMBUS_WRITE_BYTE_DATA)) {
+		/*
+		 * NOTE: AN-2079
+		 * Finisar recommends that the host implement 1 byte writes
+		 * only since this module only supports 32 byte page boundaries.
+		 * 2 byte writes are acceptable for PE and Vout changes per
+		 * Application Note AN-2071.
+		 */
+		unsigned write_max = 1;
+
+		if (write_max > io_limit)
+			write_max = io_limit;
+		if (data->use_smbus && write_max > I2C_SMBUS_BLOCK_MAX)
+			write_max = I2C_SMBUS_BLOCK_MAX;
+		data->write_max = write_max;
+
+		/* buffer (data + address at the beginning) */
+		data->writebuf = kmalloc(write_max + 2, GFP_KERNEL);
+		if (!data->writebuf) {
+			ret = -ENOMEM;
+			goto exit_kfree;
+		}
+	} else {
+			dev_warn(&client->dev,
+				"cannot write due to controller restrictions.");
+	}
+
+	if (data->use_smbus == I2C_SMBUS_WORD_DATA ||
+	    data->use_smbus == I2C_SMBUS_BYTE_DATA) {
+		dev_notice(&client->dev, "Falling back to %s reads, "
+			   "performance will suffer\n", data->use_smbus ==
+			   I2C_SMBUS_WORD_DATA ? "word" : "byte");
+	}
+#endif
+
+	i2c_set_clientdata(client, data);
+	mutex_init(&data->update_lock);
+	data->port	 = dev_id->driver_data;
+	data->client = client;
+	data->driver_type = DRIVER_TYPE_QSFP;
+
+	ret = qsfp_probe(client, dev_id, &data->qsfp);
+	if (ret < 0) {
+		goto exit_kfree_buf;
+	}
+
+	return ret;
+
+exit_kfree_buf:
+#if (MULTIPAGE_SUPPORT == 1)
+	if (data->writebuf) kfree(data->writebuf);
+#endif
+
+exit_kfree:
+	kfree(data);
+	return ret;
+}
+/* Platform dependent --- */
+
+static int qsfp_remove(struct i2c_client *client, struct qsfp_data *data)
+{
+	sfp_sysfs_eeprom_cleanup(&client->dev.kobj, &data->eeprom.bin);
+	sysfs_remove_group(&client->dev.kobj, &qsfp_group);
+	kfree(data);
+	return 0;
+}
+
+static int sfp_device_remove(struct i2c_client *client)
+{
+	int ret = 0;
+	struct sfp_port_data *data = i2c_get_clientdata(client);
+#if (MULTIPAGE_SUPPORT == 1)
+	kfree(data->writebuf);
+#endif
+
+	if (data->driver_type == DRIVER_TYPE_QSFP) {
+		ret = qsfp_remove(client, data->qsfp);
+	}
+
+	kfree(data);
+	return ret;
+}
+
+/* Addresses scanned
+ */
+static const unsigned short normal_i2c[] = { I2C_CLIENT_END };
+
+static struct i2c_driver sfp_driver = {
+	.driver = {
+		.name	  = DRIVER_NAME,
+	},
+	.probe		  = sfp_device_probe,
+	.remove		  = sfp_device_remove,
+	.id_table	  = sfp_device_id,
+	.address_list = normal_i2c,
+};
+
+static int __init sfp_init(void)
+{
+	return i2c_add_driver(&sfp_driver);
+}
+
+static void __exit sfp_exit(void)
+{
+	i2c_del_driver(&sfp_driver);
+}
+
+MODULE_AUTHOR("Brandon Chuang <brandon_chuang@accton.com.tw>");
+MODULE_DESCRIPTION("accton as6812_32x_sfp driver");
+MODULE_LICENSE("GPL");
+
+module_init(sfp_init);
+module_exit(sfp_exit);
+

--- a/packages/platforms/accton/x86-64/x86-64-accton-as6812-32x/onlp/builds/src/module/src/sfpi.c
+++ b/packages/platforms/accton/x86-64/x86-64-accton-as6812-32x/onlp/builds/src/module/src/sfpi.c
@@ -24,17 +24,35 @@
  *
  ***********************************************************/
 #include <onlp/platformi/sfpi.h>
-#include <onlplib/i2c.h>
+
+#include <fcntl.h> /* For O_RDWR && open */
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+
+#include "platform_lib.h"
 #include <onlplib/file.h>
-#include "x86_64_accton_as6812_32x_int.h"
-#include "x86_64_accton_as6812_32x_log.h"
 
-#define PORT_BUS_INDEX(port) (port+2)
-#define PORT_EEPROM_FORMAT              "/sys/bus/i2c/devices/%d-0050/eeprom"
-#define MODULE_PRESENT_FORMAT		    "/sys/bus/i2c/devices/0-00%d/module_present_%d"
-#define MODULE_PRESENT_ALL_ATTR_CPLD2	"/sys/bus/i2c/devices/0-0062/module_present_all"
-#define MODULE_PRESENT_ALL_ATTR_CPLD3	"/sys/bus/i2c/devices/0-0064/module_present_all"
+#define MAX_SFP_PATH 64
+static char sfp_node_path[MAX_SFP_PATH] = {0};
+#define FRONT_PORT_TO_CPLD_MUX_INDEX(port) (port+2)
 
+static int
+as6812_32x_sfp_node_read_int(char *node_path, int *value, int data_len)
+{
+    return onlp_file_read_int(value, node_path);
+}
+
+static char*
+as6812_32x_sfp_get_port_path(int port, char *node_name)
+{
+    sprintf(sfp_node_path, "/sys/bus/i2c/devices/%d-0050/%s",
+                           FRONT_PORT_TO_CPLD_MUX_INDEX(port),
+                           node_name);
+
+    return sfp_node_path;
+}
 
 /************************************************************
  *
@@ -73,13 +91,12 @@ onlp_sfpi_is_present(int port)
      * Return < 0 if error.
      */
     int present;
-    int addr = (port < 16) ? 62 : 64;
-    
-	if (onlp_file_read_int(&present, MODULE_PRESENT_FORMAT, addr, (port+1)) < 0) {
+    char* path = as6812_32x_sfp_get_port_path(port, "sfp_is_present");
+
+    if (as6812_32x_sfp_node_read_int(path, &present, 1) != 0) {
         AIM_LOG_ERROR("Unable to read present status from port(%d)\r\n", port);
         return ONLP_STATUS_E_INTERNAL;
     }
-
     return present;
 }
 
@@ -87,34 +104,27 @@ int
 onlp_sfpi_presence_bitmap_get(onlp_sfp_bitmap_t* dst)
 {
     uint32_t bytes[4];
-    uint32_t *ptr = bytes;
+    char* path;
     FILE* fp;
 
-    /* Read present status of port 0~31 */
-    int addr;
+    path = as6812_32x_sfp_get_port_path(0, "sfp_is_present_all");
+    fp = fopen(path, "r");
 
-    for (addr = 62; addr <= 64; addr+=2) {
-        if (addr == 62) {
-            fp = fopen(MODULE_PRESENT_ALL_ATTR_CPLD2, "r");
-        }
-        else {
-            fp = fopen(MODULE_PRESENT_ALL_ATTR_CPLD3, "r");
-        }
-
-        if(fp == NULL) {
-            AIM_LOG_ERROR("Unable to open the module_present_all device file of CPLD(0x%d)", addr);
-            return ONLP_STATUS_E_INTERNAL;
-        }
-
-        int count = fscanf(fp, "%x %x", ptr+0, ptr+1);
-        fclose(fp);
-        if(count != 2) {
-            /* Likely a CPLD read timeout. */
-            AIM_LOG_ERROR("Unable to read all fields from the module_present_all device file of CPLD(0x%d)", addr);
-            return ONLP_STATUS_E_INTERNAL;
-        }
-
-        ptr += count;
+    if(fp == NULL) {
+        AIM_LOG_ERROR("Unable to open the sfp_is_present_all device file.");
+        return ONLP_STATUS_E_INTERNAL;
+    }
+    int count = fscanf(fp, "%x %x %x %x",
+                       bytes+0,
+                       bytes+1,
+                       bytes+2,
+                       bytes+3
+                       );
+    fclose(fp);
+    if(count != AIM_ARRAYSIZE(bytes)) {
+        /* Likely a CPLD read timeout. */
+        AIM_LOG_ERROR("Unable to read all fields from the sfp_is_present_all device file.");
+        return ONLP_STATUS_E_INTERNAL;
     }
 
     /* Convert to 64 bit integer in port order */
@@ -143,22 +153,18 @@ onlp_sfpi_rx_los_bitmap_get(onlp_sfp_bitmap_t* dst)
 int
 onlp_sfpi_eeprom_read(int port, uint8_t data[256])
 {
+    char* path = as6812_32x_sfp_get_port_path(port, "sfp_eeprom");
+
     /*
      * Read the SFP eeprom into data[]
      *
      * Return MISSING if SFP is missing.
      * Return OK if eeprom is read
      */
-    int size = 0;
     memset(data, 0, 256);
 
-	if(onlp_file_read(data, 256, &size, PORT_EEPROM_FORMAT, PORT_BUS_INDEX(port)) != ONLP_STATUS_OK) {
+    if (deviceNodeReadBinary(path, (char*)data, 256, 256) != 0) {
         AIM_LOG_ERROR("Unable to read eeprom from port(%d)\r\n", port);
-        return ONLP_STATUS_E_INTERNAL;
-    }
-
-    if (size != 256) {
-        AIM_LOG_ERROR("Unable to read eeprom from port(%d), size is different!\r\n", port);
         return ONLP_STATUS_E_INTERNAL;
     }
 
@@ -170,4 +176,3 @@ onlp_sfpi_denit(void)
 {
     return ONLP_STATUS_OK;
 }
-

--- a/packages/platforms/accton/x86-64/x86-64-accton-as6812-32x/platform-config/r0/src/python/x86_64_accton_as6812_32x_r0/__init__.py
+++ b/packages/platforms/accton/x86-64/x86-64-accton-as6812-32x/platform-config/r0/src/python/x86_64_accton_as6812_32x_r0/__init__.py
@@ -8,10 +8,9 @@ class OnlPlatform_x86_64_accton_as6812_32x_r0(OnlPlatformAccton,
     SYS_OBJECT_ID=".6812.32"
 
     def baseconfig(self):
-        self.insmod('optoe')
         self.insmod('cpr_4011_4mxx')
         self.insmod("ym2651y")
-        for m in [ 'cpld', 'fan', 'psu', 'leds' ]:
+        for m in [ 'cpld', 'fan', 'psu', 'leds', 'sfp' ]:
             self.insmod("x86-64-accton-as6812-32x-%s.ko" % m)
 
         ########### initialize I2C bus 0 ###########
@@ -26,8 +25,9 @@ class OnlPlatform_x86_64_accton_as6812_32x_r0(OnlPlatformAccton,
 
         # initialize QSFP port 1~32
         for port in range(1, 33):
-            self.new_i2c_device('optoe1', 0x50, port+1)
-            subprocess.call('echo port%d > /sys/bus/i2c/devices/%d-0050/port_name' % (port, port+1), shell=True)
+            self.new_i2c_device('as6812_32x_port%d' % port,
+                                0x50,
+                                port+1)
 
         ########### initialize I2C bus 1 ###########
         self.new_i2c_devices(


### PR DESCRIPTION
Reverts opencomputeproject/OpenNetworkLinux#339

@brandonchuang These changes must be reverted as they are currently breaking the proper reading and identification of some fiber modules.