### PR TITLE
4/4 - "B" platforms (40Gb vs 100Gb) support: MSN2410B, MSN2700B, MSN2740B

### DIFF
--- a/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2410/onlp/builds/src/module/src/sysi.c
+++ b/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2410/onlp/builds/src/module/src/sysi.c
@@ -74,6 +74,12 @@ onlp_sysi_platform_set(const char* platform)
         mc_get_platform_info(mlnx_platform);
         return ONLP_STATUS_OK;
     }
+    if(!strcmp(platform, "x86-64-mlnx-msn2410b-r0")) {
+        __ONL_PLATFORM_NAME = "x86-64-mlnx_msn2410b-r0";
+        mlnx_platform = get_platform_info();
+        mc_get_platform_info(mlnx_platform);
+        return ONLP_STATUS_OK;
+    }
     if(!strcmp(platform, "x86-64-mlnx-msn2410-all")) {
         __ONL_PLATFORM_NAME = "x86-64-mlnx-msn2410-all";
         return ONLP_STATUS_OK;

--- a/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2410b/.gitignore
+++ b/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2410b/.gitignore
@@ -1,0 +1,3 @@
+*x86-64*.mk
+*x86_64*.mk
+onlpdump.mk

--- a/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2410b/Makefile
+++ b/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2410b/Makefile
@@ -1,0 +1,1 @@
+include $(ONL)/make/pkg.mk

--- a/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2410b/modules/Makefile
+++ b/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2410b/modules/Makefile
@@ -1,0 +1,1 @@
+include $(ONL)/make/pkg.mk

--- a/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2410b/modules/PKG.yml
+++ b/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2410b/modules/PKG.yml
@@ -1,0 +1,1 @@
+!include $ONL_TEMPLATES/no-platform-modules.yml ARCH=amd64 VENDOR=mellanox BASENAME=x86-64-mlnx-msn2410b

--- a/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2410b/onlp/Makefile
+++ b/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2410b/onlp/Makefile
@@ -1,0 +1,1 @@
+include $(ONL)/make/pkg.mk

--- a/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2410b/onlp/PKG.yml
+++ b/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2410b/onlp/PKG.yml
@@ -1,0 +1,1 @@
+!include $ONL_TEMPLATES/onlp-platform-any.yml PLATFORM=x86-64-mlnx-msn2410b ARCH=amd64 TOOLCHAIN=x86_64-linux-gnu

--- a/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2410b/onlp/builds/Makefile
+++ b/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2410b/onlp/builds/Makefile
@@ -1,0 +1,2 @@
+FILTER=src
+include $(ONL)/make/subdirs.mk

--- a/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2410b/onlp/builds/lib/Makefile
+++ b/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2410b/onlp/builds/lib/Makefile
@@ -1,0 +1,45 @@
+############################################################
+# <bsn.cl fy=2014 v=onl>
+#
+#           Copyright 2014 BigSwitch Networks, Inc.
+#
+# Licensed under the Eclipse Public License, Version 1.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#        http://www.eclipse.org/legal/epl-v10.html
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the
+# License.
+#
+# </bsn.cl>
+############################################################
+#
+#
+############################################################
+include $(ONL)/make/config.amd64.mk
+
+MODULE := libonlp-x86-64-mlnx-msn2410b
+include $(BUILDER)/standardinit.mk
+
+DEPENDMODULES := AIM IOF mlnx_common x86_64_mlnx_msn2410 onlplib
+DEPENDMODULE_HEADERS := sff
+
+include $(BUILDER)/dependmodules.mk
+
+SHAREDLIB := libonlp-x86-64-mlnx-msn2410b.so
+$(SHAREDLIB)_TARGETS := $(ALL_TARGETS)
+include $(BUILDER)/so.mk
+.DEFAULT_GOAL := $(SHAREDLIB)
+
+GLOBAL_CFLAGS += -I$(onlp_BASEDIR)/module/inc
+GLOBAL_CFLAGS += -I$(mlnx_common_BASEDIR)/module/inc
+GLOBAL_CFLAGS += -DAIM_CONFIG_INCLUDE_MODULES_INIT=1
+GLOBAL_CFLAGS += -fPIC
+GLOBAL_LINK_LIBS += -lpthread
+
+include $(BUILDER)/targets.mk

--- a/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2410b/onlp/builds/onlpdump/Makefile
+++ b/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2410b/onlp/builds/onlpdump/Makefile
@@ -1,0 +1,46 @@
+############################################################
+# <bsn.cl fy=2014 v=onl>
+#
+#           Copyright 2014 BigSwitch Networks, Inc.
+#
+# Licensed under the Eclipse Public License, Version 1.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#        http://www.eclipse.org/legal/epl-v10.html
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the
+# License.
+#
+# </bsn.cl>
+############################################################
+#
+#
+#
+############################################################
+include $(ONL)/make/config.amd64.mk
+
+.DEFAULT_GOAL := onlpdump
+
+MODULE := onlpdump
+include $(BUILDER)/standardinit.mk
+
+DEPENDMODULES := AIM IOF onlp mlnx_common x86_64_mlnx_msn2410 onlplib onlp_platform_defaults sff cjson cjson_util timer_wheel OS
+
+include $(BUILDER)/dependmodules.mk
+
+BINARY := onlpdump
+$(BINARY)_LIBRARIES := $(LIBRARY_TARGETS)
+include $(BUILDER)/bin.mk
+
+GLOBAL_CFLAGS += -DAIM_CONFIG_AIM_MAIN_FUNCTION=onlpdump_main
+GLOBAL_CFLAGS += -DAIM_CONFIG_INCLUDE_MODULES_INIT=1
+GLOBAL_CFLAGS += -DAIM_CONFIG_INCLUDE_MAIN=1
+GLOBAL_CFLAGS += -I$(mlnx_common_BASEDIR)/module/inc
+GLOBAL_LINK_LIBS += -lpthread -lm
+
+include $(BUILDER)/targets.mk

--- a/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2410b/platform-config/Makefile
+++ b/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2410b/platform-config/Makefile
@@ -1,0 +1,1 @@
+include $(ONL)/make/pkg.mk

--- a/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2410b/platform-config/r0/Makefile
+++ b/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2410b/platform-config/r0/Makefile
@@ -1,0 +1,1 @@
+include $(ONL)/make/pkg.mk

--- a/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2410b/platform-config/r0/PKG.yml
+++ b/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2410b/platform-config/r0/PKG.yml
@@ -1,0 +1,1 @@
+!include $ONL_TEMPLATES/platform-config-platform.yml ARCH=amd64 VENDOR=mellanox BASENAME=x86-64-mlnx-msn2410b REVISION=r0

--- a/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2410b/platform-config/r0/src/lib/x86-64-mlnx-msn2410b-r0.yml
+++ b/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2410b/platform-config/r0/src/lib/x86-64-mlnx-msn2410b-r0.yml
@@ -1,0 +1,36 @@
+---
+
+######################################################################
+#
+# platform-config for Mellanox 2410B
+#
+######################################################################
+
+x86-64-mlnx-msn2410b-r0:
+
+  grub:
+
+    serial: >-
+      --unit=0
+      --speed=115200
+      --word=8
+      --parity=0
+      --stop=1
+
+    kernel:
+      <<: *kernel-4-9
+
+    args: >-
+      nopat
+      console=ttyS0,115200n8
+      rd_NO_MD
+      rd_NO_LUKS
+      acpi_enforce_resources=lax
+      acpi=noirq
+      i2c-ismt.enable=0
+
+  ##network
+  ##  interfaces:
+  ##    ma1:
+  ##      name: ~
+  ##      syspath: pci0000:00/0000:00:14.0

--- a/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2410b/platform-config/r0/src/python/x86_64_mlnx_msn2410b_r0/__init__.py
+++ b/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2410b/platform-config/r0/src/python/x86_64_mlnx_msn2410b_r0/__init__.py
@@ -1,0 +1,17 @@
+from onl.platform.base import *
+from onl.platform.mellanox import *
+
+class OnlPlatform_x86_64_mlnx_msn2410b_r0(OnlPlatformMellanox,
+                                           OnlPlatformPortConfig_32x40):
+    PLATFORM='x86-64-mlnx-msn2410b-r0'
+    MODEL="MSN2410B"
+    SYS_OBJECT_ID=".2410.2"
+
+    def baseconfig(self):
+        # load modules
+        import os
+        # necessary if there are issues with the install
+        # os.system("/usr/bin/apt-get install")
+        os.system("/etc/mlnx/mlnx-hw-management start")
+        self.syseeprom_export();
+        return True

--- a/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2700/onlp/builds/src/module/src/sysi.c
+++ b/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2700/onlp/builds/src/module/src/sysi.c
@@ -74,6 +74,12 @@ onlp_sysi_platform_set(const char* platform)
         mc_get_platform_info(mlnx_platform);
         return ONLP_STATUS_OK;
     }
+    if(!strcmp(platform, "x86-64-mlnx-msn2700b-r0")) {
+        __ONL_PLATFORM_NAME = "x86-64-mlnx_msn2700b-r0";
+        mlnx_platform = get_platform_info();
+        mc_get_platform_info(mlnx_platform);
+        return ONLP_STATUS_OK;
+    }
     if(!strcmp(platform, "x86-64-mlnx-msn2700-all")) {
         __ONL_PLATFORM_NAME = "x86-64-mlnx-msn2700-all";
         return ONLP_STATUS_OK;

--- a/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2700b/.gitignore
+++ b/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2700b/.gitignore
@@ -1,0 +1,3 @@
+*x86-64*.mk
+*x86_64*.mk
+onlpdump.mk

--- a/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2700b/Makefile
+++ b/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2700b/Makefile
@@ -1,0 +1,1 @@
+include $(ONL)/make/pkg.mk

--- a/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2700b/modules/Makefile
+++ b/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2700b/modules/Makefile
@@ -1,0 +1,1 @@
+include $(ONL)/make/pkg.mk

--- a/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2700b/modules/PKG.yml
+++ b/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2700b/modules/PKG.yml
@@ -1,0 +1,1 @@
+!include $ONL_TEMPLATES/no-platform-modules.yml ARCH=amd64 VENDOR=mellanox BASENAME=x86-64-mlnx-msn2700b

--- a/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2700b/onlp/Makefile
+++ b/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2700b/onlp/Makefile
@@ -1,0 +1,1 @@
+include $(ONL)/make/pkg.mk

--- a/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2700b/onlp/PKG.yml
+++ b/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2700b/onlp/PKG.yml
@@ -1,0 +1,1 @@
+!include $ONL_TEMPLATES/onlp-platform-any.yml PLATFORM=x86-64-mlnx-msn2700b ARCH=amd64 TOOLCHAIN=x86_64-linux-gnu

--- a/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2700b/onlp/builds/Makefile
+++ b/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2700b/onlp/builds/Makefile
@@ -1,0 +1,2 @@
+FILTER=src
+include $(ONL)/make/subdirs.mk

--- a/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2700b/onlp/builds/lib/Makefile
+++ b/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2700b/onlp/builds/lib/Makefile
@@ -1,0 +1,45 @@
+############################################################
+# <bsn.cl fy=2014 v=onl>
+#
+#           Copyright 2014 BigSwitch Networks, Inc.
+#
+# Licensed under the Eclipse Public License, Version 1.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#        http://www.eclipse.org/legal/epl-v10.html
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the
+# License.
+#
+# </bsn.cl>
+############################################################
+#
+#
+############################################################
+include $(ONL)/make/config.amd64.mk
+
+MODULE := libonlp-x86-64-mlnx-msn2700b
+include $(BUILDER)/standardinit.mk
+
+DEPENDMODULES := AIM IOF mlnx_common x86_64_mlnx_msn2700 onlplib
+DEPENDMODULE_HEADERS := sff
+
+include $(BUILDER)/dependmodules.mk
+
+SHAREDLIB := libonlp-x86-64-mlnx-msn2700b.so
+$(SHAREDLIB)_TARGETS := $(ALL_TARGETS)
+include $(BUILDER)/so.mk
+.DEFAULT_GOAL := $(SHAREDLIB)
+
+GLOBAL_CFLAGS += -I$(onlp_BASEDIR)/module/inc
+GLOBAL_CFLAGS += -I$(mlnx_common_BASEDIR)/module/inc
+GLOBAL_CFLAGS += -DAIM_CONFIG_INCLUDE_MODULES_INIT=1
+GLOBAL_CFLAGS += -fPIC
+GLOBAL_LINK_LIBS += -lpthread
+
+include $(BUILDER)/targets.mk

--- a/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2700b/onlp/builds/onlpdump/Makefile
+++ b/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2700b/onlp/builds/onlpdump/Makefile
@@ -1,0 +1,46 @@
+############################################################
+# <bsn.cl fy=2014 v=onl>
+#
+#           Copyright 2014 BigSwitch Networks, Inc.
+#
+# Licensed under the Eclipse Public License, Version 1.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#        http://www.eclipse.org/legal/epl-v10.html
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the
+# License.
+#
+# </bsn.cl>
+############################################################
+#
+#
+#
+############################################################
+include $(ONL)/make/config.amd64.mk
+
+.DEFAULT_GOAL := onlpdump
+
+MODULE := onlpdump
+include $(BUILDER)/standardinit.mk
+
+DEPENDMODULES := AIM IOF onlp mlnx_common x86_64_mlnx_msn2700 onlplib onlp_platform_defaults sff cjson cjson_util timer_wheel OS
+
+include $(BUILDER)/dependmodules.mk
+
+BINARY := onlpdump
+$(BINARY)_LIBRARIES := $(LIBRARY_TARGETS)
+include $(BUILDER)/bin.mk
+
+GLOBAL_CFLAGS += -DAIM_CONFIG_AIM_MAIN_FUNCTION=onlpdump_main
+GLOBAL_CFLAGS += -DAIM_CONFIG_INCLUDE_MODULES_INIT=1
+GLOBAL_CFLAGS += -DAIM_CONFIG_INCLUDE_MAIN=1
+GLOBAL_CFLAGS += -I$(mlnx_common_BASEDIR)/module/inc
+GLOBAL_LINK_LIBS += -lpthread -lm
+
+include $(BUILDER)/targets.mk

--- a/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2700b/platform-config/Makefile
+++ b/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2700b/platform-config/Makefile
@@ -1,0 +1,1 @@
+include $(ONL)/make/pkg.mk

--- a/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2700b/platform-config/r0/Makefile
+++ b/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2700b/platform-config/r0/Makefile
@@ -1,0 +1,1 @@
+include $(ONL)/make/pkg.mk

--- a/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2700b/platform-config/r0/PKG.yml
+++ b/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2700b/platform-config/r0/PKG.yml
@@ -1,0 +1,1 @@
+!include $ONL_TEMPLATES/platform-config-platform.yml ARCH=amd64 VENDOR=mellanox BASENAME=x86-64-mlnx-msn2700b REVISION=r0

--- a/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2700b/platform-config/r0/src/lib/x86-64-mlnx-msn2700b-r0.yml
+++ b/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2700b/platform-config/r0/src/lib/x86-64-mlnx-msn2700b-r0.yml
@@ -1,0 +1,36 @@
+---
+
+######################################################################
+#
+# platform-config for Mellanox 2700B
+#
+######################################################################
+
+x86-64-mlnx-msn2700b-r0:
+
+  grub:
+
+    serial: >-
+      --unit=0
+      --speed=115200
+      --word=8
+      --parity=0
+      --stop=1
+
+    kernel:
+      <<: *kernel-4-9
+
+    args: >-
+      nopat
+      console=ttyS0,115200n8
+      rd_NO_MD
+      rd_NO_LUKS
+      acpi_enforce_resources=lax
+      acpi=noirq
+      i2c-ismt.enable=0
+
+  ##network
+  ##  interfaces:
+  ##    ma1:
+  ##      name: ~
+  ##      syspath: pci0000:00/0000:00:14.0

--- a/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2700b/platform-config/r0/src/python/x86_64_mlnx_msn2700b_r0/__init__.py
+++ b/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2700b/platform-config/r0/src/python/x86_64_mlnx_msn2700b_r0/__init__.py
@@ -1,0 +1,17 @@
+from onl.platform.base import *
+from onl.platform.mellanox import *
+
+class OnlPlatform_x86_64_mlnx_msn2700b_r0(OnlPlatformMellanox,
+                                           OnlPlatformPortConfig_32x40):
+    PLATFORM='x86-64-mlnx-msn2700b-r0'
+    MODEL="MSN2700B"
+    SYS_OBJECT_ID=".2700.2"
+
+    def baseconfig(self):
+        # load modules
+        import os
+        # necessary if there are issues with the install
+        # os.system("/usr/bin/apt-get install")
+        os.system("/etc/mlnx/mlnx-hw-management start")
+        self.syseeprom_export();
+        return True

--- a/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2740/onlp/builds/src/module/src/sysi.c
+++ b/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2740/onlp/builds/src/module/src/sysi.c
@@ -74,6 +74,12 @@ onlp_sysi_platform_set(const char* platform)
         mc_get_platform_info(mlnx_platform);
         return ONLP_STATUS_OK;
     }
+    if(!strcmp(platform, "x86-64-mlnx-msn2740b-r0")) {
+        __ONL_PLATFORM_NAME = "x86-64-mlnx_msn2740b-r0";
+        mlnx_platform = get_platform_info();
+        mc_get_platform_info(mlnx_platform);
+        return ONLP_STATUS_OK;
+    }
     if(!strcmp(platform, "x86-64-mlnx-msn2740-all")) {
         __ONL_PLATFORM_NAME = "x86-64-mlnx-msn2740-all";
         return ONLP_STATUS_OK;

--- a/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2740b/.gitignore
+++ b/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2740b/.gitignore
@@ -1,0 +1,3 @@
+*x86-64*.mk
+*x86_64*.mk
+onlpdump.mk

--- a/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2740b/Makefile
+++ b/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2740b/Makefile
@@ -1,0 +1,1 @@
+include $(ONL)/make/pkg.mk

--- a/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2740b/modules/Makefile
+++ b/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2740b/modules/Makefile
@@ -1,0 +1,1 @@
+include $(ONL)/make/pkg.mk

--- a/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2740b/modules/PKG.yml
+++ b/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2740b/modules/PKG.yml
@@ -1,0 +1,1 @@
+!include $ONL_TEMPLATES/no-platform-modules.yml ARCH=amd64 VENDOR=mellanox BASENAME=x86-64-mlnx-msn2740b

--- a/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2740b/onlp/Makefile
+++ b/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2740b/onlp/Makefile
@@ -1,0 +1,1 @@
+include $(ONL)/make/pkg.mk

--- a/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2740b/onlp/PKG.yml
+++ b/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2740b/onlp/PKG.yml
@@ -1,0 +1,1 @@
+!include $ONL_TEMPLATES/onlp-platform-any.yml PLATFORM=x86-64-mlnx-msn2740b ARCH=amd64 TOOLCHAIN=x86_64-linux-gnu

--- a/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2740b/onlp/builds/Makefile
+++ b/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2740b/onlp/builds/Makefile
@@ -1,0 +1,2 @@
+FILTER=src
+include $(ONL)/make/subdirs.mk

--- a/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2740b/onlp/builds/lib/Makefile
+++ b/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2740b/onlp/builds/lib/Makefile
@@ -1,0 +1,45 @@
+############################################################
+# <bsn.cl fy=2014 v=onl>
+#
+#           Copyright 2014 BigSwitch Networks, Inc.
+#
+# Licensed under the Eclipse Public License, Version 1.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#        http://www.eclipse.org/legal/epl-v10.html
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the
+# License.
+#
+# </bsn.cl>
+############################################################
+#
+#
+############################################################
+include $(ONL)/make/config.amd64.mk
+
+MODULE := libonlp-x86-64-mlnx-msn2740b
+include $(BUILDER)/standardinit.mk
+
+DEPENDMODULES := AIM IOF mlnx_common x86_64_mlnx_msn2740 onlplib
+DEPENDMODULE_HEADERS := sff
+
+include $(BUILDER)/dependmodules.mk
+
+SHAREDLIB := libonlp-x86-64-mlnx-msn2740b.so
+$(SHAREDLIB)_TARGETS := $(ALL_TARGETS)
+include $(BUILDER)/so.mk
+.DEFAULT_GOAL := $(SHAREDLIB)
+
+GLOBAL_CFLAGS += -I$(onlp_BASEDIR)/module/inc
+GLOBAL_CFLAGS += -I$(mlnx_common_BASEDIR)/module/inc
+GLOBAL_CFLAGS += -DAIM_CONFIG_INCLUDE_MODULES_INIT=1
+GLOBAL_CFLAGS += -fPIC
+GLOBAL_LINK_LIBS += -lpthread
+
+include $(BUILDER)/targets.mk

--- a/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2740b/onlp/builds/onlpdump/Makefile
+++ b/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2740b/onlp/builds/onlpdump/Makefile
@@ -1,0 +1,46 @@
+############################################################
+# <bsn.cl fy=2014 v=onl>
+#
+#           Copyright 2014 BigSwitch Networks, Inc.
+#
+# Licensed under the Eclipse Public License, Version 1.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#        http://www.eclipse.org/legal/epl-v10.html
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific
+# language governing permissions and limitations under the
+# License.
+#
+# </bsn.cl>
+############################################################
+#
+#
+#
+############################################################
+include $(ONL)/make/config.amd64.mk
+
+.DEFAULT_GOAL := onlpdump
+
+MODULE := onlpdump
+include $(BUILDER)/standardinit.mk
+
+DEPENDMODULES := AIM IOF onlp mlnx_common x86_64_mlnx_msn2740 onlplib onlp_platform_defaults sff cjson cjson_util timer_wheel OS
+
+include $(BUILDER)/dependmodules.mk
+
+BINARY := onlpdump
+$(BINARY)_LIBRARIES := $(LIBRARY_TARGETS)
+include $(BUILDER)/bin.mk
+
+GLOBAL_CFLAGS += -DAIM_CONFIG_AIM_MAIN_FUNCTION=onlpdump_main
+GLOBAL_CFLAGS += -DAIM_CONFIG_INCLUDE_MODULES_INIT=1
+GLOBAL_CFLAGS += -DAIM_CONFIG_INCLUDE_MAIN=1
+GLOBAL_CFLAGS += -I$(mlnx_common_BASEDIR)/module/inc
+GLOBAL_LINK_LIBS += -lpthread -lm
+
+include $(BUILDER)/targets.mk

--- a/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2740b/platform-config/Makefile
+++ b/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2740b/platform-config/Makefile
@@ -1,0 +1,1 @@
+include $(ONL)/make/pkg.mk

--- a/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2740b/platform-config/r0/Makefile
+++ b/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2740b/platform-config/r0/Makefile
@@ -1,0 +1,1 @@
+include $(ONL)/make/pkg.mk

--- a/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2740b/platform-config/r0/PKG.yml
+++ b/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2740b/platform-config/r0/PKG.yml
@@ -1,0 +1,1 @@
+!include $ONL_TEMPLATES/platform-config-platform.yml ARCH=amd64 VENDOR=mellanox BASENAME=x86-64-mlnx-msn2740b REVISION=r0

--- a/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2740b/platform-config/r0/src/lib/x86-64-mlnx-msn2740b-r0.yml
+++ b/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2740b/platform-config/r0/src/lib/x86-64-mlnx-msn2740b-r0.yml
@@ -1,0 +1,36 @@
+---
+
+######################################################################
+#
+# platform-config for Mellanox 2740B
+#
+######################################################################
+
+x86-64-mlnx-msn2740b-r0:
+
+  grub:
+
+    serial: >-
+      --unit=0
+      --speed=115200
+      --word=8
+      --parity=0
+      --stop=1
+
+    kernel:
+      <<: *kernel-4-9
+
+    args: >-
+      nopat
+      console=ttyS0,115200n8
+      rd_NO_MD
+      rd_NO_LUKS
+      acpi_enforce_resources=lax
+      acpi=noirq
+      i2c-ismt.enable=0
+
+  ##network
+  ##  interfaces:
+  ##    ma1:
+  ##      name: ~
+  ##      syspath: pci0000:00/0000:00:14.0

--- a/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2740b/platform-config/r0/src/python/x86_64_mlnx_msn2740b_r0/__init__.py
+++ b/packages/platforms/mellanox/x86-64/x86-64-mlnx-msn2740b/platform-config/r0/src/python/x86_64_mlnx_msn2740b_r0/__init__.py
@@ -1,0 +1,17 @@
+from onl.platform.base import *
+from onl.platform.mellanox import *
+
+class OnlPlatform_x86_64_mlnx_msn2740b_r0(OnlPlatformMellanox,
+                                           OnlPlatformPortConfig_32x40):
+    PLATFORM='x86-64-mlnx-msn2740b-r0'
+    MODEL="MSN2740B"
+    SYS_OBJECT_ID=".2740.2"
+
+    def baseconfig(self):
+        # load modules
+        import os
+        # necessary if there are issues with the install
+        # os.system("/usr/bin/apt-get install")
+        os.system("/etc/mlnx/mlnx-hw-management start")
+        self.syseeprom_export();
+        return True


### PR DESCRIPTION
This is 4-th of four pull requests:

 1. Mellanox common code restructuring. MSN2100, MSN2410, MSN2700 platforms support
 2. MSN2740 platform support
 3. MSN2010 platform support
 4. "B" platforms (40Gb vs 100Gb) support: MSN2410B, MSN2700B, MSN2740B

Signed-off-by: Nataliya Yakuts nataliyay@mellanox.com
Reviewed-by: Michael Shych michaelsh@mellanox.com