### PR TITLE
Disable BMC Monitor before bus init to prevent conflict with BMC.

### DIFF
--- a/packages/platforms/delta/x86-64/x86-64-delta-agc7648sv1/onlp/builds/src/module/src/fani.c
+++ b/packages/platforms/delta/x86-64/x86-64-delta-agc7648sv1/onlp/builds/src/module/src/fani.c
@@ -346,28 +346,39 @@ int onlp_fani_rpm_set(onlp_oid_t id, int rpm)
     int local_id;
     char data[10] = {0};
     char fullpath[70] = {0};
+    int rv;
+
     VALIDATE(id);
     local_id = ONLP_OID_ID_GET(id);
 
-    /* get fullpath */
-    switch (local_id) {
-        case FAN_1_ON_FAN_BOARD:
-        case FAN_2_ON_FAN_BOARD:
-        case FAN_3_ON_FAN_BOARD:
-        case FAN_4_ON_FAN_BOARD:
-        case FAN_5_ON_FAN_BOARD:
-        case FAN_6_ON_FAN_BOARD:
-        case FAN_7_ON_FAN_BOARD:
-        case FAN_8_ON_FAN_BOARD:
-            sprintf(fullpath, "%s%s", PREFIX_PATH, fan_path[local_id].speed);
-            break;
-        default:
-            return ONLP_STATUS_E_INVALID;
+    if(dni_bmc_check() == BMC_ON)
+    {
+        rv = ONLP_STATUS_OK;
     }
-    sprintf(data, "%d", rpm);
-    dni_i2c_lock_write_attribute(NULL, data, fullpath);
+    else
+    {
+        /* get fullpath */
+        switch (local_id) {
+            case FAN_1_ON_FAN_BOARD:
+            case FAN_2_ON_FAN_BOARD:
+            case FAN_3_ON_FAN_BOARD:
+            case FAN_4_ON_FAN_BOARD:
+            case FAN_5_ON_FAN_BOARD:
+            case FAN_6_ON_FAN_BOARD:
+            case FAN_7_ON_FAN_BOARD:
+            case FAN_8_ON_FAN_BOARD:
+                sprintf(fullpath, "%s%s", PREFIX_PATH, fan_path[local_id].speed);
+                break;
+            default:
+                return ONLP_STATUS_E_INVALID;
+        }
+        sprintf(data, "%d", rpm);
+        dni_i2c_lock_write_attribute(NULL, data, fullpath);
 
-    return ONLP_STATUS_OK;
+        rv = ONLP_STATUS_OK;
+    }
+
+    return rv;
 }
 
 /*
@@ -383,33 +394,42 @@ int onlp_fani_percentage_set(onlp_oid_t id, int p)
     int local_id;
     char data[10] = {0};
     char fullpath[70] = {0};
+    int rv;
 
     VALIDATE(id);
     local_id = ONLP_OID_ID_GET(id);
 
-    /* Select PSU member */
-    switch (local_id) {
-        case FAN_1_ON_FAN_BOARD:
-        case FAN_2_ON_FAN_BOARD:
-        case FAN_3_ON_FAN_BOARD:
-        case FAN_4_ON_FAN_BOARD:
-        case FAN_5_ON_FAN_BOARD:
-        case FAN_6_ON_FAN_BOARD:
-        case FAN_7_ON_FAN_BOARD:
-        case FAN_8_ON_FAN_BOARD:
-        case FAN_1_ON_PSU1:
-        case FAN_1_ON_PSU2:
-            break;
-        default:
-            return ONLP_STATUS_E_INVALID;
+    if(dni_bmc_check() == BMC_ON)
+    {
+        rv = ONLP_STATUS_OK;
+    }
+    else
+    {
+        /* Select PSU member */
+        switch (local_id) {
+            case FAN_1_ON_FAN_BOARD:
+            case FAN_2_ON_FAN_BOARD:
+            case FAN_3_ON_FAN_BOARD:
+            case FAN_4_ON_FAN_BOARD:
+            case FAN_5_ON_FAN_BOARD:
+            case FAN_6_ON_FAN_BOARD:
+            case FAN_7_ON_FAN_BOARD:
+            case FAN_8_ON_FAN_BOARD:
+            case FAN_1_ON_PSU1:
+            case FAN_1_ON_PSU2:
+                break;
+            default:
+                return ONLP_STATUS_E_INVALID;
+        }
+        sprintf(fullpath, "%s%s", PREFIX_PATH, fan_path[local_id].ctrl_speed);
+        /* Write percentage to psu_fan1_duty_cycle_percentage */
+        sprintf(data, "%d", p);
+        dni_i2c_lock_write_attribute(NULL, data, fullpath);
+
+        rv = ONLP_STATUS_OK;
     }
 
-    sprintf(fullpath, "%s%s", PREFIX_PATH, fan_path[local_id].ctrl_speed);
-    /* Write percentage to psu_fan1_duty_cycle_percentage */
-    sprintf(data, "%d", p);
-    dni_i2c_lock_write_attribute(NULL, data, fullpath);
-
-    return ONLP_STATUS_OK;
+    return rv;
 }
 
 /*

--- a/packages/platforms/delta/x86-64/x86-64-delta-agc7648sv1/onlp/builds/src/module/src/platform_lib.c
+++ b/packages/platforms/delta/x86-64/x86-64-delta-agc7648sv1/onlp/builds/src/module/src/platform_lib.c
@@ -132,6 +132,23 @@ int dni_bmc_data_get(int bus, int addr, int reg, int len, int *r_data)
     return rv;
 }
 
+int dni_bmc_data_set(int bus, int addr, int reg, uint8_t w_data)
+{
+    int rv = ONLP_STATUS_OK;
+    char cmd[50] = {0};
+    FILE *fptr = NULL;
+
+    sprintf(cmd, "ipmitool raw 0x38 0x3 %d 0x%x 0x%x %d > /dev/null", bus, addr, reg, w_data);
+    fptr = popen(cmd, "w");
+    if(fptr != NULL)
+        rv = ONLP_STATUS_OK;
+    else
+        rv = ONLP_STATUS_E_INVALID;
+    pclose(fptr);
+
+    return rv;
+}
+
 int dni_bmc_fanpresent_info_get(int *r_data)
 {
     int rv = ONLP_STATUS_OK;

--- a/packages/platforms/delta/x86-64/x86-64-delta-agc7648sv1/onlp/builds/src/module/src/platform_lib.h
+++ b/packages/platforms/delta/x86-64/x86-64-delta-agc7648sv1/onlp/builds/src/module/src/platform_lib.h
@@ -115,6 +115,37 @@ typedef unsigned int    UINT4;
 #define SFP_RESPOND_3 (0x0C)
 #define SFP_RESPOND_4 (0x0D)
 
+/* on SWPLD2 */
+#define SFP_PRESENCE_1 0x30
+#define SFP_PRESENCE_2 0x31
+#define SFP_PRESENCE_3 0x32
+#define SFP_PRESENCE_4 0x33
+#define SFP_PRESENCE_5 0x34
+#define SFP_PRESENCE_6 0x35
+#define SFP_RXLOS_1 0x36
+#define SFP_RXLOS_2 0x37
+#define SFP_RXLOS_3 0x38
+#define SFP_RXLOS_4 0x39
+#define SFP_RXLOS_5 0x3A
+#define SFP_RXLOS_6 0x3B
+#define SFP_TXDIS_1 0x3C
+#define SFP_TXDIS_2 0x3D
+#define SFP_TXDIS_3 0x3E
+#define SFP_TXDIS_4 0x3F
+#define SFP_TXDIS_5 0x40
+#define SFP_TXDIS_6 0x41
+#define SFP_TXFAULT_1 0x42
+#define SFP_TXFAULT_2 0x43
+#define SFP_TXFAULT_3 0x44
+#define SFP_TXFAULT_4 0x45
+#define SFP_TXFAULT_5 0x46
+#define SFP_TXFAULT_6 0x47
+
+/* on SWPLD1 */
+#define QSFP_PRESENCE  0x63
+#define QSFP_LPMODE    0x62
+#define QSFP_RESET     0x3c
+
 typedef struct mux_info_s
 {
         uint8_t offset;
@@ -151,6 +182,7 @@ int dni_i2c_lock_read_attribute(mux_info_t * mux_info, char * fullpath);
 int dni_i2c_lock_write_attribute(mux_info_t * mux_info, char * data,char * fullpath);
 int dni_psu_present(int *r_data);
 int dni_bmc_data_get(int bus, int addr, int reg, int len, int *r_data);
+int dni_bmc_data_set(int bus, int addr, int reg, uint8_t w_data);
 void lockinit();
 
 char dev_name[50][32];

--- a/packages/platforms/delta/x86-64/x86-64-delta-agc7648sv1/onlp/builds/src/module/src/psui.c
+++ b/packages/platforms/delta/x86-64/x86-64-delta-agc7648sv1/onlp/builds/src/module/src/psui.c
@@ -255,17 +255,6 @@ int onlp_psui_info_get(onlp_oid_t id, onlp_psu_info_t* info)
     memset(info, 0, sizeof(onlp_psu_info_t));
     *info = pinfo[index];
 
-    switch (index) {
-        case PSU1_ID:
-            psu_present = dni_i2c_lock_read_attribute(NULL, PSU1_PRESENT_PATH);
-            break;
-        case PSU2_ID:
-            psu_present = dni_i2c_lock_read_attribute(NULL, PSU2_PRESENT_PATH);
-            break;
-        default:
-            break;
-    }
-
     if(dni_bmc_check() == BMC_ON)
     {
         /* Check PSU have voltage input or not */
@@ -284,6 +273,17 @@ int onlp_psui_info_get(onlp_oid_t id, onlp_psu_info_t* info)
     }
     else
     {
+        switch (index) {
+            case PSU1_ID:
+                psu_present = dni_i2c_lock_read_attribute(NULL, PSU1_PRESENT_PATH);
+                break;
+            case PSU2_ID:
+                psu_present = dni_i2c_lock_read_attribute(NULL, PSU2_PRESENT_PATH);
+                break;
+            default:
+                break;
+        }
+
         /* Check PSU have voltage input or not */
         dni_psu_pmbus_info_get(index, "psu_v_in", &val);
 

--- a/packages/platforms/delta/x86-64/x86-64-delta-agc7648sv1/onlp/builds/src/module/src/sfpi.c
+++ b/packages/platforms/delta/x86-64/x86-64-delta-agc7648sv1/onlp/builds/src/module/src/sfpi.c
@@ -77,22 +77,43 @@ int onlp_sfpi_bitmap_get(onlp_sfp_bitmap_t* bmap)
   
 int onlp_sfpi_is_present(int port)
 {
-    char port_data[3] = {'\0'};
-    int present, present_bit;
+    uint8_t reg_t = 0x00;
+    int bit_t = 0x00;
+    int present, present_bit = 0x00;
 
-    if(port > 0 && port < 55)
-    {
-        /* Select QSFP/SFP port */
-        sprintf(port_data, "%d", port );
-        if(dni_i2c_lock_write_attribute(NULL, port_data, SFP_SELECT_PORT_PATH) < 0){
-            AIM_LOG_ERROR("Unable to select port(%d)\r\n", port);
-        }
+    if (port > 0 && port < 9) {          /* SFP Port 1-8 */
+        reg_t = SFP_PRESENCE_1;
+    } else if (port > 8 && port < 17) {  /* SFP Port 9-16 */
+        reg_t = SFP_PRESENCE_2;
+    } else if (port > 16 && port < 25) { /* SFP Port 17-24 */
+        reg_t = SFP_PRESENCE_3;
+    } else if (port > 24 && port < 33) { /* SFP Port 25-32 */
+        reg_t = SFP_PRESENCE_4;
+    } else if (port > 32 && port < 41) { /* SFP Port 33-40 */
+        reg_t = SFP_PRESENCE_5;
+    } else if (port > 40 && port < 49) { /* SFP Port 41-48 */
+        reg_t = SFP_PRESENCE_6;
+    } else if (port > 48 && port < 55) { /* QSFP Port 1-6 */
+        reg_t = QSFP_PRESENCE;
+    } else {
+        present_bit = 1; /* return 1, module is not present */
+    }
 
-        /* Read QSFP/SFP MODULE is present or not */
-        present_bit = dni_i2c_lock_read_attribute(NULL, SFP_IS_PRESENT_PATH);
-        if(present_bit < 0){
-            AIM_LOG_ERROR("Unable to read present or not from port(%d)\r\n", port);
-        }
+    if (port > 48 && port < 55) { /* QSFP */
+        if (dni_bmc_data_get(BMC_SWPLD_BUS, SWPLD_1_ADDR, reg_t, 1, &present_bit) != ONLP_STATUS_OK)
+            return ONLP_STATUS_E_INTERNAL;
+        port = port - 1;
+        bit_t = 1 << (port % 8);
+        present_bit = present_bit & bit_t;
+        present_bit = present_bit / bit_t;
+	}
+    else { /* SFP */
+        if (dni_bmc_data_get(BMC_SWPLD_BUS, SWPLD_2_ADDR, reg_t, 1, &present_bit) != ONLP_STATUS_OK)
+            return ONLP_STATUS_E_INTERNAL;
+        port = port - 1;
+        bit_t = 1 << (port % 8);
+        present_bit = present_bit & bit_t;
+        present_bit = present_bit / bit_t;
     }
 
     /* From sfp_is_present value,
@@ -113,9 +134,9 @@ int onlp_sfpi_is_present(int port)
 
 int onlp_sfpi_presence_bitmap_get(onlp_sfp_bitmap_t* dst)
 {
-    char present_all_data[21] = {'\0'};
-    char *r_byte;
-    char *r_array[7];
+    uint8_t reg_t = 0x00;
+    int present_data = 0x00;
+    uint8_t r_array[7] = {0};
     uint8_t bytes[7] = {0};
     int count = 0;
 
@@ -123,22 +144,24 @@ int onlp_sfpi_presence_bitmap_get(onlp_sfp_bitmap_t* dst)
      * if only port 0 is present,    return 3F FF FF FF FF FF FE
      * if only port 0 and 1 present, return 3F FF FF FF FF FF FC */
 
-    if(dni_i2c_read_attribute_string(SFP_IS_PRESENT_ALL_PATH, present_all_data,
-                                         sizeof(present_all_data), 0) < 0) {
-        return -1;
-    }
-
-    /* String split */
-    r_byte = strtok(present_all_data, " ");
-    while (r_byte != NULL) {
-        r_array[count++] = r_byte;
-        r_byte = strtok(NULL, " ");
-    }
-
-    /* Convert a string to unsigned 8 bit integer
-     * and saved into bytes[] */
     for (count = 0; count < 7; count++) {
-        bytes[count] = ~strtol(r_array[count], NULL, 16);
+        if (count < 6) { /* SFP Port 1-48 */
+            reg_t = SFP_PRESENCE_1 + count;
+            if (dni_bmc_data_get(BMC_SWPLD_BUS, SWPLD_2_ADDR, reg_t, 1, &present_data) != ONLP_STATUS_OK)
+                return ONLP_STATUS_E_INTERNAL;
+            r_array[count] = present_data;
+        }
+        else { /* QSFP Port 49-54 */
+            reg_t = QSFP_PRESENCE;
+            if (dni_bmc_data_get(BMC_SWPLD_BUS, SWPLD_1_ADDR, reg_t, 1, &present_data) != ONLP_STATUS_OK)
+                 return ONLP_STATUS_E_INTERNAL;
+            r_array[count] = present_data;
+        }
+    }
+
+    /* Invert r_array[] and reverse elements, saved into bytes[] */
+    for (count = 0; count < 7; count++) {
+        bytes[count] = ~r_array[6 - count];
     }
 
     /* Mask out non-existant SFP/QSFP ports */
@@ -189,60 +212,152 @@ int onlp_sfpi_port_map(int port, int* rport)
 int onlp_sfpi_control_get(int port, onlp_sfp_control_t control, int* value)
 {
     int value_t;
-    char port_data[3] = {'\0'};
-
-    if(port > 0 && port < 55)
-    {
-        /* Select SFP(1-48), QSFP(49-54) port */
-        sprintf(port_data, "%d", port );
-        if(dni_i2c_lock_write_attribute(NULL, port_data, SFP_SELECT_PORT_PATH) < 0){
-            AIM_LOG_INFO("Unable to select port(%d)\r\n", port);
-            return ONLP_STATUS_E_INTERNAL;
-        }
-    }
+    uint8_t reg_t = 0x00;
+    int rdata_bit = 0x00;
+    int bit_t = 0x00;
 
     switch (control) {   
         case ONLP_SFP_CONTROL_RESET_STATE:
             /* From sfp_reset value,
              * return 0 = The module is in Reset
-             * return 1 = The module is NOT in Reset */
-            *value = dni_i2c_lock_read_attribute(NULL, QSFP_RESET_PATH);
-            if (*value == 0)
-            {
+             * return 1 = The module is not in Reset */
+
+            if (port > 48 && port < 55) { /* QSFP Port 49-54 */
+                reg_t = QSFP_RESET;
+                if (dni_bmc_data_get(BMC_SWPLD_BUS, SWPLD_1_ADDR, reg_t, 1, &rdata_bit) != ONLP_STATUS_OK)
+                    return ONLP_STATUS_E_INTERNAL;
+                port = port - 1;
+                bit_t = 1 << (port % 8);
+                rdata_bit = rdata_bit & bit_t;
+                rdata_bit = rdata_bit / bit_t;
+            } else { /* In agc7648sv1 only QSFP support control RESET MODE */
+                rdata_bit = 1; /* return 1, module not in reset mode */
+            }
+
+            if (rdata_bit == 0)
                 *value = 1;
-            }
-            else if (*value == 1)
-            {
+            else if (rdata_bit == 1)
                 *value = 0;
-            }
+
             value_t = ONLP_STATUS_OK;
             break;
         case ONLP_SFP_CONTROL_RX_LOS:
             /* From sfp_rx_los value,
              * return 0 = The module is Normal Operation
              * return 1 = The module is Error */
-            *value = dni_i2c_lock_read_attribute(NULL, SFP_RX_LOS_PATH);
+
+            if (port > 0 && port < 49) { /* SFP */
+                if (port > 0 && port < 9) {          /* SFP Port 1-8 */
+                    reg_t = SFP_RXLOS_1;
+                } else if (port > 8 && port < 17) {  /* SFP Port 9-16 */
+                    reg_t = SFP_RXLOS_2;
+                } else if (port > 16 && port < 25) { /* SFP Port 17-24 */
+                    reg_t = SFP_RXLOS_3;
+                } else if (port > 24 && port < 33) { /* SFP Port 25-32 */
+                    reg_t = SFP_RXLOS_4;
+                } else if (port > 32 && port < 41) { /* SFP Port 33-40 */
+                    reg_t = SFP_RXLOS_5;
+                } else if (port > 40 && port < 49) { /* SFP Port 41-48 */
+                    reg_t = SFP_RXLOS_6;
+                }
+                if (dni_bmc_data_get(BMC_SWPLD_BUS, SWPLD_2_ADDR, reg_t, 1, &rdata_bit) != ONLP_STATUS_OK)
+                    return ONLP_STATUS_E_INTERNAL;
+				port = port - 1;
+				bit_t = 1 << (port % 8);
+				rdata_bit = rdata_bit & bit_t;
+				rdata_bit = rdata_bit / bit_t;
+            }
+            else { /* In agc7648sv1 only SFP support control RX_LOS MODE */
+                rdata_bit = 1; /* return 1, module Error */
+            }
+            *value = rdata_bit;
+
             value_t = ONLP_STATUS_OK;
             break;
         case ONLP_SFP_CONTROL_TX_DISABLE:
             /* From sfp_tx_disable value,
              * return 0 = The module is Enable Transmitter on
              * return 1 = The module is Transmitter Disabled */
-            *value = dni_i2c_lock_read_attribute(NULL, SFP_TX_DISABLE_PATH);
+
+            if (port > 0 && port < 49) { /* SFP */
+                if (port > 0 && port < 9) {          /* SFP Port 1-8 */
+                    reg_t = SFP_TXDIS_1;
+                } else if (port > 8 && port < 17) {  /* SFP Port 9-16 */
+                    reg_t = SFP_TXDIS_2;
+                } else if (port > 16 && port < 25) { /* SFP Port 17-24 */
+                    reg_t = SFP_TXDIS_3;
+                } else if (port > 24 && port < 33) { /* SFP Port 25-32 */
+                    reg_t = SFP_TXDIS_4;
+                } else if (port > 32 && port < 41) { /* SFP Port 33-40 */
+                    reg_t = SFP_TXDIS_5;
+                } else if (port > 40 && port < 49) { /* SFP Port 41-48 */
+                    reg_t = SFP_TXDIS_6;
+                }
+                if (dni_bmc_data_get(BMC_SWPLD_BUS, SWPLD_2_ADDR, reg_t, 1, &rdata_bit) != ONLP_STATUS_OK)
+                    return ONLP_STATUS_E_INTERNAL;
+				port = port - 1;
+				bit_t = 1 << (port % 8);
+				rdata_bit = rdata_bit & bit_t;
+				rdata_bit = rdata_bit / bit_t;
+            }
+            else { /* In agc7648sv1 only SFP support control TX_DISABLE MODE */
+                rdata_bit = 1; /* return 1, module Transmitter Disabled */
+            }
+            *value = rdata_bit;
+
             value_t = ONLP_STATUS_OK;
             break;
         case ONLP_SFP_CONTROL_TX_FAULT:
             /* From sfp_tx_fault value,
              * return 0 = The module is Normal
              * return 1 = The module is Fault */
-            *value = dni_i2c_lock_read_attribute(NULL, SFP_TX_FAULT_PATH);
+
+            if (port > 0 && port < 49) { /* SFP */
+                if (port > 0 && port < 9) {          /* SFP Port 1-8 */
+                    reg_t = SFP_TXFAULT_1;
+                } else if (port > 8 && port < 17) {  /* SFP Port 9-16 */
+                    reg_t = SFP_TXFAULT_2;
+                } else if (port > 16 && port < 25) { /* SFP Port 17-24 */
+                    reg_t = SFP_TXFAULT_3;
+                } else if (port > 24 && port < 33) { /* SFP Port 25-32 */
+                    reg_t = SFP_TXFAULT_4;
+                } else if (port > 32 && port < 41) { /* SFP Port 33-40 */
+                    reg_t = SFP_TXFAULT_5;
+                } else if (port > 40 && port < 49) { /* SFP Port 41-48 */
+                    reg_t = SFP_TXFAULT_6;
+                }
+                if (dni_bmc_data_get(BMC_SWPLD_BUS, SWPLD_2_ADDR, reg_t, 1, &rdata_bit) != ONLP_STATUS_OK)
+                    return ONLP_STATUS_E_INTERNAL;
+				port = port - 1;
+				bit_t = 1 << (port % 8);
+				rdata_bit = rdata_bit & bit_t;
+				rdata_bit = rdata_bit / bit_t;
+            }
+            else { /* In agc7648sv1 only SFP support control TX_FAULT MODE */
+                rdata_bit = 1; /* return 1, module is Fault */
+            }
+            *value = rdata_bit;
+
             value_t = ONLP_STATUS_OK;
             break;
         case ONLP_SFP_CONTROL_LP_MODE:
             /* From sfp_lp_mode value,
-             * return 0 = The module is NOT in LP mode
+             * return 0 = The module is not in LP mode
              * return 1 = The module is in LP mode */
-            *value = dni_i2c_lock_read_attribute(NULL, QSFP_LP_MODE_PATH);
+
+            if (port > 48 && port < 55) { /* QSFP Port 49-54 */
+                reg_t = QSFP_LPMODE;
+                if (dni_bmc_data_get(BMC_SWPLD_BUS, SWPLD_1_ADDR, reg_t, 1, &rdata_bit) != ONLP_STATUS_OK)
+                    return ONLP_STATUS_E_INTERNAL;
+                port = port - 1;
+                bit_t = 1 << (port % 8);
+                rdata_bit = rdata_bit & bit_t;
+                rdata_bit = rdata_bit / bit_t;
+            } else { /* In agc7648sv1 only QSFP support control LP MODE */
+                rdata_bit = 0; /* return 0, module is not in LP mode */
+            }
+            *value = rdata_bit;
+
             value_t = ONLP_STATUS_OK;
             break;
         default:
@@ -255,47 +370,103 @@ int onlp_sfpi_control_get(int port, onlp_sfp_control_t control, int* value)
 int onlp_sfpi_control_set(int port, onlp_sfp_control_t control, int value)
 {
     int value_t;
-    char port_data[3] = {'\0'};
-
-    if(port > 0 && port < 55)
-    {
-        /* Select SFP(1-48), QSFP(49-54) port */
-        sprintf(port_data, "%d", port );
-        if(dni_i2c_lock_write_attribute(NULL, port_data, SFP_SELECT_PORT_PATH) < 0){
-            AIM_LOG_INFO("Unable to select port(%d)\r\n", port);
-            return ONLP_STATUS_E_INTERNAL;
-        }
-    }
+    uint8_t reg_t = 0x00;
+    int data_bit = 0x00;
+    int bit_t = 0x00;
 
     switch (control) {
         case ONLP_SFP_CONTROL_RESET_STATE:
-            sprintf(port_data, "%d", value);
-            if(dni_i2c_lock_write_attribute(NULL, port_data, QSFP_RESET_PATH) < 0){
-                AIM_LOG_INFO("Unable to control reset state from port(%d)\r\n", port);
-                value_t = ONLP_STATUS_E_INTERNAL;
+            if (port > 48 && port < 55) { /* QSFP Port 49-54 */
+                reg_t = QSFP_RESET;
+                if (dni_bmc_data_get(BMC_SWPLD_BUS, SWPLD_1_ADDR, reg_t, 1, &data_bit) != ONLP_STATUS_OK)
+                    return ONLP_STATUS_E_INTERNAL;
+                /* Indicate the module is in reset mode or not
+                 * 0 = Reset
+                 * 1 = Normal */
+                port = port - 1;
+                if (value == 0) {
+                    bit_t = ~(1 << (port % 8));
+                    data_bit = data_bit & bit_t;
+                }
+                else if (value == 1) {
+                    bit_t = (1 << (port % 8));
+                    data_bit = data_bit | bit_t;
+                }
+                if (dni_bmc_data_set(BMC_SWPLD_BUS, SWPLD_1_ADDR, reg_t, (uint8_t)data_bit) != ONLP_STATUS_OK)
+                    return ONLP_STATUS_E_INTERNAL;
+            } else {
+                return ONLP_STATUS_E_UNSUPPORTED;
             }
+
             value_t = ONLP_STATUS_OK;
             break;
         case ONLP_SFP_CONTROL_RX_LOS:
             value_t = ONLP_STATUS_E_UNSUPPORTED;
             break;
         case ONLP_SFP_CONTROL_TX_DISABLE:
-            sprintf(port_data, "%d", value);
-            if(dni_i2c_lock_write_attribute(NULL, port_data, SFP_TX_DISABLE_PATH) < 0){
-                AIM_LOG_INFO("Unable to control tx disable from port(%d)\r\n", port);
-                value_t = ONLP_STATUS_E_INTERNAL;
+            if (port > 0 && port < 49) { /* SFP */
+                if (port > 0 && port < 9) {          /* SFP Port 1-8 */
+                    reg_t = SFP_TXDIS_1;
+                } else if (port > 8 && port < 17) {  /* SFP Port 9-16 */
+                    reg_t = SFP_TXDIS_2;
+                } else if (port > 16 && port < 25) { /* SFP Port 17-24 */
+                    reg_t = SFP_TXDIS_3;
+                } else if (port > 24 && port < 33) { /* SFP Port 25-32 */
+                    reg_t = SFP_TXDIS_4;
+                } else if (port > 32 && port < 41) { /* SFP Port 33-40 */
+                    reg_t = SFP_TXDIS_5;
+                } else if (port > 40 && port < 49) { /* SFP Port 41-48 */
+                    reg_t = SFP_TXDIS_6;
+                }
+
+                if (dni_bmc_data_get(BMC_SWPLD_BUS, SWPLD_2_ADDR, reg_t, 1, &data_bit) != ONLP_STATUS_OK)
+                    return ONLP_STATUS_E_INTERNAL;
+                /* Indicate the module is Enable Transmitter on or not
+                 * 0 = Enable
+                 * 1 = Disable */
+                port = port - 1;
+                if (value == 0) {
+                    bit_t = ~(1 << (port % 8));
+                    data_bit = data_bit & bit_t;
+                }
+                else if (value == 1) {
+                    bit_t = (1 << (port % 8));
+                    data_bit = data_bit | bit_t;
+                }
+                if (dni_bmc_data_set(BMC_SWPLD_BUS, SWPLD_2_ADDR, reg_t, (uint8_t)data_bit) != ONLP_STATUS_OK)
+                    return ONLP_STATUS_E_INTERNAL;
+            } else {
+                return ONLP_STATUS_E_UNSUPPORTED;
             }
+
             value_t = ONLP_STATUS_OK;
             break;
         case ONLP_SFP_CONTROL_TX_FAULT:
             value_t = ONLP_STATUS_E_UNSUPPORTED;
             break;
         case ONLP_SFP_CONTROL_LP_MODE:
-            sprintf(port_data, "%d", value);
-            if(dni_i2c_lock_write_attribute(NULL, port_data, QSFP_LP_MODE_PATH) < 0){
-                AIM_LOG_INFO("Unable to control LP mode from port(%d)\r\n", port);
-                value_t = ONLP_STATUS_E_INTERNAL;
+            if (port > 48 && port < 55) { /* QSFP Port 49-54 */
+                reg_t = QSFP_LPMODE;
+                if (dni_bmc_data_get(BMC_SWPLD_BUS, SWPLD_1_ADDR, reg_t, 1, &data_bit) != ONLP_STATUS_OK)
+                    return ONLP_STATUS_E_INTERNAL;
+                /* Indicate the module is in LP mode or not
+                 * 0 = Disable
+                 * 1 = Enable */
+                port = port - 1;
+                if (value == 0) {
+                    bit_t = ~(1 << (port % 8));
+                    data_bit = data_bit & bit_t;
+                }
+                else if (value == 1) {
+                    bit_t = (1 << (port % 8));
+                    data_bit = data_bit | bit_t;
+                }
+                if (dni_bmc_data_set(BMC_SWPLD_BUS, SWPLD_1_ADDR, reg_t, (uint8_t)data_bit) != ONLP_STATUS_OK)
+                    return ONLP_STATUS_E_INTERNAL;
+            } else {
+                return ONLP_STATUS_E_UNSUPPORTED;
             }
+
             value_t = ONLP_STATUS_OK;
             break;
         default:
@@ -340,18 +511,6 @@ int onlp_sfpi_dev_writew(int port, uint8_t devaddr, uint8_t addr, uint16_t value
 
 int onlp_sfpi_control_supported(int port, onlp_sfp_control_t control, int* rv)
 {
-    char port_data[3] = {'\0'};
-
-    if(port > 0 && port < 55)
-    {
-        /* Select SFP(1-48), QSFP(49-54) port */
-        sprintf(port_data, "%d", port);
-        if(dni_i2c_lock_write_attribute(NULL, port_data, SFP_SELECT_PORT_PATH) < 0){
-            AIM_LOG_INFO("Unable to select port(%d)\r\n", port);
-            return ONLP_STATUS_E_INTERNAL;
-        }
-    }
-
     switch (control) {
         case ONLP_SFP_CONTROL_RESET_STATE:
             if(port > 48 && port < 55) /* QSFP */
@@ -396,9 +555,9 @@ int onlp_sfpi_denit(void)
 
 int onlp_sfpi_rx_los_bitmap_get(onlp_sfp_bitmap_t* dst)
 {
-    char rxlos_all_data[18] = {'\0'};
-    char *r_byte;
-    char *r_array[6];
+    uint8_t reg_t = 0x00;
+    int rxlos_data = 0x00;
+    uint8_t r_array[6] = {0};
     uint8_t bytes[6] = {0};
     int count = 0;
 
@@ -406,22 +565,16 @@ int onlp_sfpi_rx_los_bitmap_get(onlp_sfp_bitmap_t* dst)
      * if only port 0 is normal operation,    return FF FF FF FF FF FE
      * if only port 0 and 1 normal operation, return FF FF FF FF FF FC */
 
-    if(dni_i2c_read_attribute_string(SFP_RX_LOS_ALL_PATH, rxlos_all_data,
-                                         sizeof(rxlos_all_data), 0) < 0) {
-        return -1;
+    for (count = 0; count < 6; count++) { /* SFP Port 1-48 */
+        reg_t = SFP_RXLOS_1 + count;
+        if (dni_bmc_data_get(BMC_SWPLD_BUS, SWPLD_2_ADDR, reg_t, 1, &rxlos_data) != ONLP_STATUS_OK)
+            return ONLP_STATUS_E_INTERNAL;
+        r_array[count] = rxlos_data;
     }
 
-    /* String split */
-    r_byte = strtok(rxlos_all_data, " ");
-    while (r_byte != NULL) {
-        r_array[count++] = r_byte;
-        r_byte = strtok(NULL, " ");
-    }
-
-    /* Convert a string to unsigned 8 bit integer
-     * and saved into bytes[] */
+    /* Invert r_array[] and saved into bytes[] */
     for (count = 0; count < 6; count++) {
-        bytes[count] = strtol(r_array[count], NULL, 16);
+        bytes[count] = r_array[5 - count];
     }
 
     /* Convert to 64 bit integer in port order */

--- a/packages/platforms/delta/x86-64/x86-64-delta-agc7648sv1/platform-config/r0/src/python/x86_64_delta_agc7648sv1_r0/__init__.py
+++ b/packages/platforms/delta/x86-64/x86-64-delta-agc7648sv1/platform-config/r0/src/python/x86_64_delta_agc7648sv1_r0/__init__.py
@@ -1,6 +1,7 @@
 from onl.platform.base import *
 from onl.platform.delta import *
 import os.path
+import subprocess
 
 class OnlPlatform_x86_64_delta_agc7648sv1_r0(OnlPlatformDelta,
                                               OnlPlatformPortConfig_32x100):
@@ -10,7 +11,13 @@ class OnlPlatform_x86_64_delta_agc7648sv1_r0(OnlPlatformDelta,
 
 
     def baseconfig(self):
+        #Check BMC monitor status
+        bmc_mon_status = subprocess.check_output('ipmitool raw 0x38 0x1a 0x00', shell=True)
+        if bmc_mon_status == ' 00\n':
+            os.system("ipmitool raw 0x38 0x0a 1")
+
         #Remove and rescan bus
+        os.system("i2cset -y 0 0x31 0x14 0xfd")
         os.system("echo 1 > /sys/bus/i2c/devices/i2c-0/firmware_node/physical_node/remove")
         os.system("echo 1 > /sys/bus/pci/rescan")
 
@@ -37,6 +44,12 @@ class OnlPlatform_x86_64_delta_agc7648sv1_r0(OnlPlatformDelta,
         os.system("echo 497 > /sys/class/gpio/export")
         os.system("echo 498 > /sys/class/gpio/export")
         os.system("echo 499 > /sys/class/gpio/export")
+
+        #Restore BMC Monitor status
+        if bmc_mon_status == ' 00\n':
+            os.system("ipmitool raw 0x38 0x0a 0")
+        elif bmc_mon_status == ' 01\n':
+            os.system("ipmitool raw 0x38 0x0a 1")
 
         return True
 

--- a/packages/platforms/delta/x86-64/x86-64-delta-agc7648sv1/platform-config/r0/src/python/x86_64_delta_agc7648sv1_r0/__init__.py
+++ b/packages/platforms/delta/x86-64/x86-64-delta-agc7648sv1/platform-config/r0/src/python/x86_64_delta_agc7648sv1_r0/__init__.py
@@ -51,5 +51,8 @@ class OnlPlatform_x86_64_delta_agc7648sv1_r0(OnlPlatformDelta,
         elif bmc_mon_status == ' 01\n':
             os.system("ipmitool raw 0x38 0x0a 1")
 
+        #Prevent onlpd and onlp-snmpd access i2c peripherals
+        os.system("i2cset -y -f 0 0x31 0x14 0xfc")
+
         return True
 


### PR DESCRIPTION
The gpio_pca953x driver export gpio value for fan present bit.
However, it will lead to GPIO driver init fail by CPU and BMC access buses at the same time while system is bring up.
In order to prevent bus conflict, to disable BMC Monitor function before kernel drivers initialization.