### PR TITLE
Add lm-sensor package and update kernel modules of as5912-54x for it.

### DIFF
--- a/builds/any/rootfs/jessie/common/all-base-packages.yml
+++ b/builds/any/rootfs/jessie/common/all-base-packages.yml
@@ -80,3 +80,4 @@
 - strace
 - sysstat
 - ipmitool
+- lm-sensors

--- a/packages/base/any/kernels/modules/ym2651y.c
+++ b/packages/base/any/kernels/modules/ym2651y.c
@@ -110,6 +110,7 @@ enum ym2651y_sysfs_attributes {
 	PSU_V_OUT,
 	PSU_I_OUT,
 	PSU_P_OUT,
+	PSU_P_OUT_UV,     /*In Unit of microVolt, instead of mini.*/
 	PSU_TEMP1_INPUT,
 	PSU_FAN1_SPEED,
 	PSU_FAN1_DUTY_CYCLE,
@@ -156,6 +157,14 @@ static SENSOR_DEVICE_ATTR(psu_mfr_iout_max,	S_IRUGO, show_linear, NULL, PSU_MFR_
 static SENSOR_DEVICE_ATTR(psu_mfr_pin_max,	S_IRUGO, show_linear, NULL, PSU_MFR_PIN_MAX);
 static SENSOR_DEVICE_ATTR(psu_mfr_pout_max,	S_IRUGO, show_linear, NULL, PSU_MFR_POUT_MAX);
 
+/*Duplicate nodes for lm-sensors.*/
+static SENSOR_DEVICE_ATTR(in2_input,    S_IRUGO, show_linear,    NULL, PSU_V_OUT);
+static SENSOR_DEVICE_ATTR(curr2_input,  S_IRUGO, show_linear,    NULL, PSU_I_OUT);
+static SENSOR_DEVICE_ATTR(power2_input, S_IRUGO, show_linear,    NULL, PSU_P_OUT_UV);
+static SENSOR_DEVICE_ATTR(temp1_input,  S_IRUGO, show_linear,    NULL, PSU_TEMP1_INPUT);
+static SENSOR_DEVICE_ATTR(fan1_input,   S_IRUGO, show_linear,    NULL, PSU_FAN1_SPEED);
+static SENSOR_DEVICE_ATTR(temp1_fault,  S_IRUGO, show_word,      NULL, PSU_TEMP_FAULT);
+
 static struct attribute *ym2651y_attributes[] = {
 	&sensor_dev_attr_psu_power_on.dev_attr.attr,
 	&sensor_dev_attr_psu_temp_fault.dev_attr.attr,
@@ -182,6 +191,13 @@ static struct attribute *ym2651y_attributes[] = {
 	&sensor_dev_attr_psu_mfr_vout_min.dev_attr.attr,
 	&sensor_dev_attr_psu_mfr_vout_max.dev_attr.attr,
 	&sensor_dev_attr_psu_mfr_iout_max.dev_attr.attr,
+	/*Duplicate nodes for lm-sensors.*/
+	&sensor_dev_attr_curr2_input.dev_attr.attr,
+	&sensor_dev_attr_in2_input.dev_attr.attr,
+	&sensor_dev_attr_power2_input.dev_attr.attr,
+	&sensor_dev_attr_temp1_input.dev_attr.attr,
+	&sensor_dev_attr_fan1_input.dev_attr.attr,
+	&sensor_dev_attr_temp1_fault.dev_attr.attr,
 	NULL
 };
 
@@ -279,6 +295,9 @@ static ssize_t show_linear(struct device *dev, struct device_attribute *da,
 	case PSU_I_OUT:
 		value = data->i_out;
 		break;
+	case PSU_P_OUT_UV:
+		multiplier = 1000000;  /*For lm-sensors, unit is micro-Volt.*/
+		/*Passing through*/
 	case PSU_P_OUT:
 		value = data->p_out;
 		break;

--- a/packages/platforms/accton/x86-64/x86-64-accton-as5912-54x/modules/builds/x86-64-accton-as5912-54x-fan.c
+++ b/packages/platforms/accton/x86-64/x86-64-accton-as5912-54x/modules/builds/x86-64-accton-as5912-54x-fan.c
@@ -115,10 +115,11 @@ enum sysfs_fan_attributes {
 
 /* Define attributes
  */
-#define DECLARE_FAN_FAULT_SENSOR_DEV_ATTR(index) \
-    static SENSOR_DEVICE_ATTR(fan##index##_fault, S_IRUGO, fan_show_value, NULL, FAN##index##_FAULT)
-#define DECLARE_FAN_FAULT_ATTR(index)      &sensor_dev_attr_fan##index##_fault.dev_attr.attr
-
+#define DECLARE_FAN_FAULT_SENSOR_DEV_ATTR(index, index2) \
+    static SENSOR_DEVICE_ATTR(fan##index##_fault, S_IRUGO, fan_show_value, NULL, FAN##index##_FAULT);\
+    static SENSOR_DEVICE_ATTR(fan##index2##_fault, S_IRUGO, fan_show_value, NULL, FAN##index##_FAULT)
+#define DECLARE_FAN_FAULT_ATTR(index, index2)      &sensor_dev_attr_fan##index##_fault.dev_attr.attr, \
+    &sensor_dev_attr_fan##index2##_fault.dev_attr.attr
 #define DECLARE_FAN_DIRECTION_SENSOR_DEV_ATTR(index) \
     static SENSOR_DEVICE_ATTR(fan##index##_direction, S_IRUGO, fan_show_value, NULL, FAN##index##_DIRECTION)
 #define DECLARE_FAN_DIRECTION_ATTR(index)  &sensor_dev_attr_fan##index##_direction.dev_attr.attr
@@ -127,40 +128,47 @@ enum sysfs_fan_attributes {
     static SENSOR_DEVICE_ATTR(fan##index##_duty_cycle_percentage, S_IWUSR | S_IRUGO, fan_show_value, set_duty_cycle, FAN##index##_DUTY_CYCLE_PERCENTAGE)
 #define DECLARE_FAN_DUTY_CYCLE_ATTR(index) &sensor_dev_attr_fan##index##_duty_cycle_percentage.dev_attr.attr
 
-#define DECLARE_FAN_PRESENT_SENSOR_DEV_ATTR(index) \
-    static SENSOR_DEVICE_ATTR(fan##index##_present, S_IRUGO, fan_show_value, NULL, FAN##index##_PRESENT)
-#define DECLARE_FAN_PRESENT_ATTR(index)      &sensor_dev_attr_fan##index##_present.dev_attr.attr
+#define DECLARE_FAN_PRESENT_SENSOR_DEV_ATTR(index, index2) \
+    static SENSOR_DEVICE_ATTR(fan##index##_present, S_IRUGO, fan_show_value, NULL, FAN##index##_PRESENT);\
+    static SENSOR_DEVICE_ATTR(fan##index2##_present, S_IRUGO, fan_show_value, NULL, FAN##index##_PRESENT)
+#define DECLARE_FAN_PRESENT_ATTR(index, index2)      &sensor_dev_attr_fan##index##_present.dev_attr.attr, \
+    &sensor_dev_attr_fan##index2##_present.dev_attr.attr
 
-#define DECLARE_FAN_SPEED_RPM_SENSOR_DEV_ATTR(index) \
+#define DECLARE_FAN_SPEED_RPM_SENSOR_DEV_ATTR(index, index2) \
     static SENSOR_DEVICE_ATTR(fan##index##_front_speed_rpm, S_IRUGO, fan_show_value, NULL, FAN##index##_FRONT_SPEED_RPM);\
-    static SENSOR_DEVICE_ATTR(fan##index##_rear_speed_rpm, S_IRUGO, fan_show_value, NULL, FAN##index##_REAR_SPEED_RPM)
-#define DECLARE_FAN_SPEED_RPM_ATTR(index)  &sensor_dev_attr_fan##index##_front_speed_rpm.dev_attr.attr, \
-                                           &sensor_dev_attr_fan##index##_rear_speed_rpm.dev_attr.attr
+    static SENSOR_DEVICE_ATTR(fan##index##_rear_speed_rpm, S_IRUGO, fan_show_value, NULL, FAN##index##_REAR_SPEED_RPM);\
+    static SENSOR_DEVICE_ATTR(fan##index##_input, S_IRUGO, fan_show_value, NULL, FAN##index##_FRONT_SPEED_RPM);\
+    static SENSOR_DEVICE_ATTR(fan##index2##_input, S_IRUGO, fan_show_value, NULL, FAN##index##_REAR_SPEED_RPM)
+
+#define DECLARE_FAN_SPEED_RPM_ATTR(index, index2)  &sensor_dev_attr_fan##index##_front_speed_rpm.dev_attr.attr, \
+                                           &sensor_dev_attr_fan##index##_rear_speed_rpm.dev_attr.attr, \
+                                           &sensor_dev_attr_fan##index##_input.dev_attr.attr, \
+                                           &sensor_dev_attr_fan##index2##_input.dev_attr.attr
 
 static SENSOR_DEVICE_ATTR(fan_max_speed_rpm, S_IRUGO, fan_show_value, NULL, FAN_MAX_RPM);
 #define DECLARE_FAN_MAX_RPM_ATTR(index)      &sensor_dev_attr_fan_max_speed_rpm.dev_attr.attr
 
 /* 6 fan fault attributes in this platform */
-DECLARE_FAN_FAULT_SENSOR_DEV_ATTR(1);
-DECLARE_FAN_FAULT_SENSOR_DEV_ATTR(2);
-DECLARE_FAN_FAULT_SENSOR_DEV_ATTR(3);
-DECLARE_FAN_FAULT_SENSOR_DEV_ATTR(4);
-DECLARE_FAN_FAULT_SENSOR_DEV_ATTR(5);
-DECLARE_FAN_FAULT_SENSOR_DEV_ATTR(6); 
+DECLARE_FAN_FAULT_SENSOR_DEV_ATTR(1, 11);
+DECLARE_FAN_FAULT_SENSOR_DEV_ATTR(2, 12);
+DECLARE_FAN_FAULT_SENSOR_DEV_ATTR(3, 13);
+DECLARE_FAN_FAULT_SENSOR_DEV_ATTR(4, 14);
+DECLARE_FAN_FAULT_SENSOR_DEV_ATTR(5, 15);
+DECLARE_FAN_FAULT_SENSOR_DEV_ATTR(6, 16); 
 /* 6 fan speed(rpm) attributes in this platform */
-DECLARE_FAN_SPEED_RPM_SENSOR_DEV_ATTR(1);
-DECLARE_FAN_SPEED_RPM_SENSOR_DEV_ATTR(2);
-DECLARE_FAN_SPEED_RPM_SENSOR_DEV_ATTR(3);
-DECLARE_FAN_SPEED_RPM_SENSOR_DEV_ATTR(4);
-DECLARE_FAN_SPEED_RPM_SENSOR_DEV_ATTR(5);
-DECLARE_FAN_SPEED_RPM_SENSOR_DEV_ATTR(6);
+DECLARE_FAN_SPEED_RPM_SENSOR_DEV_ATTR(1, 11);
+DECLARE_FAN_SPEED_RPM_SENSOR_DEV_ATTR(2, 12);
+DECLARE_FAN_SPEED_RPM_SENSOR_DEV_ATTR(3, 13);
+DECLARE_FAN_SPEED_RPM_SENSOR_DEV_ATTR(4, 14);
+DECLARE_FAN_SPEED_RPM_SENSOR_DEV_ATTR(5, 15);
+DECLARE_FAN_SPEED_RPM_SENSOR_DEV_ATTR(6, 16);
 /* 6 fan present attributes in this platform */
-DECLARE_FAN_PRESENT_SENSOR_DEV_ATTR(1);
-DECLARE_FAN_PRESENT_SENSOR_DEV_ATTR(2);
-DECLARE_FAN_PRESENT_SENSOR_DEV_ATTR(3);
-DECLARE_FAN_PRESENT_SENSOR_DEV_ATTR(4);
-DECLARE_FAN_PRESENT_SENSOR_DEV_ATTR(5);
-DECLARE_FAN_PRESENT_SENSOR_DEV_ATTR(6);
+DECLARE_FAN_PRESENT_SENSOR_DEV_ATTR(1, 11);
+DECLARE_FAN_PRESENT_SENSOR_DEV_ATTR(2, 12);
+DECLARE_FAN_PRESENT_SENSOR_DEV_ATTR(3, 13);
+DECLARE_FAN_PRESENT_SENSOR_DEV_ATTR(4, 14);
+DECLARE_FAN_PRESENT_SENSOR_DEV_ATTR(5, 15);
+DECLARE_FAN_PRESENT_SENSOR_DEV_ATTR(6, 16);
 /* 6 fan direction attribute in this platform */
 DECLARE_FAN_DIRECTION_SENSOR_DEV_ATTR(1);
 DECLARE_FAN_DIRECTION_SENSOR_DEV_ATTR(2);
@@ -173,24 +181,24 @@ DECLARE_FAN_DUTY_CYCLE_SENSOR_DEV_ATTR();
 
 static struct attribute *as5912_54x_fan_attributes[] = {
     /* fan related attributes */
-    DECLARE_FAN_FAULT_ATTR(1),
-    DECLARE_FAN_FAULT_ATTR(2),
-    DECLARE_FAN_FAULT_ATTR(3),
-    DECLARE_FAN_FAULT_ATTR(4),
-    DECLARE_FAN_FAULT_ATTR(5),
-    DECLARE_FAN_FAULT_ATTR(6),
-    DECLARE_FAN_SPEED_RPM_ATTR(1),
-    DECLARE_FAN_SPEED_RPM_ATTR(2),
-    DECLARE_FAN_SPEED_RPM_ATTR(3),
-    DECLARE_FAN_SPEED_RPM_ATTR(4),
-    DECLARE_FAN_SPEED_RPM_ATTR(5),
-    DECLARE_FAN_SPEED_RPM_ATTR(6),
-    DECLARE_FAN_PRESENT_ATTR(1),
-    DECLARE_FAN_PRESENT_ATTR(2),
-    DECLARE_FAN_PRESENT_ATTR(3),
-    DECLARE_FAN_PRESENT_ATTR(4),
-    DECLARE_FAN_PRESENT_ATTR(5),
-    DECLARE_FAN_PRESENT_ATTR(6),
+    DECLARE_FAN_FAULT_ATTR(1, 11),
+    DECLARE_FAN_FAULT_ATTR(2, 12),
+    DECLARE_FAN_FAULT_ATTR(3, 13),
+    DECLARE_FAN_FAULT_ATTR(4, 14),
+    DECLARE_FAN_FAULT_ATTR(5, 15),
+    DECLARE_FAN_FAULT_ATTR(6, 16),
+    DECLARE_FAN_SPEED_RPM_ATTR(1, 11),
+    DECLARE_FAN_SPEED_RPM_ATTR(2, 12),
+    DECLARE_FAN_SPEED_RPM_ATTR(3, 13),
+    DECLARE_FAN_SPEED_RPM_ATTR(4, 14),
+    DECLARE_FAN_SPEED_RPM_ATTR(5, 15),
+    DECLARE_FAN_SPEED_RPM_ATTR(6, 16),
+    DECLARE_FAN_PRESENT_ATTR(1, 11),
+    DECLARE_FAN_PRESENT_ATTR(2, 12),
+    DECLARE_FAN_PRESENT_ATTR(3, 13),
+    DECLARE_FAN_PRESENT_ATTR(4, 14),
+    DECLARE_FAN_PRESENT_ATTR(5, 15),
+    DECLARE_FAN_PRESENT_ATTR(6, 16),
 	DECLARE_FAN_DIRECTION_ATTR(1),
 	DECLARE_FAN_DIRECTION_ATTR(2),
 	DECLARE_FAN_DIRECTION_ATTR(3),


### PR DESCRIPTION
Add supporting of "sensors" command to dump hwmon information.
To conform with lm-sensor naming, update related kernel modules of  as5912-54x.

Example log:
root@localhost:~# cat /etc/onl/platform
x86-64-accton-as5912-54x-r0
root@localhost:~# export LANG=UTF-8
root@localhost:~# sensors
lm75-i2c-3-4a
Adapter: i2c-0-mux (chan_id 1)
temp1:        +30.5 C  (high = +80.0 C, hyst = +75.0 C)

lm75-i2c-3-48
Adapter: i2c-0-mux (chan_id 1)
temp1:        +29.5 C  (high = +80.0 C, hyst = +75.0 C)

coretemp-isa-0000
Adapter: ISA adapter
Core 0:       +23.0 C  (high = +98.0 C, crit = +98.0 C)
Core 1:       +23.0 C  (high = +98.0 C, crit = +98.0 C)
Core 2:       +24.0 C  (high = +98.0 C, crit = +98.0 C)
Core 3:       +24.0 C  (high = +98.0 C, crit = +98.0 C)

as5912_54x_fan-i2c-2-66
Adapter: i2c-0-mux (chan_id 0)
fan1:        5000 RPM
fan2:        5100 RPM
fan3:        5100 RPM
fan4:        5000 RPM
fan5:        5200 RPM
fan6:        4700 RPM
fan11:       4300 RPM
fan12:       4400 RPM
fan13:       4400 RPM
fan14:       4300 RPM
fan15:       4400 RPM
fan16:       4000 RPM

ym2651-i2c-10-58
Adapter: i2c-1-mux (chan_id 0)
in3:         +11.84 V
fan1:        4896 RPM
temp1:        +25.0 C
power2:       33.00 W
curr2:        +2.84 A

lm75-i2c-3-4b
Adapter: i2c-0-mux (chan_id 1)
temp1:        +27.0 C  (high = +80.0 C, hyst = +75.0 C)

lm75-i2c-3-49
Adapter: i2c-0-mux (chan_id 1)
temp1:        +29.5 C  (high = +80.0 C, hyst = +75.0 C)

ym2651-i2c-11-5b
Adapter: i2c-1-mux (chan_id 1)
in3:         +12.14 V
fan1:        5000 RPM
temp1:        +30.0 C
power2:       21.00 W
curr2:        +1.73 A