### PR TITLE
[Accton]Fix problem for management port not link up.

### DIFF
--- a/packages/base/any/kernels/4.14-lts/patches/0003-drivers-net-ethernet-broadcom-tg3.patch
+++ b/packages/base/any/kernels/4.14-lts/patches/0003-drivers-net-ethernet-broadcom-tg3.patch
@@ -1,16 +1,52 @@
-diff -Naur a/drivers/net/ethernet/broadcom/tg3.c b/drivers/net/ethernet/broadcom/tg3.c
---- a/drivers/net/ethernet/broadcom/tg3.c	2019-03-27 13:13:56.000000000 +0800
-+++ b/drivers/net/ethernet/broadcom/tg3.c	2019-04-26 11:08:20.307848693 +0800
-@@ -11734,6 +11734,12 @@
- 		pci_set_power_state(tp->pdev, PCI_D3hot);
- 	}
+---
+ drivers/net/ethernet/broadcom/tg3.c | 20 ++++++++++++++++++++
+ 1 file changed, 20 insertions(+)
 
-+	if (tg3_asic_rev(tp) == ASIC_REV_5720){
-+		/*Fixed ASIC_REV_5720 support 100M/10M feature */
-+       __tg3_writephy(tp, 0x8, 0x10, 0x1d0);
-+       __tg3_writephy(tp, 0x1f, 0x4, 0x5e1);
+diff --git a/drivers/net/ethernet/broadcom/tg3.c b/drivers/net/ethernet/broadcom/tg3.c
+index bc0221e..87802d4 100644
+--- a/drivers/net/ethernet/broadcom/tg3.c
++++ b/drivers/net/ethernet/broadcom/tg3.c
+@@ -235,6 +235,14 @@ static int tg3_debug = -1;	/* -1 == use TG3_DEF_MSG_ENABLE as value */
+ module_param(tg3_debug, int, 0);
+ MODULE_PARM_DESC(tg3_debug, "Tigon3 bitmapped debugging message enable value");
+ 
++static int short_preamble = 0;
++module_param(short_preamble, int, 0);
++MODULE_PARM_DESC(short_preamble, "Enable short preamble.");
++
++static int bcm5718s_reset = 0;
++module_param(bcm5718s_reset, int, 0);
++MODULE_PARM_DESC(bcm5718s_reset, "Enable BCM5718S reset support.");
++
+ #define TG3_DRV_DATA_FLAG_10_100_ONLY	0x0001
+ #define TG3_DRV_DATA_FLAG_5705_10_100	0x0002
+ 
+@@ -1488,6 +1496,12 @@ static void tg3_mdio_config_5785(struct tg3 *tp)
+ static void tg3_mdio_start(struct tg3 *tp)
+ {
+ 	tp->mi_mode &= ~MAC_MI_MODE_AUTO_POLL;
++
++        if(short_preamble) {
++	  netdev_info(tp->dev, "Setting short preamble...");
++	  tp->mi_mode |= MAC_MI_MODE_SHORT_PREAMBLE;
++        }
++
+ 	tw32_f(MAC_MI_MODE, tp->mi_mode);
+ 	udelay(80);
+ 
+@@ -2690,6 +2704,12 @@ static int tg3_phy_reset(struct tg3 *tp)
+ 		}
+ 	}
+ 
++	if (bcm5718s_reset && tp->phy_id == TG3_PHY_ID_BCM5718S) {
++	  netdev_info(tp->dev, "BCM5718S reset...");
++	  __tg3_writephy(tp, 0x8, 0x10, 0x1d0); /* set internal phy 0x8 to make linkup */
++	  __tg3_writephy(tp, 0x1f, 0x4, 0x5e1); /* enable 10/100 cability of external phy */
 +	}
 +
- 	return err;
- }
+ 	if (tg3_flag(tp, 5717_PLUS) &&
+ 	    (tp->phy_flags & TG3_PHYFLG_MII_SERDES))
+ 		return 0;
+-- 
+2.1.4
 


### PR DESCRIPTION
Original patch makes  management port not link up on some platforms. 
Fix that problem and move changes to kernel paramters.
Signed-off-by: roylee123 <roy_lee@accton.com>