### PR TITLE
[as5916-54xm] Detect correct IDPROM i2c address

### DIFF
--- a/packages/platforms/accton/x86-64/x86-64-accton-as5916-54xm/onlp/builds/src/module/src/platform_lib.h
+++ b/packages/platforms/accton/x86-64/x86-64-accton-as5916-54xm/onlp/builds/src/module/src/platform_lib.h
@@ -51,7 +51,8 @@
 #define FAN_BOARD_PATH	"/sys/bus/i2c/devices/9-0066/"
 #define FAN_NODE(node)	FAN_BOARD_PATH#node
 
-#define IDPROM_PATH "/sys/bus/i2c/devices/0-0056/eeprom"
+#define IDPROM_PATH_1 "/sys/bus/i2c/devices/0-0056/eeprom"
+#define IDPROM_PATH_2 "/sys/bus/i2c/devices/0-0057/eeprom"
 
 int onlp_file_write_integer(char *filename, int value);
 int onlp_file_read_binary(char *filename, char *buffer, int buf_size, int data_len);

--- a/packages/platforms/accton/x86-64/x86-64-accton-as5916-54xm/onlp/builds/src/module/src/sysi.c
+++ b/packages/platforms/accton/x86-64/x86-64-accton-as5916-54xm/onlp/builds/src/module/src/sysi.c
@@ -56,26 +56,28 @@ onlp_sysi_platform_get(void)
 int
 onlp_sysi_onie_data_get(uint8_t** data, int* size)
 {
-    int ret = ONLP_STATUS_OK;
-    int i = 0;
     uint8_t* rdata = aim_zmalloc(256);
+    char* idprom_path = NULL; 
+    int   ret = ONLP_STATUS_OK;
 
-    for (i = 0; i < 128; i++) {
-        ret = onlp_i2c_readw(0, 0x56, i*2, ONLP_I2C_F_FORCE);
-        if (ret < 0) {
-            aim_free(rdata);
-            *size = 0;
-            return ret;
-        }
-
-        rdata[i*2]   = ret & 0xff;
-        rdata[i*2+1] = (ret >> 8) & 0xff;
+    ret = onlp_file_find("/sys/bus/i2c/devices/0-0056/", "eeprom", &idprom_path);
+    if (idprom_path) {
+        free(idprom_path);
     }
 
-    *size = 256;
-    *data = rdata;
+    idprom_path = (ONLP_STATUS_OK == ret) ? IDPROM_PATH_1 : IDPROM_PATH_2;
 
-    return ONLP_STATUS_OK;
+    if(onlp_file_read(rdata, 256, size, idprom_path) == ONLP_STATUS_OK) {
+        if(*size == 256) {
+            *data = rdata;
+            return ONLP_STATUS_OK;
+        }
+    }
+
+    aim_free(rdata);
+    *size = 0;
+    return ONLP_STATUS_E_INTERNAL;
+
 }
 
 int


### PR DESCRIPTION
1. IR3570a need to be disabled first to make sure i2c block mode access will work correctly.
2. Detect if IDPROM i2c address is 0x56 or 0x57