### PR TITLE
[platform]as5916-26xb/as7316-26xb: add support for DC-PSU, model YM-2401U.

### DIFF
--- a/packages/platforms/accton/x86-64/x86-64-accton-as5916-26xb/modules/builds/x86-64-accton-as5916-26xb-psu.c
+++ b/packages/platforms/accton/x86-64/x86-64-accton-as5916-26xb/modules/builds/x86-64-accton-as5916-26xb-psu.c
@@ -425,8 +425,8 @@ static ssize_t show_psu(struct device *dev, struct device_attribute *da, char *b
 		case PSU1_FAN_INPUT:
 		case PSU2_FAN_INPUT:
             VALIDATE_PRESENT_RETURN(pid);
-			value = ((int)data->ipmi_resp[pid].status[PSU_FAN0] |
-                     (int)data->ipmi_resp[pid].status[PSU_FAN1] << 8);
+			value = (((unsigned char)data->ipmi_resp[pid].status[PSU_FAN0]) |
+                     ((unsigned char)data->ipmi_resp[pid].status[PSU_FAN1]) << 8);
 			break; 
 		default:
 			return -EINVAL;

--- a/packages/platforms/accton/x86-64/x86-64-accton-as5916-26xb/onlp/builds/src/module/src/psui.c
+++ b/packages/platforms/accton/x86-64/x86-64-accton-as5916-26xb/onlp/builds/src/module/src/psui.c
@@ -57,6 +57,22 @@ static onlp_psu_info_t pinfo[] =
     }
 };
 
+static int
+get_DCorAC_cap(char *model)
+{
+    const char *dc_models[] = {"YM-2401U", "um400d", NULL };
+    int i;
+
+    i = 0;
+    while(dc_models[i]) {
+        if (!strncasecmp(model, dc_models[i], strlen(dc_models[i]))){
+            return ONLP_PSU_CAPS_DC12;
+        }
+        i++;
+    }
+    return ONLP_PSU_CAPS_AC;
+}
+
 int
 onlp_psui_info_get(onlp_oid_t id, onlp_psu_info_t* info)
 {
@@ -140,6 +156,7 @@ onlp_psui_info_get(onlp_oid_t id, onlp_psu_info_t* info)
     if (string && len) {
         strncpy(info->model, string, len);
         aim_free(string);
+        info->caps |= get_DCorAC_cap (info->model);
     }
 
     /* Read serial */

--- a/packages/platforms/accton/x86-64/x86-64-accton-as7316-26xb/modules/builds/x86-64-accton-as7316-26xb-psu.c
+++ b/packages/platforms/accton/x86-64/x86-64-accton-as7316-26xb/modules/builds/x86-64-accton-as7316-26xb-psu.c
@@ -425,8 +425,8 @@ static ssize_t show_psu(struct device *dev, struct device_attribute *da, char *b
 		case PSU1_FAN_INPUT:
 		case PSU2_FAN_INPUT:
             VALIDATE_PRESENT_RETURN(pid);
-			value = ((int)data->ipmi_resp[pid].status[PSU_FAN0] |
-                     (int)data->ipmi_resp[pid].status[PSU_FAN1] << 8);
+			value = (((unsigned char)data->ipmi_resp[pid].status[PSU_FAN0]) |
+                     ((unsigned char)data->ipmi_resp[pid].status[PSU_FAN1]) << 8);
 			break; 
 		default:
 			return -EINVAL;

--- a/packages/platforms/accton/x86-64/x86-64-accton-as7316-26xb/onlp/builds/src/module/src/psui.c
+++ b/packages/platforms/accton/x86-64/x86-64-accton-as7316-26xb/onlp/builds/src/module/src/psui.c
@@ -57,6 +57,22 @@ static onlp_psu_info_t pinfo[] =
     }
 };
 
+static int
+get_DCorAC_cap(char *model)
+{
+    const char *dc_models[] = {"YM-2401U", "um400d", NULL };
+    int i;
+
+    i = 0;
+    while(dc_models[i]) {
+        if (!strncasecmp(model, dc_models[i], strlen(dc_models[i]))){
+            return ONLP_PSU_CAPS_DC12;
+        }
+        i++;
+    }
+    return ONLP_PSU_CAPS_AC;
+}
+
 int
 onlp_psui_info_get(onlp_oid_t id, onlp_psu_info_t* info)
 {
@@ -140,6 +156,7 @@ onlp_psui_info_get(onlp_oid_t id, onlp_psu_info_t* info)
     if (string && len) {
         strncpy(info->model, string, len);
         aim_free(string);
+        info->caps |= get_DCorAC_cap (info->model);
     }
 
     /* Read serial */


### PR DESCRIPTION
Fix wrong fan speed of DC PSU at AS5916-26xb and AS7316-26xb. 
Targeted for a DC-to-DC PSU, named YM-2401U,

Code change for: 
1. For x86-64-accton-as5916-26xb-psu.c/x86-64-accton-as7316-26xb-psu.c, take 2 bytes RPM as unsigned bytes. Do this to avoid sign extension.
2. For psui.c of onlpdump, examine model name to tell if a PSU is DC-DC or AC-DC, and set the capability accordingly.