### PR TITLE
Fix onlpd memory leakage for s9180 bmc enabled platform

### DIFF
--- a/packages/base/any/onlp/src/onlp/module/src/platform_manager.c
+++ b/packages/base/any/onlp/src/onlp/module/src/platform_manager.c
@@ -306,6 +306,8 @@ platform_psus_notify__(void)
         ONLP_OID_TABLE_ITER_TYPE(si.hdr.coids, oidp, PSU) {
             psu_oid_table[i++] = *oidp;
         }
+        /* free allocated memory */
+        onlp_sys_info_free(&si);
     }
 
     for(i = 0; i < AIM_ARRAYSIZE(psu_oid_table); i++) {
@@ -417,6 +419,8 @@ platform_fans_notify__(void)
         ONLP_OID_TABLE_ITER_TYPE(si.hdr.coids, oidp, FAN) {
             fan_oid_table[i++] = *oidp;
         }
+        /* free allocated memory */
+        onlp_sys_info_free(&si);
     }
 
     for(i = 0; i < AIM_ARRAYSIZE(fan_oid_table); i++) {

--- a/packages/platforms/ingrasys/x86-64/s9180-32x/onlp/builds/x86_64_ingrasys_s9180_32x/module/src/sysi.c
+++ b/packages/platforms/ingrasys/x86-64/s9180-32x/onlp/builds/x86_64_ingrasys_s9180_32x/module/src/sysi.c
@@ -84,6 +84,14 @@ onlp_sysi_onie_data_get(uint8_t** data, int* size)
     return ONLP_STATUS_E_INTERNAL;
 }
 
+void
+onlp_sysi_onie_data_free(uint8_t* data)
+{
+    if (data) {
+        aim_free(data);
+    }
+}
+
 int
 onlp_sysi_oids_get(onlp_oid_t* table, int max)
 {
@@ -379,5 +387,17 @@ onlp_sysi_platform_info_get(onlp_platform_info_t* pi)
     }
     
     return ONLP_STATUS_OK;
+}
+
+void
+onlp_sysi_platform_info_free(onlp_platform_info_t* pi)
+{
+    if (pi->cpld_versions) {
+        aim_free(pi->cpld_versions);
+    }
+
+    if (pi->cpld_versions) {
+        aim_free(pi->other_versions);
+    }
 }
 


### PR DESCRIPTION
This commit including following changes :
1. add 2 functions (onlp_sysi_onie_data_free, onlp_sysi_platform_info_free) in sysi.c to free allocated memory for s9180 platform
2.  add onlp_sys_info_free after invoking onlp_sys_info_get to free allocated memory in platform_manager.c