### PR TITLE
[as5916-54xks] Fix PSU incorrect serial number/model name issue

### DIFF
--- a/packages/platforms/accton/x86-64/as5916-54xks/onlp/builds/x86_64_accton_as5916_54xks/module/src/psui.c
+++ b/packages/platforms/accton/x86-64/as5916-54xks/onlp/builds/x86_64_accton_as5916_54xks/module/src/psui.c
@@ -138,14 +138,16 @@ onlp_psui_info_get(onlp_oid_t id, onlp_psu_info_t* info)
     char *string = NULL;
     int len = onlp_file_read_str(&string, "%s""psu%d_model", PSU_SYSFS_PATH, pid);
     if (string && len) {
-        aim_strlcpy(info->model, string, len);
+        memcpy(info->model, string, len);
+        info->model[len] = '\0';
         aim_free(string);
     }
 
     /* Read serial */
     len = onlp_file_read_str(&string, "%s""psu%d_serial", PSU_SYSFS_PATH, pid);
     if (string && len) {
-        aim_strlcpy(info->serial, string, len);
+        memcpy(info->serial, string, len);
+        info->serial[len] = '\0';
         aim_free(string);
     }
 


### PR DESCRIPTION
1. Fix PSU incorrect serial number/model name issue.
2. Add IPMI retry mechanism in psu driver 