### PR TITLE
Add broadcom tg3 support 100M/10M feature.

### DIFF
--- a/packages/base/any/kernels/4.14-lts/patches/0003-drivers-net-ethernet-broadcom-tg3.patch
+++ b/packages/base/any/kernels/4.14-lts/patches/0003-drivers-net-ethernet-broadcom-tg3.patch
@@ -1,0 +1,16 @@
+diff -Naur a/drivers/net/ethernet/broadcom/tg3.c b/drivers/net/ethernet/broadcom/tg3.c
+--- a/drivers/net/ethernet/broadcom/tg3.c	2019-03-27 13:13:56.000000000 +0800
++++ b/drivers/net/ethernet/broadcom/tg3.c	2019-04-26 11:08:20.307848693 +0800
+@@ -11734,6 +11734,12 @@
+ 		pci_set_power_state(tp->pdev, PCI_D3hot);
+ 	}
+
++	if (tg3_asic_rev(tp) == ASIC_REV_5720){
++		/*Fixed ASIC_REV_5720 support 100M/10M feature */
++       __tg3_writephy(tp, 0x8, 0x10, 0x1d0);
++       __tg3_writephy(tp, 0x1f, 0x4, 0x5e1);
++	}
++
+ 	return err;
+ }
+

--- a/packages/base/any/kernels/4.14-lts/patches/series
+++ b/packages/base/any/kernels/4.14-lts/patches/series
@@ -3,4 +3,5 @@ drivers-usb-phy-phy-xgs-iproc-usb-phy-mode.patch
 drivers-i2c-busses-xgs_iproc_smbus-clk-freq.patch
 0001-drivers-i2c-muxes-pca954x-deselect-on-exit.patch
 0002-driver-support-intel-igb-bcm5461S-phy.patch
+0003-drivers-net-ethernet-broadcom-tg3.patch
 driver-ixgbe-external-phy.patch


### PR DESCRIPTION
This is for the patch the Broadcom tg3 driver to support 100M/10M Ethernet port.
The patch has been verified in platform_accton_asxvolt16. Note that the patch didn't include CONFIG_TIGON3_PHY_SERDES which is not used for accton_asxvolt16.