### PR TITLE
Fixed bug of showing shifted SFP EEPROM data

### DIFF
--- a/packages/platforms/accton/x86-64/x86-64-accton-wedge100bf-32x/onlp/builds/src/module/src/sfpi.c
+++ b/packages/platforms/accton/x86-64/x86-64-accton-wedge100bf-32x/onlp/builds/src/module/src/sfpi.c
@@ -177,8 +177,8 @@ sfpi_eeprom_read(int port, uint8_t devaddr, uint8_t data[256])
             return ONLP_STATUS_E_INTERNAL;
         }
 
-        data[i]   = val & 0xff;
-        data[i+1] = (val >> 8) & 0xff;
+        data[i*2]   = val & 0xff;
+        data[(i*2)+1] = (val >> 8) & 0xff;
     }
 
     return ONLP_STATUS_OK;


### PR DESCRIPTION
Fixed bug of showing shifted SFP EEPROM data, by shifting value by 2 bytes.