### PR TITLE
Fixed onlp_sfp_eeprom_read shifts QSFP EEPROM data

### DIFF
--- a/packages/platforms/accton/x86-64/x86-64-accton-wedge100bf-65x/onlp/builds/src/module/src/sfpi.c
+++ b/packages/platforms/accton/x86-64/x86-64-accton-wedge100bf-65x/onlp/builds/src/module/src/sfpi.c
@@ -214,8 +214,8 @@ sfpi_eeprom_read(int port, uint8_t devaddr, uint8_t data[256])
             return ONLP_STATUS_E_INTERNAL;
         }
 
-        data[i]   = val & 0xff;
-        data[i+1] = (val >> 8) & 0xff;
+        data[i*2]   = val & 0xff;
+        data[(i*2)+1] = (val >> 8) & 0xff;
     }
 
     return ONLP_STATUS_OK;


### PR DESCRIPTION
Replaced data[i] and data[i+1] with data[i2] and data[(i2)+1] respectively in sfpi.c file. After replacing, connected the innolight transceiver to Accton Wedge100BF_65x SFP port to read the SFP EEPROM and data can be read correctly. 