### PR TITLE
[Accton as7326_56x] Fixed upon comment of PR 347

### DIFF
--- a/packages/platforms/accton/x86-64/x86-64-accton-as7326-56x/onlp/builds/src/module/src/platform_lib.c
+++ b/packages/platforms/accton/x86-64/x86-64-accton-as7326-56x/onlp/builds/src/module/src/platform_lib.c
@@ -5,41 +5,12 @@
 #include "x86_64_accton_as7326_56x_log.h"
 
 
-static int _onlp_file_write(char *filename, char *buffer, int buf_size, int data_len)
-{
-    int fd;
-    int len;
-
-    if ((buffer == NULL) || (buf_size < 0)) {
-        return -1;
-    }
-
-    if ((fd = open(filename, O_WRONLY, S_IWUSR)) == -1) {
-        return -1;
-    }
-
-    if ((len = write(fd, buffer, buf_size)) < 0) {
-        close(fd);
-        return -1;
-    }
-
-    if ((close(fd) == -1)) {
-        return -1;
-    }
-
-    if ((len > buf_size) || (data_len != 0 && len != data_len)) {
-        return -1;
-    }
-
-    return 0;
-}
-
 int onlp_file_write_integer(char *filename, int value)
 {
     char buf[8] = {0};
     sprintf(buf, "%d", value);
 
-    return _onlp_file_write(filename, buf, (int)strlen(buf), 0);
+    return onlp_file_write((uint8_t*)buf, strlen(buf), filename);
 }
 
 int onlp_file_read_binary(char *filename, char *buffer, int buf_size, int data_len)

--- a/packages/platforms/accton/x86-64/x86-64-accton-as7326-56x/platform-config/r0/src/python/x86_64_accton_as7326_56x_r0/__init__.py
+++ b/packages/platforms/accton/x86-64/x86-64-accton-as7326-56x/platform-config/r0/src/python/x86_64_accton_as7326_56x_r0/__init__.py
@@ -6,7 +6,7 @@ class OnlPlatform_x86_64_accton_as7326_56x_r0(OnlPlatformAccton,
 
     PLATFORM='x86-64-accton-as7326-56x-r0'
     MODEL="AS7326-56X"
-    SYS_OBJECT_ID=".7326.54"
+    SYS_OBJECT_ID=".7326.56"
 
     def baseconfig(self):
         self.insmod('optoe')


### PR DESCRIPTION
By the comment of https://github.com/opencomputeproject/OpenNetworkLinux/pull/347,
commit for
1. correct SYS_OBJECT_ID.
2. replace local file write API to one in onlplib.

Signed-off-by: roy_lee <roy_lee@accton.com>