### PR TITLE
Fixed SYSTEM LED RED and BLUE reversed wrong color issue

### DIFF
--- a/packages/platforms/accton/x86-64/x86-64-accton-wedge100bf-32x/onlp/builds/src/module/src/ledi.c
+++ b/packages/platforms/accton/x86-64/x86-64-accton-wedge100bf-32x/onlp/builds/src/module/src/ledi.c
@@ -67,12 +67,12 @@ static led_mode_info_t led_mode_info[] =
 {
     {ONLP_LED_MODE_OFF, 0x0},
     {ONLP_LED_MODE_OFF, 0x8},
-    {ONLP_LED_MODE_RED, 0x1},
-    {ONLP_LED_MODE_RED_BLINKING, 0x9},
+    {ONLP_LED_MODE_BLUE, 0x1},
+    {ONLP_LED_MODE_BLUE_BLINKING, 0x9},
     {ONLP_LED_MODE_GREEN, 0x2},
     {ONLP_LED_MODE_GREEN_BLINKING, 0xa},
-    {ONLP_LED_MODE_BLUE, 0x4},
-    {ONLP_LED_MODE_BLUE_BLINKING, 0xc},
+    {ONLP_LED_MODE_RED, 0x4},
+    {ONLP_LED_MODE_RED_BLINKING, 0xc},
 };
 
 /*


### PR DESCRIPTION
Changed the RED LED register value to Blue and changed the BLUE LED register value to Red.
Tested successfully and result is System LED1 and LED2 can blink and turn ON respectively with correct color using onlp_led_mode_set function. 