### PR TITLE
Use i2c word mode instead of use block mode for access sys eeprom

### DIFF
--- a/packages/platforms/accton/x86-64/x86-64-accton-as7716-32x/onlp/builds/src/module/src/sysi.c
+++ b/packages/platforms/accton/x86-64/x86-64-accton-as7716-32x/onlp/builds/src/module/src/sysi.c
@@ -26,6 +26,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 
+#include <onlplib/i2c.h>
 #include <onlplib/file.h>
 #include <onlp/platformi/sysi.h>
 #include <onlp/platformi/ledi.h>
@@ -52,17 +53,26 @@ onlp_sysi_platform_get(void)
 int
 onlp_sysi_onie_data_get(uint8_t** data, int* size)
 {
+    int ret = ONLP_STATUS_OK;
+    int i = 0;
     uint8_t* rdata = aim_zmalloc(256);
-    if(onlp_file_read(rdata, 256, size, IDPROM_PATH) == ONLP_STATUS_OK) {
-        if(*size == 256) {
-            *data = rdata;
-            return ONLP_STATUS_OK;
+  
+    for (i = 0; i < 128; i++) {
+        ret = onlp_i2c_readw(0, 0x56, i*2, ONLP_I2C_F_FORCE);
+        if (ret < 0) {
+            aim_free(rdata);
+            *size = 0;
+            return ret;
         }
+
+        rdata[i*2]   = ret & 0xff;
+        rdata[i*2+1] = (ret >> 8) & 0xff;
     }
 
-    aim_free(rdata);
-    *size = 0;
-    return ONLP_STATUS_E_INTERNAL;
+    *size = 256;
+    *data = rdata;
+
+    return ONLP_STATUS_OK;
 }
 
 int

--- a/packages/platforms/accton/x86-64/x86-64-accton-as7716-32x/platform-config/r0/src/python/x86_64_accton_as7716_32x_r0/__init__.py
+++ b/packages/platforms/accton/x86-64/x86-64-accton-as7716-32x/platform-config/r0/src/python/x86_64_accton_as7716_32x_r0/__init__.py
@@ -85,7 +85,7 @@ class OnlPlatform_x86_64_accton_as7716_32x_r0(OnlPlatformAccton,
                 ('optoe1', 0x50, 54),
                 ('optoe1', 0x50, 55),
                 ('optoe1', 0x50, 56),
-                ('24c02', 0x56, 0),
+                #('24c02', 0x56, 0),
                 ])
 
         subprocess.call('echo port9 > /sys/bus/i2c/devices/25-0050/port_name', shell=True)


### PR DESCRIPTION
Use i2c word mode instead of use block mode for access sys eeprom