### PR TITLE
[wedge100bf-65x] enhance get data performance

### DIFF
--- a/packages/platforms/accton/x86-64/x86-64-accton-wedge100bf-65x/onlp/builds/src/module/src/platform_lib.h
+++ b/packages/platforms/accton/x86-64/x86-64-accton-wedge100bf-65x/onlp/builds/src/module/src/platform_lib.h
@@ -64,6 +64,9 @@ int bmc_i2c_writeb(uint8_t bus, uint8_t devaddr, uint8_t addr, uint8_t value);
 int bmc_i2c_readw(uint8_t bus, uint8_t devaddr, uint8_t addr);
 int bmc_i2c_readraw(uint8_t bus, uint8_t devaddr, uint8_t addr, char* data, int data_size);
 
+int bmc_tty_init(void);
+int bmc_tty_deinit(void);
+
 #endif  /* __PLATFORM_LIB_H__ */
 
 

--- a/packages/platforms/accton/x86-64/x86-64-accton-wedge100bf-65x/onlp/builds/src/module/src/psui.c
+++ b/packages/platforms/accton/x86-64/x86-64-accton-wedge100bf-65x/onlp/builds/src/module/src/psui.c
@@ -24,6 +24,7 @@
  *
  ***********************************************************/
 #include <onlplib/i2c.h>
+#include <unistd.h>
 #include <onlplib/file.h>
 #include <onlp/platformi/psui.h>
 #include "platform_lib.h"
@@ -121,6 +122,7 @@ onlp_psui_info_get(onlp_oid_t id, onlp_psu_info_t* info)
     if (bmc_i2c_writeb(7, 0x70, 0, value) < 0) {
         return ONLP_STATUS_E_INTERNAL;
     }
+    usleep(1200);
 
     /* Read vin */
     addr  = (pid == PSU1_ID) ? 0x59 : 0x5a;
@@ -164,7 +166,10 @@ onlp_psui_info_get(onlp_oid_t id, onlp_psu_info_t* info)
     }
 
     /* Get model name */
-    return bmc_i2c_readraw(7, addr, 0x9a, info->model, sizeof(info->model));
+    bmc_i2c_readraw(7, addr, 0x9a, info->model, sizeof(info->model));
+
+    /* Get serial number */
+    return bmc_i2c_readraw(7, addr, 0x9e, info->serial, sizeof(info->serial));
 }
 
 int

--- a/packages/platforms/accton/x86-64/x86-64-accton-wedge100bf-65x/onlp/builds/src/module/src/sysi.c
+++ b/packages/platforms/accton/x86-64/x86-64-accton-wedge100bf-65x/onlp/builds/src/module/src/sysi.c
@@ -86,6 +86,7 @@ onlp_sysi_oids_get(onlp_oid_t* table, int max)
         *e++ = ONLP_FAN_ID_CREATE(i);
     }
 
+    bmc_tty_init();
     return 0;
 }
 


### PR DESCRIPTION
    1. old method: open UART and close UART whenever we need to get information from BMC.
       new method: open UART at beginning, then we use the UART(TTY) device directly.
    2. old method: use onlp_i2c_readw() to get all QSFP/SFP's eeprom data, it spends 128 times i2c access time.
       new method: use OOM's sysfs
                   we also correct the port mapping
    3. reduce the UART(TTY) retry time and timeout time
    4. add PSU's serial number information
(sysi.c: only add one line "bmc_tty_init();", the others are related to ^M)