### PR TITLE
Add watchdog.conf by default

### DIFF
--- a/packages/base/all/initrds/loader-initrd-files/src/etc/watchdog.conf
+++ b/packages/base/all/initrds/loader-initrd-files/src/etc/watchdog.conf
@@ -1,0 +1,52 @@
+#ping                   = 172.31.14.1
+#ping                   = 172.26.1.255
+#interface              = eth0
+#file                   = /var/log/messages
+#change                 = 1407
+
+# Uncomment to enable test. Setting one of these values to '0' disables it.
+# These values will hopefully never reboot your machine during normal use
+# (if your machine is really hung, the loadavg will go much higher than 25)
+#max-load-1             = 24
+#max-load-5             = 18
+#max-load-15            = 12
+
+# Note that this is the number of pages!
+# To get the real size, check how large the pagesize is on your machine.
+#min-memory             = 1
+
+#repair-binary          = /usr/sbin/repair
+#repair-timeout         =
+#test-binary            =
+#test-timeout           =
+
+# Set the watchdog device name. Default is to disable keep alive support.
+watchdog-device        = /dev/watchdog
+
+# Set the watchdog device timeout during startup
+watchdog-timeout       = 30
+
+# Defaults compiled into the binary
+#temperature-device     =
+#max-temperature        = 120
+
+# Defaults compiled into the binary
+#admin                  = root
+
+# Set the interval between two writes to the watchdog device.
+interval                = 5
+
+#logtick                = 1
+#log-dir                = /var/log/watchdog
+
+# This greatly decreases the chance that watchdog won't be scheduled before
+# your machine is really loaded
+
+# If set to yes watchdog will lock itself into memory so it is never swapped out.
+realtime                = yes
+
+# Set the schedule priority for realtime mode.
+priority                = 1
+
+# Check if syslogd is still running by enabling the following line
+#pidfile                = /var/run/syslogd.pid


### PR DESCRIPTION
- Enable watchdog device
- The timeout of WD is 30s
- Interval is 5s
- Enable realtime
- Setting the priority is 1

Signed-off-by: Phil Huang <phil_huang@edge-core.com>