### PR TITLE
Added YM2851J PSU support to AS7816_64x platform

### DIFF
--- a/packages/platforms/accton/x86-64/x86-64-accton-as7816-64x/onlp/builds/src/module/src/platform_lib.c
+++ b/packages/platforms/accton/x86-64/x86-64-accton-as7816-64x/onlp/builds/src/module/src/platform_lib.c
@@ -96,6 +96,10 @@ psu_type_t psu_type_get(int id, char* modelname, int modelname_len)
         return PSU_TYPE_AC_YM2851_F2B;
     }
 
+    if (strncmp(model, "YM-2851J", strlen("YM-2851J")) == 0) {
+        return PSU_TYPE_AC_YM2851_F2B;
+    }
+
     return PSU_TYPE_UNKNOWN;
 }
 


### PR DESCRIPTION
I have added **YM2851J** model PSU support to **AS7816-64X** platform.  After adding, **onlpdump** command can show **YM2851J**  PSU attributes.