### PR TITLE
Hide non-onlp symbols (ONLPv2)

### DIFF
--- a/make/onlp.version
+++ b/make/onlp.version
@@ -1,4 +1,4 @@
-LIBONLP_1.0 {
+LIBONLP_2.0 {
     local: cjson*;
            cJSON*;
            aim*;

--- a/make/onlp.version
+++ b/make/onlp.version
@@ -1,0 +1,7 @@
+LIBONLP_1.0 {
+    local: cjson*;
+           cJSON*;
+           aim*;
+           sff*;
+           biglist*;
+};

--- a/packages/base/any/onlp/builds/onlp-platform-defaults/Makefile
+++ b/packages/base/any/onlp/builds/onlp-platform-defaults/Makefile
@@ -44,6 +44,7 @@ include $(BUILDER)/dependmodules.mk
 
 SHAREDLIB := libonlp-platform-defaults.so
 $(SHAREDLIB)_TARGETS := $(ALL_TARGETS)
+LDFLAGS += -Wl,--version-script=$(ONL)/make/onlp.version
 include $(BUILDER)/so.mk
 
 .DEFAULT_GOAL := sharedlibs

--- a/packages/base/any/onlp/builds/onlp-platform/Makefile
+++ b/packages/base/any/onlp/builds/onlp-platform/Makefile
@@ -33,6 +33,7 @@ include $(BUILDER)/dependmodules.mk
 
 SHAREDLIB := libonlp-platform.so
 $(SHAREDLIB)_TARGETS := $(ALL_TARGETS)
+LDFLAGS += -Wl,--version-script=$(ONL)/make/onlp.version
 include $(BUILDER)/so.mk
 
 .DEFAULT_GOAL := sharedlibs

--- a/packages/base/any/onlp/builds/onlp/Makefile
+++ b/packages/base/any/onlp/builds/onlp/Makefile
@@ -36,6 +36,7 @@ include $(BUILDER)/dependmodules.mk
 
 SHAREDLIB := libonlp.so
 $(SHAREDLIB)_TARGETS := $(ALL_TARGETS)
+LDFLAGS += -Wl,--version-script=$(ONL)/make/onlp.version
 include $(BUILDER)/so.mk
 
 .DEFAULT_GOAL := sharedlibs

--- a/packages/base/any/onlp/builds/platform/libonlp-platform.mk
+++ b/packages/base/any/onlp/builds/platform/libonlp-platform.mk
@@ -30,6 +30,7 @@ include $(BUILDER)/dependmodules.mk
 
 SHAREDLIB := libonlp-$(PLATFORM).so
 $(SHAREDLIB)_TARGETS := $(ALL_TARGETS)
+LDFLAGS += -Wl,--version-script=$(ONL)/make/onlp.version
 include $(BUILDER)/so.mk
 .DEFAULT_GOAL := $(SHAREDLIB)
 


### PR DESCRIPTION
ONLP libraries expose some symbols from utilities (e.g., `cJSON_*`) as global binding.
Those symbols cause unexpected behavior to the binary which links to it (libonlp*.so).