### PR TITLE
 Fix ir3570a i2c casue to read eeprom fail

### DIFF
--- a/packages/platforms/accton/x86-64/as5916-54x/platform-config/r1/src/python/x86_64_accton_as5916_54x_r1/__init__.py
+++ b/packages/platforms/accton/x86-64/as5916-54x/platform-config/r1/src/python/x86_64_accton_as5916_54x_r1/__init__.py
@@ -1,6 +1,41 @@
 from onl.platform.base import *
 from onl.platform.accton import *
 
+import commands
+
+#IR3570A chip casue problem when read eeprom by i2c-block mode.
+#It happen when read 16th-byte offset that value is 0x8. So disable chip 
+def disable_i2c_ir3570a(addr):
+    check_i2c="i2cget -y 0 0x4 0x1"
+    status, output = commands.getstatusoutput(check_i2c)
+    if status!=0:
+        return -1
+    cmd = "i2cset -y 0 0x%x 0xE5 0x01" % addr
+    status, output = commands.getstatusoutput(cmd)
+    cmd = "i2cset -y 0 0x%x 0x12 0x02" % addr
+    status, output = commands.getstatusoutput(cmd)
+    return status
+
+def ir3570_check():
+    check_i2c="i2cget -y 0 0x42 0x1"
+    status, output = commands.getstatusoutput(check_i2c)
+    if status!=0:
+        return -1
+    cmd = "i2cdump -y 0 0x42 s 0x9a"
+    try:
+        status, output = commands.getstatusoutput(cmd)
+        lines = output.split('\n')
+        hn = re.findall(r'\w+', lines[-1])
+        version = int(hn[1], 16)
+        if version == 0x24:  #Find IR3570A
+            ret = disable_i2c_ir3570a(4)
+        else:
+            ret = 0
+    except Exception as e:
+        print "Error on ir3570_check() e:" + str(e)
+        return -1
+    return ret
+
 class OnlPlatform_x86_64_accton_as5916_54x_r1(OnlPlatformAccton,
                                               OnlPlatformPortConfig_48x10_6x40):
     PLATFORM='x86-64-accton-as5916-54x-r1'
@@ -69,6 +104,8 @@ class OnlPlatform_x86_64_accton_as5916_54x_r1(OnlPlatformAccton,
 
         for port in range(1, 55):
             subprocess.call('echo port%d > /sys/bus/i2c/devices/%d-0050/port_name' % (port, port+32), shell=True)
+
+        ir3570_check()
 
         return True
 

--- a/packages/platforms/accton/x86-64/as5916-54xm/platform-config/r0/src/python/x86_64_accton_as5916_54xm_r0/__init__.py
+++ b/packages/platforms/accton/x86-64/as5916-54xm/platform-config/r0/src/python/x86_64_accton_as5916_54xm_r0/__init__.py
@@ -1,6 +1,41 @@
 from onl.platform.base import *
 from onl.platform.accton import *
 
+import commands
+
+#IR3570A chip casue problem when read eeprom by i2c-block mode.
+#It happen when read 16th-byte offset that value is 0x8. So disable chip 
+def disable_i2c_ir3570a(addr):
+    check_i2c="i2cget -y 0 0x4 0x1"
+    status, output = commands.getstatusoutput(check_i2c)
+    if status!=0:
+        return -1
+    cmd = "i2cset -y 0 0x%x 0xE5 0x01" % addr
+    status, output = commands.getstatusoutput(cmd)
+    cmd = "i2cset -y 0 0x%x 0x12 0x02" % addr
+    status, output = commands.getstatusoutput(cmd)
+    return status
+
+def ir3570_check():
+    check_i2c="i2cget -y 0 0x42 0x1"
+    status, output = commands.getstatusoutput(check_i2c)
+    if status!=0:
+        return -1
+    cmd = "i2cdump -y 0 0x42 s 0x9a"
+    try:
+        status, output = commands.getstatusoutput(cmd)
+        lines = output.split('\n')
+        hn = re.findall(r'\w+', lines[-1])
+        version = int(hn[1], 16)
+        if version == 0x24:  #Find IR3570A
+            ret = disable_i2c_ir3570a(4)
+        else:
+            ret = 0
+    except Exception as e:
+        print "Error on ir3570_check() e:" + str(e)
+        return -1
+    return ret
+
 class OnlPlatform_x86_64_accton_as5916_54xm_r0(OnlPlatformAccton,
                                               OnlPlatformPortConfig_48x10_6x40):
     PLATFORM='x86-64-accton-as5916-54xm-r0'
@@ -85,6 +120,8 @@ class OnlPlatform_x86_64_accton_as5916_54xm_r0(OnlPlatformAccton,
         for port in range(1, 49):
             self.new_i2c_device('optoe2', 0x50, port+40)
             subprocess.call('echo port%d > /sys/bus/i2c/devices/%d-0050/port_name' % (port, port+40), shell=True)
+
+        ir3570_check()
 
         return True
 

--- a/packages/platforms/accton/x86-64/as7726-32x/platform-config/r0/src/python/x86_64_accton_as7726_32x_r0/__init__.py
+++ b/packages/platforms/accton/x86-64/as7726-32x/platform-config/r0/src/python/x86_64_accton_as7726_32x_r0/__init__.py
@@ -1,6 +1,42 @@
 from onl.platform.base import *
 from onl.platform.accton import *
 
+import commands
+
+#IR3570A chip casue problem when read eeprom by i2c-block mode.
+#It happen when read 16th-byte offset that value is 0x8. So disable chip 
+def disable_i2c_ir3570a(addr):
+    check_i2c="i2cget -y 0 0x4 0x1"
+    status, output = commands.getstatusoutput(check_i2c)
+    if status!=0:
+        return -1
+    cmd = "i2cset -y 0 0x%x 0xE5 0x01" % addr
+    status, output = commands.getstatusoutput(cmd)
+    cmd = "i2cset -y 0 0x%x 0x12 0x02" % addr
+    status, output = commands.getstatusoutput(cmd)
+    return status
+
+def ir3570_check():
+    check_i2c="i2cget -y 0 0x42 0x1"
+    status, output = commands.getstatusoutput(check_i2c)
+    if status!=0:
+        return -1
+    cmd = "i2cdump -y 0 0x42 s 0x9a"
+    try:
+        status, output = commands.getstatusoutput(cmd)
+        lines = output.split('\n')
+        hn = re.findall(r'\w+', lines[-1])
+        version = int(hn[1], 16)
+        if version == 0x24:  #Find IR3570A
+            ret = disable_i2c_ir3570a(4)
+        else:
+            ret = 0
+    except Exception as e:
+        print "Error on ir3570_check() e:" + str(e)
+        return -1
+    return ret
+
+
 class OnlPlatform_x86_64_accton_as7726_32x_r0(OnlPlatformAccton,
                                               OnlPlatformPortConfig_48x25_6x100):
 
@@ -98,7 +134,8 @@ class OnlPlatform_x86_64_accton_as7726_32x_r0(OnlPlatformAccton,
             self.new_i2c_device('optoe1', 0x50, port-18)
             subprocess.call('echo port%d > /sys/bus/i2c/devices/%d-0050/port_name' % (port, port-18), shell=True)
 
-        
-       
         self.new_i2c_device('24c02', 0x56, 0)
+
+        ir3570_check() 
+
         return True


### PR DESCRIPTION
 Fix ir3570a i2c casue to read eeprom fail