### PR TITLE
fixing the issue of wrong color of system LEDs

### DIFF
--- a/packages/platforms/accton/x86-64/x86-64-accton-wedge100bf-65x/onlp/builds/src/module/src/ledi.c
+++ b/packages/platforms/accton/x86-64/x86-64-accton-wedge100bf-65x/onlp/builds/src/module/src/ledi.c
@@ -67,12 +67,12 @@ static led_mode_info_t led_mode_info[] =
 {
     {ONLP_LED_MODE_OFF, 0x0},
     {ONLP_LED_MODE_OFF, 0x8},
-    {ONLP_LED_MODE_RED, 0x1},
-    {ONLP_LED_MODE_RED_BLINKING, 0x9},
+    {ONLP_LED_MODE_BLUE, 0x1},
+    {ONLP_LED_MODE_BLUE_BLINKING, 0x9},
     {ONLP_LED_MODE_GREEN, 0x2},
     {ONLP_LED_MODE_GREEN_BLINKING, 0xa},
-    {ONLP_LED_MODE_BLUE, 0x4},
-    {ONLP_LED_MODE_BLUE_BLINKING, 0xc},
+    {ONLP_LED_MODE_RED, 0x4},
+    {ONLP_LED_MODE_RED_BLINKING, 0xc},
 };
 
 /*


### PR DESCRIPTION
Interchanged the color codes of System LED1 and System LED2 for Blue and Red color for Wedge100 Barefoot 65x.