### PR TITLE
enhance get data performance

### DIFF
--- a/packages/platforms/accton/x86-64/x86-64-accton-wedge100bf-32x/onlp/builds/src/module/src/platform_lib.h
+++ b/packages/platforms/accton/x86-64/x86-64-accton-wedge100bf-32x/onlp/builds/src/module/src/platform_lib.h
@@ -64,6 +64,9 @@ int bmc_i2c_writeb(uint8_t bus, uint8_t devaddr, uint8_t addr, uint8_t value);
 int bmc_i2c_readw(uint8_t bus, uint8_t devaddr, uint8_t addr);
 int bmc_i2c_readraw(uint8_t bus, uint8_t devaddr, uint8_t addr, char* data, int data_size);
 
+int bmc_tty_init(void);
+int bmc_tty_deinit(void);
+
 #endif  /* __PLATFORM_LIB_H__ */
 
 

--- a/packages/platforms/accton/x86-64/x86-64-accton-wedge100bf-32x/onlp/builds/src/module/src/psui.c
+++ b/packages/platforms/accton/x86-64/x86-64-accton-wedge100bf-32x/onlp/builds/src/module/src/psui.c
@@ -24,6 +24,7 @@
  *
  ***********************************************************/
 #include <onlplib/i2c.h>
+#include <unistd.h>
 #include <onlplib/file.h>
 #include <onlp/platformi/psui.h>
 #include "platform_lib.h"
@@ -121,6 +122,7 @@ onlp_psui_info_get(onlp_oid_t id, onlp_psu_info_t* info)
     if (bmc_i2c_writeb(7, 0x70, 0, value) < 0) {
         return ONLP_STATUS_E_INTERNAL;
     }
+    usleep(1200);
 
     /* Read vin */
     addr  = (pid == PSU1_ID) ? 0x59 : 0x5a;
@@ -164,7 +166,10 @@ onlp_psui_info_get(onlp_oid_t id, onlp_psu_info_t* info)
     }
 
     /* Get model name */
-    return bmc_i2c_readraw(7, addr, 0x9a, info->model, sizeof(info->model));
+    bmc_i2c_readraw(7, addr, 0x9a, info->model, sizeof(info->model));
+
+    /* Get serial number */
+    return bmc_i2c_readraw(7, addr, 0x9e, info->serial, sizeof(info->serial));
 }
 
 int

--- a/packages/platforms/accton/x86-64/x86-64-accton-wedge100bf-32x/onlp/builds/src/module/src/sfpi.c
+++ b/packages/platforms/accton/x86-64/x86-64-accton-wedge100bf-32x/onlp/builds/src/module/src/sfpi.c
@@ -32,6 +32,8 @@
 
 #define BIT(i)          (1 << (i))
 #define NUM_OF_SFP_PORT 32
+#define PORT_EEPROM_FORMAT              "/sys/bus/i2c/devices/%d-0050/eeprom"
+
 static const int sfp_bus_index[] = {
    3,  2,  5,  4,  7,  6,  9, 8,
  11,  10, 13, 12, 15, 14, 17, 16,
@@ -156,44 +158,55 @@ onlp_sfpi_rx_los_bitmap_get(onlp_sfp_bitmap_t* dst)
     return ONLP_STATUS_OK;
 }
 
-static int
-sfpi_eeprom_read(int port, uint8_t devaddr, uint8_t data[256])
-{
-    int i;
-
-    /*
-     * Read the SFP eeprom into data[]
-     *
-     * Return MISSING if SFP is missing.
-     * Return OK if eeprom is read
-     */
-    memset(data, 0, 256);
-
-    for (i = 0; i < 128; i++) {
-        int bus = sfp_bus_index[port];
-        int val = onlp_i2c_readw(bus, devaddr, i*2, ONLP_I2C_F_FORCE);
-
-        if (val < 0) {
-            return ONLP_STATUS_E_INTERNAL;
-        }
-
-        data[i*2]   = val & 0xff;
-        data[(i*2)+1] = (val >> 8) & 0xff;
-    }
-
-    return ONLP_STATUS_OK;
-}
-
 int
 onlp_sfpi_eeprom_read(int port, uint8_t data[256])
 {
-    return sfpi_eeprom_read(port, 0x50, data);
+    int size = 0;
+    if(port <0 || port >= NUM_OF_SFP_PORT)
+        return ONLP_STATUS_E_INTERNAL;
+    memset(data, 0, 256);
+
+    if(onlp_file_read(data, 256, &size, PORT_EEPROM_FORMAT, sfp_bus_index[port]) != ONLP_STATUS_OK) {
+        AIM_LOG_ERROR("Unable to read eeprom from port(%d)\r\n", port);
+        return ONLP_STATUS_E_INTERNAL;
+    }
+
+    if (size != 256) {
+        AIM_LOG_ERROR("Unable to read eeprom from port(%d), size(%d) is different!\r\n", port, size);
+        return ONLP_STATUS_E_INTERNAL;
+    }
+
+    return ONLP_STATUS_OK;
+
 }
 
 int
 onlp_sfpi_dom_read(int port, uint8_t data[256])
 {
-    return sfpi_eeprom_read(port, 0x51, data);
+    FILE* fp;
+    char file[64] = {0};
+
+    sprintf(file, PORT_EEPROM_FORMAT, sfp_bus_index[port]);
+    fp = fopen(file, "r");
+    if(fp == NULL) {
+        AIM_LOG_ERROR("Unable to open the eeprom device file of port(%d)", port);
+        return ONLP_STATUS_E_INTERNAL;
+    }
+
+    if (fseek(fp, 256, SEEK_CUR) != 0) {
+        fclose(fp);
+        AIM_LOG_ERROR("Unable to set the file position indicator of port(%d)", port);
+        return ONLP_STATUS_E_INTERNAL;
+    }
+
+    int ret = fread(data, 1, 256, fp);
+    fclose(fp);
+    if (ret != 256) {
+        AIM_LOG_ERROR("Unable to read the module_eeprom device file of port(%d, %d)", port, ret);
+        return ONLP_STATUS_E_INTERNAL;
+    }
+
+    return ONLP_STATUS_OK;
 }
 
 int

--- a/packages/platforms/accton/x86-64/x86-64-accton-wedge100bf-32x/onlp/builds/src/module/src/sysi.c
+++ b/packages/platforms/accton/x86-64/x86-64-accton-wedge100bf-32x/onlp/builds/src/module/src/sysi.c
@@ -86,6 +86,7 @@ onlp_sysi_oids_get(onlp_oid_t* table, int max)
         *e++ = ONLP_FAN_ID_CREATE(i);
     }
 
+    bmc_tty_init();
     return 0;
 }
 


### PR DESCRIPTION
    1. old method: open UART and close UART whenever we need to get information from BMC.
       new method: open UART at beginning, then we use the UART(TTY) device directly.
    2. old method: use onlp_i2c_readw() to get all QSFP/SFP's eeprom data, it spends 128 times i2c access time.
       new method: use OOM's sysfs
    3. reduce the UART(TTY) retry time and timeout time
    4. add PSU's serial number information
(sysi.c: only add one line "bmc_tty_init();", the others are related to ^M)