### PR TITLE
[as5916_54xm]Change one thermal sensor's i2c address to be 0x4C or 0x48.

### DIFF
--- a/packages/platforms/accton/x86-64/x86-64-accton-as5916-54xm/onlp/builds/src/module/src/thermali.c
+++ b/packages/platforms/accton/x86-64/x86-64-accton-as5916-54xm/onlp/builds/src/module/src/thermali.c
@@ -34,11 +34,15 @@
         }                                       \
     } while(0)
 
+
+/*Thermal 1 can be at 0x48 for R0A board, or 0x4C otherwise.*/
+static int thermal1_addr[] = {0x4c, 0x48};
+
 static char* devfiles__[] =  /* must map with onlp_thermal_id */
 {
     NULL,
     NULL,                  /* CPU_CORE files */
-    "/sys/bus/i2c/devices/10-004c*temp1_input",
+    "/sys/bus/i2c/devices/10-00%2x*temp1_input",
     "/sys/bus/i2c/devices/10-0049*temp1_input",
     "/sys/bus/i2c/devices/10-004a*temp1_input",
     "/sys/bus/i2c/devices/10-004b*temp1_input",
@@ -62,7 +66,7 @@ static onlp_thermal_info_t linfo[] = {
             ONLP_THERMAL_STATUS_PRESENT,
             ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
         },	
-	{ { ONLP_THERMAL_ID_CREATE(THERMAL_1_ON_MAIN_BROAD), "LM75-1-4C", 0}, 
+	{ { ONLP_THERMAL_ID_CREATE(THERMAL_1_ON_MAIN_BROAD), "LM75-1-%2X", 0},
             ONLP_THERMAL_STATUS_PRESENT,
             ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
         },
@@ -97,6 +101,25 @@ onlp_thermali_init(void)
     return ONLP_STATUS_OK;
 }
 
+/*check which addr of thermal1_addr[] can be read.*/
+static int
+_get_valid_t1_addr(char *path, int *addr)
+{
+    char fname[ONLP_OID_DESC_SIZE];
+    int i, rv, tmp;
+
+    for (i=0; i<AIM_ARRAYSIZE(thermal1_addr); i++){
+        snprintf(fname, sizeof(fname), path, thermal1_addr[i]);
+        rv = onlp_file_read_int(&tmp, fname);
+        if (rv == ONLP_STATUS_OK){
+            *addr = thermal1_addr[i];
+            return ONLP_STATUS_OK;
+        }
+    }
+    return ONLP_STATUS_E_INVALID;
+}
+
+
 /*
  * Retrieve the information structure for the given thermal OID.
  *
@@ -111,18 +134,44 @@ int
 onlp_thermali_info_get(onlp_oid_t id, onlp_thermal_info_t* info)
 {
     int   tid;
+    char *devfile;
+    char fname[ONLP_OID_DESC_SIZE];
+
     VALIDATE(id);
 	
     tid = ONLP_OID_ID_GET(id);
-	
     /* Set the onlp_oid_hdr_t and capabilities */		
     *info = linfo[tid];
-
     if(tid == THERMAL_CPU_CORE) {
         int rv = onlp_file_read_int_max(&info->mcelsius, cpu_coretemp_files);
         return rv;
     }
 
-    return onlp_file_read_int(&info->mcelsius, devfiles__[tid]);
+    if (tid >= AIM_ARRAYSIZE(devfiles__)){
+        return ONLP_STATUS_E_PARAM;
+    }
+
+	devfile = devfiles__[tid];
+    if (tid == THERMAL_1_ON_MAIN_BROAD)
+    {
+        onlp_oid_desc_t *des = &info->hdr.description;
+        char tmp[ONLP_OID_DESC_SIZE];
+        int t1_addr = thermal1_addr[0];
+        int rv;
+
+        rv = _get_valid_t1_addr(devfiles__[tid], &t1_addr);
+        if(rv != ONLP_STATUS_OK)
+            return rv;
+
+        /*Get real path of THERMAL_1 dev file*/
+        snprintf(fname, sizeof(fname), devfiles__[tid], t1_addr);
+        devfile = fname;
+
+        /*Replace description*/
+        strncpy(tmp, *des, sizeof(tmp));
+        snprintf(*des, sizeof(*des), tmp, t1_addr);
+    }
+
+    return onlp_file_read_int(&info->mcelsius, devfile);
 }
 

--- a/packages/platforms/accton/x86-64/x86-64-accton-as5916-54xm/onlp/builds/src/module/src/thermali.c
+++ b/packages/platforms/accton/x86-64/x86-64-accton-as5916-54xm/onlp/builds/src/module/src/thermali.c
@@ -38,7 +38,7 @@ static char* devfiles__[] =  /* must map with onlp_thermal_id */
 {
     NULL,
     NULL,                  /* CPU_CORE files */
-    "/sys/bus/i2c/devices/10-0048*temp1_input",
+    "/sys/bus/i2c/devices/10-004c*temp1_input",
     "/sys/bus/i2c/devices/10-0049*temp1_input",
     "/sys/bus/i2c/devices/10-004a*temp1_input",
     "/sys/bus/i2c/devices/10-004b*temp1_input",
@@ -62,7 +62,7 @@ static onlp_thermal_info_t linfo[] = {
             ONLP_THERMAL_STATUS_PRESENT,
             ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
         },	
-	{ { ONLP_THERMAL_ID_CREATE(THERMAL_1_ON_MAIN_BROAD), "LM75-1-48", 0}, 
+	{ { ONLP_THERMAL_ID_CREATE(THERMAL_1_ON_MAIN_BROAD), "LM75-1-4C", 0}, 
             ONLP_THERMAL_STATUS_PRESENT,
             ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
         },

--- a/packages/platforms/accton/x86-64/x86-64-accton-as5916-54xm/platform-config/r0/src/python/x86_64_accton_as5916_54xm_r0/__init__.py
+++ b/packages/platforms/accton/x86-64/x86-64-accton-as5916-54xm/platform-config/r0/src/python/x86_64_accton_as5916_54xm_r0/__init__.py
@@ -27,7 +27,8 @@ class OnlPlatform_x86_64_accton_as5916_54xm_r0(OnlPlatformAccton,
                 ('as5916_54xm_fan', 0x66, 9),
 
                 # inititate LM75
-                ('lm75', 0x4c, 10),
+                ('lm75', 0x48, 10),  #For R0A
+                ('lm75', 0x4c, 10),  #For R0B or later
                 ('lm75', 0x49, 10),
                 ('lm75', 0x4a, 10),
                 ('lm75', 0x4b, 10),

--- a/packages/platforms/accton/x86-64/x86-64-accton-as5916-54xm/platform-config/r0/src/python/x86_64_accton_as5916_54xm_r0/__init__.py
+++ b/packages/platforms/accton/x86-64/x86-64-accton-as5916-54xm/platform-config/r0/src/python/x86_64_accton_as5916_54xm_r0/__init__.py
@@ -27,7 +27,7 @@ class OnlPlatform_x86_64_accton_as5916_54xm_r0(OnlPlatformAccton,
                 ('as5916_54xm_fan', 0x66, 9),
 
                 # inititate LM75
-                ('lm75', 0x48, 10),
+                ('lm75', 0x4c, 10),
                 ('lm75', 0x49, 10),
                 ('lm75', 0x4a, 10),
                 ('lm75', 0x4b, 10),


### PR DESCRIPTION
For R0B board or later version, hardware has changed a LM75 sensor from from 0x48 to 0x4C.
Due to this change, ONLP has to be updated to tell if running on R0A or other version of PCB.
Onlpdump will examine device on 0x4C of i2c bus 10 to judge whether it's later version of underlying hardware.
