### PR TITLE
mkinstaller.py: Substitude ONLVERSION in installer.sh.in template

### DIFF
--- a/builds/any/installer/grub/builds/Makefile
+++ b/builds/any/installer/grub/builds/Makefile
@@ -11,6 +11,7 @@ include $(ONL)/make/versions/version-onl.mk
 INSTALLER_NAME=$(FNAME_PRODUCT_VERSION)_ONL-OS_$(FNAME_BUILD_ID)_$(UARCH)_$(BOOTMODE)_INSTALLER
 
 MKINSTALLER_OPTS	= \
+  --onl-version "$(VERSION_STRING)" \
   --arch $(ARCH) \
   --boot-config boot-config \
   --add-dir config \

--- a/builds/any/installer/uboot/builds/Makefile
+++ b/builds/any/installer/uboot/builds/Makefile
@@ -11,6 +11,7 @@ include $(ONL)/make/versions/version-onl.mk
 INSTALLER_NAME=$(FNAME_PRODUCT_VERSION)_ONL-OS_$(FNAME_BUILD_ID)_$(UARCH)_$(BOOTMODE)_INSTALLER
 
 MKINSTALLER_OPTS	= \
+  --onl-version "$(VERSION_STRING)" \
   --arch $(ARCH) \
   --boot-config boot-config \
   --add-dir config \

--- a/tools/mkinstaller.py
+++ b/tools/mkinstaller.py
@@ -23,7 +23,7 @@ if ONL is None:
     sys.exit(1)
 
 class InstallerShar(object):
-    def __init__(self, arch, template=None, work_dir=None):
+    def __init__(self, onl_version, arch, template=None, work_dir=None):
         self.ONL = ONL
 
         if template is None:
@@ -59,6 +59,8 @@ class InstallerShar(object):
             self.setvar("ARCH", 'x86_64')
         else:
             self.setvar("ARCH", self.arch)
+
+        self.setvar("ONLVERSION", onl_version)
 
     def abort(self, msg):
         logger.error(msg)
@@ -174,6 +176,7 @@ class InstallerShar(object):
 if __name__ == '__main__':
 
     ap = argparse.ArgumentParser(NAME)
+    ap.add_argument("--onl-version", help="Installer ONL Version.", required=True)
     ap.add_argument("--arch", help="Installer Architecture.", required=True,
                     choices = ['amd64', 'powerpc', 'armel', 'arm64'])
     ap.add_argument("--initrd", nargs=2, help="The system initrd.")
@@ -195,7 +198,7 @@ if __name__ == '__main__':
                     help="Specify a Python plugin (runs from within the installer chroot)")
 
     ops = ap.parse_args()
-    installer = InstallerShar(ops.arch, ops.work_dir)
+    installer = InstallerShar(ops.onl_version, ops.arch, ops.work_dir)
 
     if ops.arch == 'amd64':
         if ops.initrd is None:

--- a/tools/onl-nos-create.py
+++ b/tools/onl-nos-create.py
@@ -920,6 +920,7 @@ include %(MTOP)s/make/versions/version-%(prefix)s.mk
 INSTALLER_NAME=$(FNAME_PRODUCT_VERSION)_ONL-OS_$(FNAME_BUILD_ID)_$(UARCH)_$(BOOTMODE)_INSTALLER
 
 MKINSTALLER_OPTS := \
+  --onl-version "$(VERSION_STRING)" \
   --arch $(ARCH) \
   --boot-config boot-config \
   --swi %(prefix)s-swi:$(ARCH)


### PR DESCRIPTION
To show ONL version at image installation time add --onl-version
option to mkinstaller.py and pass VERSION_STRING to it.

Fixes: 9a98e40c09c7 ("Use the new mkinstaller script.")
Signed-off-by: Sergey Popovich <sergey.popovich@ordnance.co>