### PR TITLE
rfs: fix bug that bash doesn't return on error

### DIFF
--- a/tools/onlrfs.py
+++ b/tools/onlrfs.py
@@ -389,8 +389,7 @@ class OnlRfsBuilder(object):
         script = os.path.join(dir_, "tmp/configure.sh")
         with open(script, "w") as f:
             os.chmod(script, 0700)
-            f.write("""
-#!/bin/bash -ex
+            f.write("""#!/bin/bash -ex
 /bin/echo -e "#!/bin/sh\\nexit 101" >/usr/sbin/policy-rc.d
 chmod +x /usr/sbin/policy-rc.d
 export DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
bash doesn't respect -ex flags when it is not written in the first line

Signed-off-by: Wataru Ishida <ishida@nel-america.com>