### PR TITLE
[wedge100bf-32x] Added bmc_tty_init() function call for fan, psu, thermal

### DIFF
--- a/packages/platforms/accton/x86-64/wedge100bf-32x/onlp/builds/x86_64_accton_wedge100bf_32x/module/src/fani.c
+++ b/packages/platforms/accton/x86-64/wedge100bf-32x/onlp/builds/x86_64_accton_wedge100bf_32x/module/src/fani.c
@@ -112,7 +112,8 @@ int onlp_fani_info_get(onlp_oid_id_t id, onlp_fan_info_t* info) {
 
     fid = ONLP_OID_ID_GET(id);
     *info = finfo[fid];
-
+    bmc_tty_init();
+    
     /* get fan present status
      *
      * 0x0 Present
@@ -215,7 +216,8 @@ onlp_fani_percentage_set(onlp_oid_t id, int p)
     char cmd[32] = {0};
 
     sprintf(cmd, "set_fan_speed.sh %d", p);
-
+    bmc_tty_init();
+    
     if (bmc_send_command(cmd) < 0) {
         AIM_LOG_ERROR("Unable to send command to bmc(%s)\r\n", cmd);
         return ONLP_STATUS_E_INTERNAL;

--- a/packages/platforms/accton/x86-64/wedge100bf-32x/onlp/builds/x86_64_accton_wedge100bf_32x/module/src/psui.c
+++ b/packages/platforms/accton/x86-64/wedge100bf-32x/onlp/builds/x86_64_accton_wedge100bf_32x/module/src/psui.c
@@ -126,6 +126,7 @@ int onlp_psui_info_get(onlp_oid_id_t id, onlp_psu_info_t* info) {
     char path[80] = {0};
     
     *info = pinfo[id]; /* Set the onlp_oid_hdr_t */
+    bmc_tty_init();
 
     /* Get the present status
      */

--- a/packages/platforms/accton/x86-64/wedge100bf-32x/onlp/builds/x86_64_accton_wedge100bf_32x/module/src/thermali.c
+++ b/packages/platforms/accton/x86-64/wedge100bf-32x/onlp/builds/x86_64_accton_wedge100bf_32x/module/src/thermali.c
@@ -122,6 +122,7 @@ int onlp_thermali_info_get(onlp_oid_id_t id, onlp_thermal_info_t* info) {
 
     /* Set the onlp_oid_hdr_t and capabilities */
     *info = linfo[tid];
+    bmc_tty_init();
 
     /* get path */
     if (THERMAL_CPU_CORE == tid) {


### PR DESCRIPTION
It is needed to include bmc_tty_init() function in psui.c, fani.c, thermali.c in order to login into BMC prompt of wedge100BF_32x,  before **bmc_send_command** function is called. 
For **onlps->show** command ( **all peripheral data dump**), bmc_tty_init() function is called in chassisi.c, so cannot find any issue.
But for onlp APIs called separately without chassisi.c dependence, will find issue with sending commands to BMC without bmc login ( bmc_tty_init).
This pull request will fix this issue. 