### PR TITLE
Add broadcom tg3 support 100M/10M feature.

### DIFF
--- a/packages/base/any/kernels/4.14-lts/patches/0003-drivers-net-ethernet-broadcom-tg3-100M-10M-support.patch
+++ b/packages/base/any/kernels/4.14-lts/patches/0003-drivers-net-ethernet-broadcom-tg3-100M-10M-support.patch
@@ -1,0 +1,29 @@
+diff -Naur a/drivers/net/ethernet/broadcom/tg3.c b/drivers/net/ethernet/broadcom/tg3.c
+--- a/drivers/net/ethernet/broadcom/tg3.c	2018-06-12 04:49:22.000000000 +0800
++++ b/drivers/net/ethernet/broadcom/tg3.c	2018-09-12 21:48:31.841337337 +0800
+@@ -1488,6 +1488,7 @@
+ static void tg3_mdio_start(struct tg3 *tp)
+ {
+ 	tp->mi_mode &= ~MAC_MI_MODE_AUTO_POLL;
++	tp->mi_mode |= MAC_MI_MODE_SHORT_PREAMBLE;
+ 	tw32_f(MAC_MI_MODE, tp->mi_mode);
+ 	udelay(80);
+ 
+@@ -11724,7 +11725,16 @@
+ 		tg3_frob_aux_power(tp, false);
+ 		pci_set_power_state(tp->pdev, PCI_D3hot);
+ 	}
+-
++#ifdef CONFIG_TIGON3_PHY_SERDES        /*AS7716, MGMT port with serdes mode(for PXE boot support) */
++       __tg3_writephy(tp, 0x8, 0x10, 0x1d0);
++       __tg3_writephy(tp, 0x1f, 0x00, 0x8140);
++       udelay(10000);
++       __tg3_writephy(tp, 0x1f, 0x1c, 0xfc0d);
++       __tg3_writephy(tp, 0x1f, 0x00, 0x1140);
++#else  /* use SGMII interface */
++       __tg3_writephy(tp, 0x8, 0x10, 0x1d0);
++       __tg3_writephy(tp, 0x1f, 0x4, 0x5e1);
++#endif
+ 	return err;
+ }
+ 

--- a/packages/base/any/kernels/4.14-lts/patches/series
+++ b/packages/base/any/kernels/4.14-lts/patches/series
@@ -3,3 +3,4 @@ drivers-usb-phy-phy-xgs-iproc-usb-phy-mode.patch
 drivers-i2c-busses-xgs_iproc_smbus-clk-freq.patch
 0001-drivers-i2c-muxes-pca954x-deselect-on-exit.patch
 0002-driver-support-intel-igb-bcm5461S-phy.patch
+0003-drivers-net-ethernet-broadcom-tg3-100M-10M-support.patch


### PR DESCRIPTION
This is for the patch the Broadcom tg3 driver to support 100M/10M  Ethernet port.
The patch has been verified in platform_accton_asxvolt16.