### PR TITLE
Added kernel 4.9 patches for mlx-platform

### DIFF
--- a/packages/base/any/kernels/4.9-lts/patches/0014-platform-x86-mlx-platform-backport-from-4.19.patch
+++ b/packages/base/any/kernels/4.9-lts/patches/0014-platform-x86-mlx-platform-backport-from-4.19.patch
@@ -1,0 +1,215 @@
+From 4674fe003c7b71aff4f14bb4fdb723f066cf398b Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@mellanox.com>
+Date: Thu, 9 Aug 2018 16:41:16 +0000
+Subject: [patch backport from 4.19 1/1] platform/x86: mlx-platform: backport
+ from 4.19
+
+Signed-off-by: Vadim Pasternak <vadimp@mellanox.com>
+---
+ drivers/platform/mellanox/mlxreg-hotplug.c | 43 +++++++++---------------------
+ drivers/platform/x86/mlx-platform.c        | 22 +++++++--------
+ include/linux/platform_data/mlxreg.h       |  5 ++--
+ 3 files changed, 26 insertions(+), 44 deletions(-)
+
+diff --git a/drivers/platform/mellanox/mlxreg-hotplug.c b/drivers/platform/mellanox/mlxreg-hotplug.c
+index 4761211..b6d4455 100644
+--- a/drivers/platform/mellanox/mlxreg-hotplug.c
++++ b/drivers/platform/mellanox/mlxreg-hotplug.c
+@@ -50,10 +50,8 @@
+ #define MLXREG_HOTPLUG_MASK_OFF		2
+ #define MLXREG_HOTPLUG_AGGR_MASK_OFF	1
+ 
+-/* ASIC health parameters. */
+-#define MLXREG_HOTPLUG_DOWN_MASK	0x00
+-#define MLXREG_HOTPLUG_HEALTH_MASK	0x02
+-#define MLXREG_HOTPLUG_RST_CNTR		2
++/* ASIC good health mask. */
++#define MLXREG_HOTPLUG_GOOD_HEALTH_MASK	0x02
+ 
+ #define MLXREG_HOTPLUG_ATTRS_MAX	24
+ #define MLXREG_HOTPLUG_NOT_ASSERT	3
+@@ -68,7 +66,6 @@
+  * @dwork_irq: delayed work template;
+  * @lock: spin lock;
+  * @hwmon: hwmon device;
+- * @kobj: hwmon kobject for notification;
+  * @mlxreg_hotplug_attr: sysfs attributes array;
+  * @mlxreg_hotplug_dev_attr: sysfs sensor device attribute array;
+  * @group: sysfs attribute group;
+@@ -88,7 +85,6 @@ struct mlxreg_hotplug_priv_data {
+ 	struct delayed_work dwork_irq;
+ 	spinlock_t lock; /* sync with interrupt */
+ 	struct device *hwmon;
+-	struct kobject *kobj;
+ 	struct attribute *mlxreg_hotplug_attr[MLXREG_HOTPLUG_ATTRS_MAX + 1];
+ 	struct sensor_device_attribute_2
+ 			mlxreg_hotplug_dev_attr[MLXREG_HOTPLUG_ATTRS_MAX];
+@@ -107,7 +103,7 @@ static int mlxreg_hotplug_device_create(struct mlxreg_hotplug_priv_data *priv,
+ 	struct mlxreg_core_hotplug_platform_data *pdata;
+ 
+ 	/* Notify user by sending hwmon uevent. */
+-	kobject_uevent(priv->kobj, KOBJ_CHANGE);
++	kobject_uevent(&priv->hwmon->kobj, KOBJ_CHANGE);
+ 
+ 	/*
+ 	 * Return if adapter number is negative. It could be in case hotplug
+@@ -145,7 +141,7 @@ mlxreg_hotplug_device_destroy(struct mlxreg_hotplug_priv_data *priv,
+ 			      struct mlxreg_core_data *data)
+ {
+ 	/* Notify user by sending hwmon uevent. */
+-	kobject_uevent(priv->kobj, KOBJ_CHANGE);
++	kobject_uevent(&priv->hwmon->kobj, KOBJ_CHANGE);
+ 
+ 	if (data->hpdev.client) {
+ 		i2c_unregister_device(data->hpdev.client);
+@@ -336,23 +332,19 @@ mlxreg_hotplug_health_work_helper(struct mlxreg_hotplug_priv_data *priv,
+ 			goto out;
+ 
+ 		regval &= data->mask;
++
++		if (item->cache == regval)
++			goto ack_event;
++
+ 		/*
+ 		 * ASIC health indication is provided through two bits. Bits
+ 		 * value 0x2 indicates that ASIC reached the good health, value
+ 		 * 0x0 indicates ASIC the bad health or dormant state and value
+-		 * 0x2 indicates the booting state. During ASIC reset it should
++		 * 0x3 indicates the booting state. During ASIC reset it should
+ 		 * pass the following states: dormant -> booting -> good.
+-		 * The transition from dormant to booting state and from
+-		 * booting to good state are indicated by ASIC twice, so actual
+-		 * sequence for getting to the steady state after reset is:
+-		 * dormant -> booting -> booting -> good -> good. It is
+-		 * possible that due to some hardware noise, the transition
+-		 * sequence will look like: dormant -> booting -> [ booting ->
+-		 * good -> dormant -> booting ] -> good -> good.
+ 		 */
+-		if (regval == MLXREG_HOTPLUG_HEALTH_MASK) {
+-			if ((++data->health_cntr == MLXREG_HOTPLUG_RST_CNTR) ||
+-			    !priv->after_probe) {
++		if (regval == MLXREG_HOTPLUG_GOOD_HEALTH_MASK) {
++			if (!data->attached) {
+ 				/*
+ 				 * ASIC is in steady state. Connect associated
+ 				 * device, if configured.
+@@ -363,25 +355,17 @@ mlxreg_hotplug_health_work_helper(struct mlxreg_hotplug_priv_data *priv,
+ 		} else {
+ 			if (data->attached) {
+ 				/*
+-				 * ASIC health is dropped after ASIC has been
++				 * ASIC health is failed after ASIC has been
+ 				 * in steady state. Disconnect associated
+ 				 * device, if it has been connected.
+ 				 */
+ 				mlxreg_hotplug_device_destroy(priv, data);
+ 				data->attached = false;
+ 				data->health_cntr = 0;
+-			} else if (regval == MLXREG_HOTPLUG_DOWN_MASK &&
+-				   item->cache == MLXREG_HOTPLUG_HEALTH_MASK) {
+-				/*
+-				 * Decrease counter, if health has been dropped
+-				 * before ASIC reaches the steady state, like:
+-				 * good -> dormant -> booting.
+-				 */
+-				data->health_cntr--;
+ 			}
+ 		}
+ 		item->cache = regval;
+-
++ack_event:
+ 		/* Acknowledge event. */
+ 		ret = regmap_write(priv->regmap, data->reg +
+ 				   MLXREG_HOTPLUG_EVENT_OFF, 0);
+@@ -674,7 +658,6 @@ static int mlxreg_hotplug_probe(struct platform_device *pdev)
+ 			PTR_ERR(priv->hwmon));
+ 		return PTR_ERR(priv->hwmon);
+ 	}
+-	priv->kobj = &priv->hwmon->kobj;
+ 
+ 	/* Perform initial interrupts setup. */
+ 	mlxreg_hotplug_set_irq(priv);
+diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
+index e1f9fce..84e17cd 100644
+--- a/drivers/platform/x86/mlx-platform.c
++++ b/drivers/platform/x86/mlx-platform.c
+@@ -83,12 +83,12 @@
+ #define MLXPLAT_CPLD_LPC_REG_TACHO4_OFFSET	0xe7
+ #define MLXPLAT_CPLD_LPC_REG_TACHO5_OFFSET	0xe8
+ #define MLXPLAT_CPLD_LPC_REG_TACHO6_OFFSET	0xe9
+-#define MLXPLAT_CPLD_LPC_REG_TACHO7_OFFSET	0xea
+-#define MLXPLAT_CPLD_LPC_REG_TACHO8_OFFSET	0xeb
+-#define MLXPLAT_CPLD_LPC_REG_TACHO9_OFFSET	0xec
+-#define MLXPLAT_CPLD_LPC_REG_TACHO10_OFFSET	0xed
+-#define MLXPLAT_CPLD_LPC_REG_TACHO11_OFFSET	0xee
+-#define MLXPLAT_CPLD_LPC_REG_TACHO12_OFFSET	0xef
++#define MLXPLAT_CPLD_LPC_REG_TACHO7_OFFSET	0xeb
++#define MLXPLAT_CPLD_LPC_REG_TACHO8_OFFSET	0xec
++#define MLXPLAT_CPLD_LPC_REG_TACHO9_OFFSET	0xed
++#define MLXPLAT_CPLD_LPC_REG_TACHO10_OFFSET	0xee
++#define MLXPLAT_CPLD_LPC_REG_TACHO11_OFFSET	0xef
++#define MLXPLAT_CPLD_LPC_REG_TACHO12_OFFSET	0xf0
+ #define MLXPLAT_CPLD_LPC_IO_RANGE		0x100
+ #define MLXPLAT_CPLD_LPC_I2C_CH1_OFF		0xdb
+ #define MLXPLAT_CPLD_LPC_I2C_CH2_OFF		0xda
+@@ -1499,21 +1499,21 @@ static const struct dmi_system_id mlxplat_dmi_table[] __initconst = {
+ 		.callback = mlxplat_dmi_qmb7xx_matched,
+ 		.matches = {
+ 			DMI_MATCH(DMI_BOARD_VENDOR, "Mellanox Technologies"),
+-			DMI_MATCH(DMI_PRODUCT_NAME, "QMB7"),
++			DMI_MATCH(DMI_PRODUCT_NAME, "MQM87"),
+ 		},
+ 	},
+ 	{
+ 		.callback = mlxplat_dmi_qmb7xx_matched,
+ 		.matches = {
+ 			DMI_MATCH(DMI_BOARD_VENDOR, "Mellanox Technologies"),
+-			DMI_MATCH(DMI_PRODUCT_NAME, "SN37"),
++			DMI_MATCH(DMI_PRODUCT_NAME, "MSN37"),
+ 		},
+ 	},
+ 	{
+ 		.callback = mlxplat_dmi_qmb7xx_matched,
+ 		.matches = {
+ 			DMI_MATCH(DMI_BOARD_VENDOR, "Mellanox Technologies"),
+-			DMI_MATCH(DMI_PRODUCT_NAME, "SN34"),
++			DMI_MATCH(DMI_PRODUCT_NAME, "MSN34"),
+ 		},
+ 	},
+ 	{
+@@ -1704,8 +1704,8 @@ static int __init mlxplat_init(void)
+ 					PLATFORM_DEVID_NONE, NULL, 0,
+ 					mlxplat_fan,
+ 					sizeof(*mlxplat_fan));
+-		if (IS_ERR(priv->pdev_io_regs)) {
+-			err = PTR_ERR(priv->pdev_io_regs);
++		if (IS_ERR(priv->pdev_fan)) {
++			err = PTR_ERR(priv->pdev_fan);
+ 			goto fail_platform_io_regs_register;
+ 		}
+ 	}
+diff --git a/include/linux/platform_data/mlxreg.h b/include/linux/platform_data/mlxreg.h
+index b77c7a5..19f5cb61 100644
+--- a/include/linux/platform_data/mlxreg.h
++++ b/include/linux/platform_data/mlxreg.h
+@@ -58,15 +58,14 @@ struct mlxreg_hotplug_device {
+  * struct mlxreg_core_data - attributes control data:
+  *
+  * @label: attribute label;
+- * @label: attribute register offset;
+  * @reg: attribute register;
+  * @mask: attribute access mask;
+- * @mode: access mode;
+  * @bit: attribute effective bit;
++ * @mode: access mode;
+  * @np - pointer to node platform associated with attribute;
+  * @hpdev - hotplug device data;
+  * @health_cntr: dynamic device health indication counter;
+- * @attached: true if device has been attached after good helath indication;
++ * @attached: true if device has been attached after good health indication;
+  */
+ struct mlxreg_core_data {
+ 	char label[MLXREG_CORE_LABEL_MAX_SIZE];
+-- 
+2.1.4
+

--- a/packages/base/any/kernels/4.9-lts/patches/0015-platform-x86-mlx-platform-Add-support-for-register-a.patch
+++ b/packages/base/any/kernels/4.9-lts/patches/0015-platform-x86-mlx-platform-Add-support-for-register-a.patch
@@ -1,0 +1,203 @@
+From d73a1884eeb2107b4803650c3dce511bc951ce3e Mon Sep 17 00:00:00 2001
+From: Oleksandr Shamray <oleksandrs@mellanox.com>
+Date: Tue, 14 Aug 2018 13:32:40 +0000
+Subject: [PATCH] platform/x86: mlx-platform: Add support for register
+ CPLD3_VER, RST_CUSE Add NG system type support
+
+Signed-off-by: Oleksandr Shamray <oleksandrs@mellanox.com>
+---
+ drivers/hwmon/mlxreg-fan.c          |   2 +-
+ drivers/platform/x86/mlx-platform.c | 126 +++++++++++++++++++++++++++++++++++-
+ 2 files changed, 125 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/hwmon/mlxreg-fan.c b/drivers/hwmon/mlxreg-fan.c
+index de46577..d8fa4be 100644
+--- a/drivers/hwmon/mlxreg-fan.c
++++ b/drivers/hwmon/mlxreg-fan.c
+@@ -51,7 +51,7 @@
+  */
+ #define MLXREG_FAN_GET_RPM(rval, d, s)	(DIV_ROUND_CLOSEST(15000000 * 100, \
+ 					 ((rval) + (s)) * (d)))
+-#define MLXREG_FAN_GET_FAULT(val, mask) (!!((val) ^ (mask)))
++#define MLXREG_FAN_GET_FAULT(val, mask) (!((val) ^ (mask)))
+ #define MLXREG_FAN_PWM_DUTY2STATE(duty)	(DIV_ROUND_CLOSEST((duty) *	\
+ 					 MLXREG_FAN_MAX_STATE,		\
+ 					 MLXREG_FAN_MAX_DUTY))
+diff --git a/drivers/platform/x86/mlx-platform.c b/drivers/platform/x86/mlx-platform.c
+index 84e17cd..e8782f5 100644
+--- a/drivers/platform/x86/mlx-platform.c
++++ b/drivers/platform/x86/mlx-platform.c
+@@ -49,7 +49,10 @@
+ #define MLXPLAT_CPLD_LPC_REG_BASE_ADRR		0x2500
+ #define MLXPLAT_CPLD_LPC_REG_CPLD1_VER_OFFSET	0x00
+ #define MLXPLAT_CPLD_LPC_REG_CPLD2_VER_OFFSET	0x01
++#define MLXPLAT_CPLD_LPC_REG_CPLD3_VER_OFFSET   0x02
+ #define MLXPLAT_CPLD_LPC_REG_RESET_CAUSE_OFFSET	0x1d
++#define MLXPLAT_CPLD_LPC_REG_RST_CAUSE1_OFFSET	0x1e
++#define MLXPLAT_CPLD_LPC_REG_RST_CAUSE2_OFFSET	0x1f
+ #define MLXPLAT_CPLD_LPC_REG_LED1_OFFSET	0x20
+ #define MLXPLAT_CPLD_LPC_REG_LED2_OFFSET	0x21
+ #define MLXPLAT_CPLD_LPC_REG_LED3_OFFSET	0x22
+@@ -1101,6 +1104,118 @@ static struct mlxreg_core_platform_data mlxplat_msn21xx_regs_io_data = {
+ 		.counter = ARRAY_SIZE(mlxplat_mlxcpld_msn21xx_regs_io_data),
+ };
+ 
++/* Platform register access for next generation systems families data */
++static struct mlxreg_core_data mlxplat_mlxcpld_default_ng_regs_io_data[] = {
++	{
++		.label = "cpld1_version",
++		.reg = MLXPLAT_CPLD_LPC_REG_CPLD1_VER_OFFSET,
++		.bit = GENMASK(7, 0),
++		.mode = 0444,
++	},
++	{
++		.label = "cpld2_version",
++		.reg = MLXPLAT_CPLD_LPC_REG_CPLD2_VER_OFFSET,
++		.bit = GENMASK(7, 0),
++		.mode = 0444,
++	},
++	{
++		.label = "cpld3_version",
++		.reg = MLXPLAT_CPLD_LPC_REG_CPLD3_VER_OFFSET,
++		.bit = GENMASK(7, 0),
++		.mode = 0444,
++        },
++	{
++		.label = "reset_long_pb",
++		.reg = MLXPLAT_CPLD_LPC_REG_RESET_CAUSE_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(0),
++		.mode = 0444,
++	},
++	{
++		.label = "reset_short_pb",
++		.reg = MLXPLAT_CPLD_LPC_REG_RESET_CAUSE_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(1),
++		.mode = 0444,
++	},
++	{
++		.label = "reset_aux_pwr_or_ref",
++		.reg = MLXPLAT_CPLD_LPC_REG_RESET_CAUSE_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(2),
++		.mode = 0444,
++	},
++	{
++		.label = "reset_from_comex",
++		.reg = MLXPLAT_CPLD_LPC_REG_RESET_CAUSE_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(4),
++		.mode = 0444,
++	},
++	{
++		.label = "reset_asic_thermal",
++		.reg = MLXPLAT_CPLD_LPC_REG_RESET_CAUSE_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(7),
++		.mode = 0444,
++	},
++	{
++		.label = "reset_comex_pwr_fail",
++		.reg = MLXPLAT_CPLD_LPC_REG_RST_CAUSE1_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(3),
++		.mode = 0444,
++	},
++	{
++		.label = "reset_voltmon_upgrade_fail",
++		.reg = MLXPLAT_CPLD_LPC_REG_RST_CAUSE2_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(0),
++		.mode = 0444,
++	},
++	{
++		.label = "reset_system",
++		.reg = MLXPLAT_CPLD_LPC_REG_RST_CAUSE2_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(1),
++		.mode = 0444,
++	},
++	{
++		.label = "psu1_on",
++		.reg = MLXPLAT_CPLD_LPC_REG_GP1_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(0),
++		.mode = 0200,
++	},
++	{
++		.label = "psu2_on",
++		.reg = MLXPLAT_CPLD_LPC_REG_GP1_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(1),
++		.mode = 0200,
++	},
++	{
++		.label = "pwr_cycle",
++		.reg = MLXPLAT_CPLD_LPC_REG_GP1_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(2),
++		.mode = 0200,
++	},
++	{
++		.label = "pwr_down",
++		.reg = MLXPLAT_CPLD_LPC_REG_GP1_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(3),
++		.mode = 0200,
++	},
++	{
++		.label = "jtag_enable",
++		.reg = MLXPLAT_CPLD_LPC_REG_GP2_OFFSET,
++		.mask = GENMASK(7, 0) & ~BIT(4),
++		.mode = 0644,
++	},
++	{
++		.label = "asic_health",
++		.reg = MLXPLAT_CPLD_LPC_REG_ASIC_HEALTH_OFFSET,
++		.mask = MLXPLAT_CPLD_ASIC_MASK,
++		.bit = 1,
++		.mode = 0444,
++	},
++};
++
++static struct mlxreg_core_platform_data mlxplat_default_ng_regs_io_data = {
++		.data = mlxplat_mlxcpld_default_ng_regs_io_data,
++		.counter = ARRAY_SIZE(mlxplat_mlxcpld_default_ng_regs_io_data),
++};
++
+ /* Platform FAN default */
+ static struct mlxreg_core_data mlxplat_mlxcpld_default_fan_data[] = {
+ 	{
+@@ -1208,7 +1323,10 @@ static bool mlxplat_mlxcpld_readable_reg(struct device *dev, unsigned int reg)
+ 	switch (reg) {
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD1_VER_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD2_VER_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_CPLD3_VER_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_RESET_CAUSE_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_RST_CAUSE1_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_RST_CAUSE2_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_LED1_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_LED2_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_LED3_OFFSET:
+@@ -1258,7 +1376,10 @@ static bool mlxplat_mlxcpld_volatile_reg(struct device *dev, unsigned int reg)
+ 	switch (reg) {
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD1_VER_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_CPLD2_VER_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_CPLD3_VER_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_RESET_CAUSE_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_RST_CAUSE1_OFFSET:
++	case MLXPLAT_CPLD_LPC_REG_RST_CAUSE2_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_LED1_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_LED2_OFFSET:
+ 	case MLXPLAT_CPLD_LPC_REG_LED3_OFFSET:
+@@ -1421,7 +1542,7 @@ static int __init mlxplat_dmi_msn201x_matched(const struct dmi_system_id *dmi)
+ 	mlxplat_hotplug = &mlxplat_mlxcpld_msn201x_data;
+ 	mlxplat_hotplug->deferred_nr =
+ 		mlxplat_default_channels[i - 1][MLXPLAT_CPLD_GRP_CHNL_NUM - 1];
+-	mlxplat_led = &mlxplat_default_ng_led_data;
++	mlxplat_led = &mlxplat_msn21xx_led_data;
+ 	mlxplat_regs_io = &mlxplat_msn21xx_regs_io_data;
+ 
+ 	return 1;
+@@ -1439,7 +1560,8 @@ static int __init mlxplat_dmi_qmb7xx_matched(const struct dmi_system_id *dmi)
+ 	mlxplat_hotplug = &mlxplat_mlxcpld_default_ng_data;
+ 	mlxplat_hotplug->deferred_nr =
+ 		mlxplat_msn21xx_channels[MLXPLAT_CPLD_GRP_CHNL_NUM - 1];
+-	mlxplat_led = &mlxplat_msn21xx_led_data;
++	mlxplat_led = &mlxplat_default_ng_led_data;
++	mlxplat_regs_io = &mlxplat_default_ng_regs_io_data;
+ 	mlxplat_fan = &mlxplat_default_fan_data;
+ 
+ 	return 1;
+-- 
+2.1.4
+

--- a/packages/base/any/kernels/4.9-lts/patches/series
+++ b/packages/base/any/kernels/4.9-lts/patches/series
@@ -14,3 +14,5 @@ driver-support-intel-igb-bcm5461-phy.patch
 driver-i2c-i2c-core.patch
 driver-add-the-support-max6620.patch
 0013-Mellanox-backport-patchwork-from-kernels-4.17-4.19.patch
+0014-platform-x86-mlx-platform-backport-from-4.19.patch
+0015-platform-x86-mlx-platform-Add-support-for-register-a.patch


### PR DESCRIPTION
This patch combines backporting of upstream code from the kernel 4.19 

Author: Oleksandr Shamray <oleksandrs@mellanox.com>
    platform/x86: mlx-platform: Add support for register CPLD3_VER, RST_CUSE
    Add NG system type support
    
Author: Vadim Pasternak <vadimp@mellanox.com>
    platform/x86: mlx-platform: backport from 4.19

