### PR TITLE
Fix to set Intel-iommu=off as default for ASXVOLT16. Note that if Int…

### DIFF
--- a/packages/platforms/accton/x86-64/asxvolt16/platform-config/r0/src/lib/x86-64-accton-asxvolt16-r0.yml
+++ b/packages/platforms/accton/x86-64/asxvolt16/platform-config/r0/src/lib/x86-64-accton-asxvolt16-r0.yml
@@ -25,6 +25,7 @@ x86-64-accton-asxvolt16-r0:
       console=ttyS0,115200n8
       tg3.short_preamble=1
       tg3.bcm5718s_reset=1
+      intel_iommu=off
 
   ##network:
   ##  interfaces:


### PR DESCRIPTION
This is the fix the to correct failure of GPON chip initialization for ASXVOLT16.
In the master, the kernel config is set to Intel-iommu=ON as default. For ASXVOLT16, it is required to set Intel-iommu=OFF as default.