### PR TITLE
Assorted set of fixes and improvements to ONL

### DIFF
--- a/builds/any/rootfs/jessie/common/all-base-packages.yml
+++ b/builds/any/rootfs/jessie/common/all-base-packages.yml
@@ -8,6 +8,8 @@
 - python
 - apt
 - apt-utils
+- debconf
+- dialog
 - procps
 - net-tools
 - iputils-ping

--- a/builds/any/rootfs/stretch/common/all-base-packages.yml
+++ b/builds/any/rootfs/stretch/common/all-base-packages.yml
@@ -8,6 +8,8 @@
 - python
 - apt
 - apt-utils
+- debconf
+- dialog
 - procps
 - net-tools
 - iputils-ping

--- a/builds/any/rootfs/wheezy/common/all-base-packages.yml
+++ b/builds/any/rootfs/wheezy/common/all-base-packages.yml
@@ -7,6 +7,8 @@
 - python
 - apt
 - apt-utils
+- debconf
+- dialog
 - procps
 - net-tools
 - iputils-ping

--- a/packages/base/all/initrds/loader-initrd-files/src/bin/ifup
+++ b/packages/base/all/initrds/loader-initrd-files/src/bin/ifup
@@ -44,18 +44,21 @@ if [ "${NETHW}" ]; then
     ip link set dev ${NETDEV} addr ${NETHW}
 fi
 
-# Default DHCP timeout is 10 requests in 10 seconds.
-NETRETRIES_DEFAULT=10
-NETRETRIES=${NETRETRIES:-$NETRETRIES_DEFAULT}
-if [ "$NETRETRIES" = "infinite" ]; then
-    NETRETRIES=
-elif [ $(echo "$NETRETRIES" | tr -d '[:digit:]') ] || [ "$NETRETRIES" -lt 0 ]; then
-    echo "Warning: the NETRETRIES setting is currently '$NETRETRIES'. This is invalid and the default value of $NETRETRIES_DEFAULT will be used instead."
-    NETRETRIES=$NETRETRIES_DEFAULT
-fi
 case "${NETAUTO}" in
     dhcp|auto)
+        # Default DHCP timeout is 10 requests in 10 seconds.
+        NETRETRIES_DEFAULT=10
+        NETRETRIES=${NETRETRIES:-$NETRETRIES_DEFAULT}
+        if [ "$NETRETRIES" = "infinite" ]; then
+            NETRETRIES=
+        elif [ $(echo "$NETRETRIES" | tr -d '[:digit:]') ] || [ "$NETRETRIES" -lt 0 ]; then
+            echo "Warning: the NETRETRIES setting is currently '$NETRETRIES'."
+            echo "This is invalid and the default value of $NETRETRIES_DEFAULT will be used instead."
+            NETRETRIES=$NETRETRIES_DEFAULT
+        fi
+
         echo 1 >/proc/sys/net/ipv6/conf/${NETDEV}/autoconf
+
         if [ -n "${NETRETRIES}" ]; then
             if ! udhcpc --retries $NETRETRIES --now -i ${NETDEV}; then
                 echo "**********************************************************************"

--- a/packages/base/all/initrds/loader-initrd-files/src/bin/ifup
+++ b/packages/base/all/initrds/loader-initrd-files/src/bin/ifup
@@ -81,6 +81,9 @@ case "${NETAUTO}" in
     up)
         ifconfig "${NETDEV}" up
         ;;
+    none)
+        exit 0
+        ;;
     *)
         if [ "${NETIP}" ] && [ "${NETMASK}" ] && [ "${NETIP#*/}" = "${NETIP}" ]; then
             NETIP=${NETIP}/$(ipcalc -p -s ${NETIP} ${NETMASK} | sed -n 's/PREFIX=//p')
@@ -118,6 +121,7 @@ for i in $(seq 30); do
     fi
     sleep 1
 done
+
 wait_link_up()
 {
     local intf=$1
@@ -144,4 +148,5 @@ wait_link_up()
 if [ -n "${NETAUTO}" ]; then
     wait_link_up $NETDEV 100
 fi
-return 0
+
+exit 0

--- a/packages/base/all/vendor-config-onl/src/python/onl/bootconfig/__init__.py
+++ b/packages/base/all/vendor-config-onl/src/python/onl/bootconfig/__init__.py
@@ -191,7 +191,7 @@ class OnlBootConfigNet(OnlBootConfig):
                 if not self.is_ip_address(netdns):
                     raise ValueError("NETDNS=%s is not a valid ip-address" % (netdns))
 
-        elif self.keys['NETAUTO'] not in ['dhcp', 'up']:
+        elif self.keys['NETAUTO'] not in ['dhcp', 'up', '']:
             raise ValueError("The NETAUTO value '%s' is invalid." % self.keys['NETAUTO'])
         elif self.keys['NETAUTO'] == 'up' and self.NET_REQUIRED:
             raise ValueError("NETAUTO is 'up' but non-local networking is required.")

--- a/packages/base/all/vendor-config-onl/src/python/onl/bootconfig/__init__.py
+++ b/packages/base/all/vendor-config-onl/src/python/onl/bootconfig/__init__.py
@@ -191,7 +191,7 @@ class OnlBootConfigNet(OnlBootConfig):
                 if not self.is_ip_address(netdns):
                     raise ValueError("NETDNS=%s is not a valid ip-address" % (netdns))
 
-        elif self.keys['NETAUTO'] not in ['dhcp', 'up', '']:
+        elif self.keys['NETAUTO'] not in ['dhcp', 'up', 'none', '']:
             raise ValueError("The NETAUTO value '%s' is invalid." % self.keys['NETAUTO'])
         elif self.keys['NETAUTO'] == 'up' and self.NET_REQUIRED:
             raise ValueError("NETAUTO is 'up' but non-local networking is required.")


### PR DESCRIPTION
With this series I present following fixes and improvements to base ONL system:

  1) Make ifup from initrds to skip when NETAUTO="none"  to support Debian networking configuration.
  2) Make NETRETRIES checks private to NETAUTO="dhcp" mode in ifup from initrds.
  3) Explicitly add debconf and dialog to base packages on all arches: debconf.

See individual commit description messages for more details on proposed changes.
