### PR TITLE
Fix to set Intel-iommu=off as default. Note that if Intel-iommu is se…

### DIFF
--- a/packages/platforms/accton/x86-64/asgvolt64/platform-config/r0/src/lib/x86-64-accton-asgvolt64-r0.yml
+++ b/packages/platforms/accton/x86-64/asgvolt64/platform-config/r0/src/lib/x86-64-accton-asgvolt64-r0.yml
@@ -25,6 +25,7 @@ x86-64-accton-asgvolt64-r0:
       console=ttyS0,115200n8
       tg3.short_preamble=1
       tg3.bcm5718s_reset=1
+      intel_iommu=off
 
   ##network:
   ##  interfaces:


### PR DESCRIPTION
This is the fix the to correct failure of GPON chip initialization for ASGVOLT64.
In the master, the kernel config is set to Intel-iommu=ON as default. For ASGVOLT64, it is required to set Intel-iommu=OFF as default.