### PR TITLE
we change the method to get PSU's EEPROM data.

### DIFF
--- a/packages/platforms/accton/x86-64/x86-64-accton-wedge100bf-32x/onlp/builds/src/module/src/platform_lib.h
+++ b/packages/platforms/accton/x86-64/x86-64-accton-wedge100bf-32x/onlp/builds/src/module/src/platform_lib.h
@@ -58,9 +58,11 @@ enum onlp_thermal_id
 };
 
 int bmc_send_command(char *cmd);
+int bmc_file_read_str(char *file, char *result, int slen);
 int bmc_file_read_int(int* value, char *file, int base);
 int bmc_i2c_readb(uint8_t bus, uint8_t devaddr, uint8_t addr);
 int bmc_i2c_writeb(uint8_t bus, uint8_t devaddr, uint8_t addr, uint8_t value);
+int bmc_i2c_write_quick_mode(uint8_t bus, uint8_t devaddr, uint8_t value);
 int bmc_i2c_readw(uint8_t bus, uint8_t devaddr, uint8_t addr);
 int bmc_i2c_readraw(uint8_t bus, uint8_t devaddr, uint8_t addr, char* data, int data_size);
 

--- a/packages/platforms/accton/x86-64/x86-64-accton-wedge100bf-65x/onlp/builds/src/module/src/platform_lib.h
+++ b/packages/platforms/accton/x86-64/x86-64-accton-wedge100bf-65x/onlp/builds/src/module/src/platform_lib.h
@@ -58,9 +58,11 @@ enum onlp_thermal_id
 };
 
 int bmc_send_command(char *cmd);
+int bmc_file_read_str(char *file, char *result, int slen);
 int bmc_file_read_int(int* value, char *file, int base);
 int bmc_i2c_readb(uint8_t bus, uint8_t devaddr, uint8_t addr);
 int bmc_i2c_writeb(uint8_t bus, uint8_t devaddr, uint8_t addr, uint8_t value);
+int bmc_i2c_write_quick_mode(uint8_t bus, uint8_t devaddr, uint8_t value);
 int bmc_i2c_readw(uint8_t bus, uint8_t devaddr, uint8_t addr);
 int bmc_i2c_readraw(uint8_t bus, uint8_t devaddr, uint8_t addr, char* data, int data_size);
 


### PR DESCRIPTION
old method: use i2c raw command to access PSU
new method: use OpenBMC's sysfs to access PSU