### PR TITLE
[as5916_54xm]Change a thermal sensor's i2c address from  0x48 to 0x4C.

### DIFF
--- a/packages/platforms/accton/x86-64/x86-64-accton-as5916-54xm/onlp/builds/src/module/src/thermali.c
+++ b/packages/platforms/accton/x86-64/x86-64-accton-as5916-54xm/onlp/builds/src/module/src/thermali.c
@@ -38,7 +38,7 @@ static char* devfiles__[] =  /* must map with onlp_thermal_id */
 {
     NULL,
     NULL,                  /* CPU_CORE files */
-    "/sys/bus/i2c/devices/10-0048*temp1_input",
+    "/sys/bus/i2c/devices/10-004c*temp1_input",
     "/sys/bus/i2c/devices/10-0049*temp1_input",
     "/sys/bus/i2c/devices/10-004a*temp1_input",
     "/sys/bus/i2c/devices/10-004b*temp1_input",
@@ -62,7 +62,7 @@ static onlp_thermal_info_t linfo[] = {
             ONLP_THERMAL_STATUS_PRESENT,
             ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
         },	
-	{ { ONLP_THERMAL_ID_CREATE(THERMAL_1_ON_MAIN_BROAD), "LM75-1-48", 0}, 
+	{ { ONLP_THERMAL_ID_CREATE(THERMAL_1_ON_MAIN_BROAD), "LM75-1-4C", 0}, 
             ONLP_THERMAL_STATUS_PRESENT,
             ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
         },

--- a/packages/platforms/accton/x86-64/x86-64-accton-as5916-54xm/platform-config/r0/src/python/x86_64_accton_as5916_54xm_r0/__init__.py
+++ b/packages/platforms/accton/x86-64/x86-64-accton-as5916-54xm/platform-config/r0/src/python/x86_64_accton_as5916_54xm_r0/__init__.py
@@ -27,7 +27,7 @@ class OnlPlatform_x86_64_accton_as5916_54xm_r0(OnlPlatformAccton,
                 ('as5916_54xm_fan', 0x66, 9),
 
                 # inititate LM75
-                ('lm75', 0x48, 10),
+                ('lm75', 0x4c, 10),
                 ('lm75', 0x49, 10),
                 ('lm75', 0x4a, 10),
                 ('lm75', 0x4b, 10),


### PR DESCRIPTION
For R0B board or later version, hardware has changed a LM75 sensor from from 0x48 to 0x4C.
Due to this change,  ONLP has to be updated as well.