### PR TITLE
Improve autobuild scripts

### DIFF
--- a/builds/amd64/rootfs/builds/Makefile
+++ b/builds/amd64/rootfs/builds/Makefile
@@ -4,7 +4,9 @@ include $(ONL)/make/config.amd64.mk
 # Default to include all available amd64 platforms.
 # You override this with you own list or yaml file.
 #
+ifndef PLATFORM_LIST
 export PLATFORM_LIST=$(shell onlpm --list-platforms --arch amd64 --csv )
+endif
 
 RFS_CONFIG := $(ONL)/builds/any/rootfs/$(ONL_DEBIAN_SUITE)/standard/standard.yml
 RFS_DIR := rootfs-amd64.d
@@ -12,5 +14,3 @@ RFS_CPIO := rootfs-amd64.cpio.gz
 RFS_SQUASH := rootfs-amd64.sqsh
 
 include $(ONL)/make/rfs.mk
-
-

--- a/tools/autobuild/build.sh
+++ b/tools/autobuild/build.sh
@@ -7,39 +7,39 @@ ONL="$(realpath $(dirname $AUTOBUILD_SCRIPT)/../../)"
 
 
 # Default build branch
-BUILD_BRANCH=master
+BUILD_BRANCH='master'
 
-while getopts ":b:s:d:u:p:l:a:vVc789r:" opt; do
-    case $opt in
+while getopts ':b:s:d:u:p:l:a:vVc789r:' opt; do
+    case "$opt" in
         7)
-            ONLB_OPTIONS=--7
+            ONLB_OPTIONS='--7'
             if [ -z "$DOCKER_IMAGE" ]; then
-                echo "Selecting Debian 7 build..."
+                echo 'Selecting Debian 7 build...'
             fi
             ;;
         8)
-            ONLB_OPTIONS=--8
+            ONLB_OPTIONS='--8'
             if [ -z "$DOCKER_IMAGE" ]; then
-                echo "Selecting Debian 8 build..."
+                echo 'Selecting Debian 8 build...'
             fi
             ;;
         9)
-            ONLB_OPTIONS=--9
+            ONLB_OPTIONS='--9'
             if [ -z "$DOCKER_IMAGE" ]; then
-                echo "Selecting Debian 9 build..."
+                echo 'Selecting Debian 9 build...'
             fi
             ;;
         c)
             BUILD_CLOSED=1
             ;;
         b)
-            BUILD_BRANCH=$OPTARG
+            BUILD_BRANCH="$OPTARG"
             ;;
         a)
-            ARCH=$OPTARG
+            ARCH="$OPTARG"
             ;;
         l)
-            PLATFORM_LIST=$OPTARG
+            PLATFORM_LIST="$OPTARG"
             ;;
         v)
             set -x
@@ -48,7 +48,7 @@ while getopts ":b:s:d:u:p:l:a:vVc789r:" opt; do
             export VERBOSE=1
             ;;
         r)
-            export BUILDROOTMIRROR=$OPTARG
+            export BUILDROOTMIRROR="$OPTARG"
             ;;
         *)
             ;;
@@ -57,8 +57,8 @@ done
 
 if [ -z "$ONLB_OPTIONS" ]; then
     # Build both 8 and 9
-    $AUTOBUILD_SCRIPT --8 $@
-    $AUTOBUILD_SCRIPT --9 $@
+    "$AUTOBUILD_SCRIPT" --8 "$@"
+    "$AUTOBUILD_SCRIPT" --9 "$@"
     exit $?
 fi
 
@@ -71,12 +71,12 @@ fi
 #
 if [ -z "$DOCKER_IMAGE" ]; then
     # Execute ourselves under the builder
-    ONLB=$ONL/docker/tools/onlbuilder
-    if [ -x $ONLB ]; then
-        $ONLB $ONLB_OPTIONS --volumes $ONL --non-interactive -c $AUTOBUILD_SCRIPT $@
+    ONLB="$ONL/docker/tools/onlbuilder"
+    if [ -x "$ONLB" ]; then
+        "$ONLB" $ONLB_OPTIONS --volumes "$ONL" --non-interactive -c "$AUTOBUILD_SCRIPT" "$@"
         exit $?
     else
-        echo "Not running in a docker workspace and the onlbuilder script is not available."
+        echo 'Not running in a docker workspace and the onlbuilder script is not available.'
         exit 1
     fi
 fi
@@ -89,7 +89,7 @@ cd "$ONL"
 # This is to normalize environments where the checkout might instead
 # be in a detached head (like jenkins)
 echo "Switching to branch $BUILD_BRANCH..."
-git checkout $BUILD_BRANCH
+git checkout "$BUILD_BRANCH"
 
 # Fetch closed platforms submodules when requested
 [ -z "$BUILD_CLOSED" ] ||
@@ -108,7 +108,7 @@ if [ -n "$PLATFORM_LIST" ]; then
 fi
 
 if ! make "${ARCH:-all}"; then
-    echo Build Failed.
+    echo 'Build Failed.'
     exit 1
 fi
 
@@ -116,6 +116,6 @@ make -C REPO build-clean
 
 # Remove all installer/rootfs/swi packages from the repo. These do not need to be kept and take significant
 # amounts of time to transfer.
-find REPO \( -name "*-installer_0.*" -o -name "*-rootfs_0.*" -o -name "*-swi_0.*" \) -a -delete
+find REPO \( -name '*-installer_0.*' -o -name '*-rootfs_0.*' -o -name '*-swi_0.*' \) -a -delete
 
-echo Build Succeeded.
+echo 'Build Succeeded.'

--- a/tools/autobuild/build.sh
+++ b/tools/autobuild/build.sh
@@ -72,7 +72,7 @@ if [ -z "$DOCKER_IMAGE" ]; then
     # Execute ourselves under the builder
     ONLB="$ONL/docker/tools/onlbuilder"
     if [ -x "$ONLB" ]; then
-        "$ONLB" $ONLB_OPTIONS --volumes "$ONL" --non-interactive -c "$AUTOBUILD_SCRIPT" "$@"
+        exec "$ONLB" $ONLB_OPTIONS --volumes "$ONL" --non-interactive -c "$AUTOBUILD_SCRIPT" "$@"
         exit $?
     else
         echo 'Not running in a docker workspace and the onlbuilder script is not available.'

--- a/tools/autobuild/build.sh
+++ b/tools/autobuild/build.sh
@@ -30,7 +30,7 @@ while getopts ":b:s:d:u:p:l:a:vVc789r:" opt; do
             fi
             ;;
         c)
-            cd $ONL && git submodule update --init --recursive packages/platforms-closed
+            BUILD_CLOSED=1
             ;;
         b)
             BUILD_BRANCH=$OPTARG
@@ -90,6 +90,10 @@ cd "$ONL"
 # be in a detached head (like jenkins)
 echo "Switching to branch $BUILD_BRANCH..."
 git checkout $BUILD_BRANCH
+
+# Fetch closed platforms submodules when requested
+[ -z "$BUILD_CLOSED" ] ||
+    git submodule update --init --recursive packages/platforms-closed
 
 #
 # Full build

--- a/tools/autobuild/build.sh
+++ b/tools/autobuild/build.sh
@@ -83,19 +83,18 @@ fi
 
 echo "Now running under $DOCKER_IMAGE..."
 
+cd "$ONL"
 
 # The expectation is that we will already be on the required branch.
 # This is to normalize environments where the checkout might instead
 # be in a detached head (like jenkins)
 echo "Switching to branch $BUILD_BRANCH..."
-cd $ONL && git checkout $BUILD_BRANCH
-
+git checkout $BUILD_BRANCH
 
 #
 # Full build
 #
-cd $ONL
-. setup.env
+. ./setup.env
 
 apt-cacher-ng >/dev/null 2>&1 ||:
 
@@ -109,12 +108,10 @@ if ! make "${ARCH:-all}"; then
     exit 1
 fi
 
-make -C $ONL/REPO build-clean
+make -C REPO build-clean
 
 # Remove all installer/rootfs/swi packages from the repo. These do not need to be kept and take significant
 # amounts of time to transfer.
-find $ONL/REPO -name "*-installer_0.*" -delete
-find $ONL/REPO -name "*-rootfs_0.*" -delete
-find $ONL/REPO -name "*-swi_0*" -delete
+find REPO \( -name "*-installer_0.*" -o -name "*-rootfs_0.*" -o -name "*-swi_0.*" \) -a -delete
 
 echo Build Succeeded.

--- a/tools/autobuild/build.sh
+++ b/tools/autobuild/build.sh
@@ -9,7 +9,7 @@ ONL="$(realpath $(dirname $AUTOBUILD_SCRIPT)/../../)"
 # Default build branch
 BUILD_BRANCH=master
 
-while getopts ":b:s:d:u:p:vVc789r:" opt; do
+while getopts ":b:s:d:u:p:l:a:vVc789r:" opt; do
     case $opt in
         7)
             ONLB_OPTIONS=--7
@@ -34,6 +34,12 @@ while getopts ":b:s:d:u:p:vVc789r:" opt; do
             ;;
         b)
             BUILD_BRANCH=$OPTARG
+            ;;
+        a)
+            ARCH=$OPTARG
+            ;;
+        l)
+            PLATFORM_LIST=$OPTARG
             ;;
         v)
             set -x
@@ -91,7 +97,12 @@ cd $ONL && git checkout $BUILD_BRANCH
 cd $ONL
 . setup.env
 
-if ! make all; then
+if [ -n "$PLATFORM_LIST" ]; then
+    export PLATFORM_LIST
+    export PLATFORMS="$(IFS=','; echo ${PLATFORM_LIST})"
+fi
+
+if ! make "${ARCH:-all}"; then
     echo Build Failed.
     exit 1
 fi

--- a/tools/autobuild/build.sh
+++ b/tools/autobuild/build.sh
@@ -55,16 +55,15 @@ set -e ${BUILD_VERBOSE:+-x}
 AUTOBUILD_SCRIPT="$(readlink -e "$0")" || exit
 ONL="${AUTOBUILD_SCRIPT%/*/*/*}"
 
+#
+# Restart with correct build options
+#
 if [ -z "$ONLB_OPTIONS" ]; then
     # Build both 8 and 9
     "$AUTOBUILD_SCRIPT" --8 "$@"
     "$AUTOBUILD_SCRIPT" --9 "$@"
     exit $?
 fi
-
-
-
-
 
 #
 # Restart under correct builder environment.
@@ -112,9 +111,13 @@ if ! make "${ARCH:-all}"; then
     exit 1
 fi
 
+#
+# Cleanup
+#
 make -C REPO build-clean
 
-# Remove all installer/rootfs/swi packages from the repo. These do not need to be kept and take significant
+# Remove all installer/rootfs/swi packages from the repo.
+# These do not need to be kept and take significant
 # amounts of time to transfer.
 find REPO \( -name '*-installer_0.*' -o -name '*-rootfs_0.*' -o -name '*-swi_0.*' \) -a -delete
 

--- a/tools/autobuild/build.sh
+++ b/tools/autobuild/build.sh
@@ -4,7 +4,7 @@
 # Default build branch
 BUILD_BRANCH='master'
 
-while getopts ':b:s:d:u:p:l:a:vVc789r:' opt; do
+while getopts ':b:s:d:u:p:l:a:nvVc789r:' opt; do
     case "$opt" in
         7)
             ONLB_OPTIONS='--7'
@@ -29,6 +29,9 @@ while getopts ':b:s:d:u:p:l:a:vVc789r:' opt; do
             ;;
         b)
             BUILD_BRANCH="$OPTARG"
+            ;;
+        n)
+            BUILD_BRANCH=
             ;;
         a)
             ARCH="$OPTARG"
@@ -87,8 +90,10 @@ cd "$ONL"
 # The expectation is that we will already be on the required branch.
 # This is to normalize environments where the checkout might instead
 # be in a detached head (like jenkins)
-echo "Switching to branch $BUILD_BRANCH..."
-git checkout "$BUILD_BRANCH"
+if [ -n "$BUILD_BRANCH" ]; then
+    echo "Switching to branch $BUILD_BRANCH..."
+    git checkout "$BUILD_BRANCH"
+fi
 
 # Fetch closed platforms submodules when requested
 [ -z "$BUILD_CLOSED" ] ||

--- a/tools/autobuild/build.sh
+++ b/tools/autobuild/build.sh
@@ -1,10 +1,5 @@
-#!/bin/bash
+#!/bin/sh
 ############################################################
-set -e
-
-AUTOBUILD_SCRIPT="$(realpath ${BASH_SOURCE[0]})"
-ONL="$(realpath $(dirname $AUTOBUILD_SCRIPT)/../../)"
-
 
 # Default build branch
 BUILD_BRANCH='master'
@@ -42,7 +37,7 @@ while getopts ':b:s:d:u:p:l:a:vVc789r:' opt; do
             PLATFORM_LIST="$OPTARG"
             ;;
         v)
-            set -x
+            BUILD_VERBOSE=1
             ;;
         V)
             export VERBOSE=1
@@ -54,6 +49,11 @@ while getopts ':b:s:d:u:p:l:a:vVc789r:' opt; do
             ;;
     esac
 done
+
+set -e ${BUILD_VERBOSE:+-x}
+
+AUTOBUILD_SCRIPT="$(readlink -e "$0")" || exit
+ONL="${AUTOBUILD_SCRIPT%/*/*/*}"
 
 if [ -z "$ONLB_OPTIONS" ]; then
     # Build both 8 and 9

--- a/tools/autobuild/build.sh
+++ b/tools/autobuild/build.sh
@@ -97,6 +97,8 @@ cd $ONL && git checkout $BUILD_BRANCH
 cd $ONL
 . setup.env
 
+apt-cacher-ng >/dev/null 2>&1 ||:
+
 if [ -n "$PLATFORM_LIST" ]; then
     export PLATFORM_LIST
     export PLATFORMS="$(IFS=','; echo ${PLATFORM_LIST})"

--- a/tools/autobuild/install.sh
+++ b/tools/autobuild/install.sh
@@ -1,9 +1,7 @@
-#!/bin/bash
+#!/bin/sh
 ############################################################
-set -e
 
-ONL="$(realpath $(dirname $BASH_SOURCE[0])/../../)"
-
+# Default build branch
 BUILD_BRANCH="${BUILD_BRANCH:-$(git rev-parse --abbrev-ref HEAD)}"
 
 #
@@ -42,9 +40,15 @@ while getopts ':s:d:u:p:b:t:v' opt; do
             BUILD_BRANCH="$OPTARG"
             ;;
         v)
-            set -x
+            BUILD_VERBOSE=1
+            ;;
     esac
 done
+
+set -e ${BUILD_VERBOSE:+-x}
+
+AUTOBUILD_SCRIPT="$(readlink -e "$0")" || exit
+ONL="${AUTOBUILD_SCRIPT%/*/*/*}"
 
 
 if [ -z "$REMOTE_SERVER" ]; then
@@ -77,7 +81,7 @@ do_cleanup() {
     cd /tmp
     /bin/rm -fr "$workdir"
 }
-trap 'do_cleanup' 0 1
+trap 'do_cleanup' EXIT
 
 RSYNC="${RSYNC:-rsync}"
 RSYNC_OPTS="${RSYNC_OPTS:+$RSYNC_OPTS }\

--- a/tools/autobuild/install.sh
+++ b/tools/autobuild/install.sh
@@ -83,12 +83,15 @@ RSYNC="${RSYNC:-rsync}"
 RSYNC_OPTS="${RSYNC_OPTS:+$RSYNC_OPTS }\
 -v --copy-links --delete -a --exclude-from=$workdir/git.exclude --exclude .lock"
 
+RSH="sshpass -p $REMOTE_PASS \
+ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -l $REMOTE_USER"
+
 _rsync() {
     cd $1 && git ls-files --cached > $workdir/git.exclude
-    $RSYNC $RSYNC_OPTS --rsh="sshpass -p $REMOTE_PASS ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -l $REMOTE_USER" $1 $2
+    $RSYNC $RSYNC_OPTS --rsh="$RSH" "$1" "$2"
 }
 
-sshpass -p $REMOTE_PASS ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -l $REMOTE_USER $REMOTE_SERVER mkdir -p $REMOTE_DIR
+$RSH $REMOTE_SERVER mkdir -p $REMOTE_DIR
 _rsync RELEASE $REMOTE_SERVER:$REMOTE_DIR
 _rsync REPO $REMOTE_SERVER:$REMOTE_DIR
-sshpass -p $REMOTE_PASS ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -l $REMOTE_USER $REMOTE_SERVER "$REMOTE_BASE_DIR/.tools/update-latest.py" --dir "$REMOTE_BASE_DIR/$BUILD_BRANCH" || true
+$RSH $REMOTE_SERVER "$REMOTE_BASE_DIR/.tools/update-latest.py" --dir "$REMOTE_BASE_DIR/$BUILD_BRANCH" || :

--- a/tools/autobuild/install.sh
+++ b/tools/autobuild/install.sh
@@ -4,7 +4,7 @@ set -e
 
 ONL="$(realpath $(dirname $BASH_SOURCE[0])/../../)"
 
-BUILD_BRANCH=${BUILD_BRANCH:-$(git rev-parse --abbrev-ref HEAD)}
+BUILD_BRANCH="${BUILD_BRANCH:-$(git rev-parse --abbrev-ref HEAD)}"
 
 #
 # Release artifacts can be automatically installed on a remote server
@@ -24,22 +24,22 @@ REMOTE_USER=
 # The remote password for RSYNC
 REMOTE_PASS=
 
-while getopts ":s:d:u:p:b:t:v" opt; do
-    case $opt in
+while getopts ':s:d:u:p:b:t:v' opt; do
+    case "$opt" in
         s)
-            REMOTE_SERVER=$OPTARG
+            REMOTE_SERVER="$OPTARG"
             ;;
         d)
-            REMOTE_BASE_DIR=$OPTARG
+            REMOTE_BASE_DIR="$OPTARG"
             ;;
         u)
-            REMOTE_USER=$OPTARG
+            REMOTE_USER="$OPTARG"
             ;;
         p)
-            REMOTE_PASS=$OPTARG
+            REMOTE_PASS="$OPTARG"
             ;;
         b)
-            BUILD_BRANCH=$OPTARG
+            BUILD_BRANCH="$OPTARG"
             ;;
         v)
             set -x
@@ -48,22 +48,22 @@ done
 
 
 if [ -z "$REMOTE_SERVER" ]; then
-    echo "Remote installation requires a server (-s)"
+    echo 'Remote installation requires a server (-s)'
     exit 1
 fi
 
 if [ -z "$REMOTE_BASE_DIR" ]; then
-    echo "Remote installation requires a branch directory (-d)"
+    echo 'Remote installation requires a branch directory (-d)'
     exit 1
 fi
 
 if [ -z "$REMOTE_USER" ]; then
-    echo "Remote installation requires a remote user (-u)"
+    echo 'Remote installation requires a remote user (-u)'
     exit 1
 fi
 
 if [ -z "$REMOTE_PASS" ]; then
-    echo "Remote installation requires a remote password (-p)"
+    echo 'Remote installation requires a remote password (-p)'
     exit 1
 fi
 
@@ -72,12 +72,12 @@ cd "$ONL"
 . ./make/versions/version-onl.sh
 REMOTE_DIR="$REMOTE_BASE_DIR/$BUILD_BRANCH/$FNAME_BUILD_ID"
 
-workdir=$(mktemp -d -t update-XXXXXX)
+workdir="$(mktemp -d -t 'update-XXXXXX')"
 do_cleanup() {
     cd /tmp
-    /bin/rm -fr $workdir
+    /bin/rm -fr "$workdir"
 }
-trap "do_cleanup" 0 1
+trap 'do_cleanup' 0 1
 
 RSYNC="${RSYNC:-rsync}"
 RSYNC_OPTS="${RSYNC_OPTS:+$RSYNC_OPTS }\
@@ -87,11 +87,11 @@ RSH="sshpass -p $REMOTE_PASS \
 ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -l $REMOTE_USER"
 
 _rsync() {
-    cd $1 && git ls-files --cached > $workdir/git.exclude
-    $RSYNC $RSYNC_OPTS --rsh="$RSH" "$1" "$2"
+    cd "$1" && git ls-files --cached > "$workdir/git.exclude"
+    "$RSYNC" $RSYNC_OPTS --rsh="$RSH" "$1" "$2"
 }
 
-$RSH $REMOTE_SERVER mkdir -p $REMOTE_DIR
-_rsync RELEASE $REMOTE_SERVER:$REMOTE_DIR
-_rsync REPO $REMOTE_SERVER:$REMOTE_DIR
-$RSH $REMOTE_SERVER "$REMOTE_BASE_DIR/.tools/update-latest.py" --dir "$REMOTE_BASE_DIR/$BUILD_BRANCH" || :
+$RSH "$REMOTE_SERVER" mkdir -p "$REMOTE_DIR"
+_rsync RELEASE "$REMOTE_SERVER:$REMOTE_DIR"
+_rsync REPO "$REMOTE_SERVER:$REMOTE_DIR"
+$RSH "$REMOTE_SERVER" "$REMOTE_BASE_DIR/.tools/update-latest.py" --dir "$REMOTE_BASE_DIR/$BUILD_BRANCH" || :

--- a/tools/autobuild/install.sh
+++ b/tools/autobuild/install.sh
@@ -79,10 +79,9 @@ do_cleanup() {
 }
 trap "do_cleanup" 0 1
 
-RSYNC_OPTS=${RSYNC_OPTS}${RSYNC_OPTS:+" "}"--exclude-from=$workdir/git.exclude"
-
-RSYNC=rsync
-RSYNC_OPTS=" -v --copy-links --delete -a --exclude-from=$workdir/git.exclude --exclude .lock"
+RSYNC="${RSYNC:-rsync}"
+RSYNC_OPTS="${RSYNC_OPTS:+$RSYNC_OPTS }\
+-v --copy-links --delete -a --exclude-from=$workdir/git.exclude --exclude .lock"
 
 _rsync() {
     cd $1 && git ls-files --cached > $workdir/git.exclude

--- a/tools/autobuild/install.sh
+++ b/tools/autobuild/install.sh
@@ -67,8 +67,9 @@ if [ -z "$REMOTE_PASS" ]; then
     exit 1
 fi
 
+cd "$ONL"
 
-. $ONL/make/versions/version-onl.sh
+. ./make/versions/version-onl.sh
 REMOTE_DIR="$REMOTE_BASE_DIR/$BUILD_BRANCH/$FNAME_BUILD_ID"
 
 workdir=$(mktemp -d -t update-XXXXXX)
@@ -89,6 +90,6 @@ _rsync() {
 }
 
 sshpass -p $REMOTE_PASS ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -l $REMOTE_USER $REMOTE_SERVER mkdir -p $REMOTE_DIR
-_rsync $ONL/RELEASE $REMOTE_SERVER:$REMOTE_DIR
-_rsync $ONL/REPO $REMOTE_SERVER:$REMOTE_DIR
+_rsync RELEASE $REMOTE_SERVER:$REMOTE_DIR
+_rsync REPO $REMOTE_SERVER:$REMOTE_DIR
 sshpass -p $REMOTE_PASS ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -l $REMOTE_USER $REMOTE_SERVER "$REMOTE_BASE_DIR/.tools/update-latest.py" --dir "$REMOTE_BASE_DIR/$BUILD_BRANCH" || true

--- a/tools/autobuild/run.sh
+++ b/tools/autobuild/run.sh
@@ -1,8 +1,10 @@
-#!/bin/bash
+#!/bin/sh
 ############################################################
 set -e
 
-PARENT_DIR="$(realpath $(dirname $BASH_SOURCE[0]))"
+AUTOBUILD_SCRIPT="$(readlink -e "$0")" || exit
+PARENT_DIR="${AUTOBUILD_SCRIPT%/*}"
+
 cd "$PARENT_DIR"
 
 ./build.sh "$@"

--- a/tools/autobuild/run.sh
+++ b/tools/autobuild/run.sh
@@ -3,7 +3,7 @@
 set -e
 
 PARENT_DIR="$(realpath $(dirname $BASH_SOURCE[0]))"
-cd $PARENT_DIR
+cd "$PARENT_DIR"
 
-./build.sh $@
-./install.sh $@
+./build.sh "$@"
+./install.sh "$@"


### PR DESCRIPTION
Building ONL by the hands requires few additional steps like preparing environment, starting 
apt-cacher-ng, running onlbuilder, etc.

Luckily there is tools/autobuild script used by CI/CD systems to build/deploy ONL images from given 
branch that can be used to build manually when testing new features.

With this series we add following improvements:

  1) Add options to build.sh to provide comma separated list of target platforms we want to build and
architecture we building (options -a and -l to build.sh). By providing list of platforms we reduce build 
time as well as final image size.
  2) Call apt-cacher-ng from build.sh
  3) Various improvements to scripts intended to remove bashisms and make them dash compatible.

See individual commit message for more information about changes presented.
