### PR TITLE
Fixed transcievers bitmap is not updated on removal issue

### DIFF
--- a/packages/base/any/onlp/src/onlp/module/src/sfp.c
+++ b/packages/base/any/onlp/src/onlp/module/src/sfp.c
@@ -110,6 +110,15 @@ ONLP_LOCKED_API1(onlp_sfp_is_present, int, port);
 static int
 onlp_sfp_presence_bitmap_get_locked__(onlp_sfp_bitmap_t* dst)
 {
+    
+    /* Initializing bit map variable to zero, before reading from port */
+    int count=0;
+    int max_size=0;
+    max_size = (sizeof(dst->words)/sizeof(dst->words[0]));
+    for(count=0;count<max_size;count++) {
+        dst->words[count]=0;
+    }
+
     int rv = onlp_sfpi_presence_bitmap_get(dst);
 
     if(rv == ONLP_STATUS_E_UNSUPPORTED) {


### PR DESCRIPTION
I have set the bitmap array to zero inside the called function "onlp_sfp_presence_bitmap_get_locked__" instead of setting to zero just before the calling function, as this function is called from more than one source file.   Tested on barefoot wedge100_32x device for tranceiver removal.