### PR TITLE
[wedge100bf-32x] Added bmc_tty_init() function call inside bmc_send_command function

### DIFF
--- a/packages/platforms/accton/x86-64/wedge100bf-32x/onlp/builds/x86_64_accton_wedge100bf_32x/module/src/chassisi.c
+++ b/packages/platforms/accton/x86-64/wedge100bf-32x/onlp/builds/x86_64_accton_wedge100bf_32x/module/src/chassisi.c
@@ -69,7 +69,6 @@ int onlp_chassisi_hdr_get(onlp_oid_id_t id, onlp_oid_hdr_t* hdr)
     *e++ = ONLP_SFP_ID_CREATE(i);
   }
   
-  bmc_tty_init();
   return ONLP_STATUS_OK;
 }
 

--- a/packages/platforms/accton/x86-64/wedge100bf-32x/onlp/builds/x86_64_accton_wedge100bf_32x/module/src/platform_lib.c
+++ b/packages/platforms/accton/x86-64/wedge100bf-32x/onlp/builds/x86_64_accton_wedge100bf_32x/module/src/platform_lib.c
@@ -123,10 +123,7 @@ static int tty_login(void)
 int bmc_tty_init(void)
 {
     int i;
-    if (tty_fd >= 0){
-        return 0;
-    }
-
+    
     for (i = 1; i <= TTY_RETRY; i++) {
         if (tty_open() != 0) {
             AIM_LOG_ERROR("ERROR: Cannot open TTY device\n");
@@ -159,6 +156,10 @@ int bmc_tty_deinit(void)
 int bmc_send_command(char *cmd)
 {
     int i, ret = 0;
+    
+    if( tty_fd == -1 ){
+        bmc_tty_init();
+    }
     
     for (i = 1; i <= TTY_RETRY; i++) {
         snprintf(tty_buf, MAXIMUM_TTY_BUFFER_LENGTH, "%s", cmd);


### PR DESCRIPTION
Added **bmc_tty_init** function call inside **bmc_send_command** function,
as it is mandatory to login BMC prompt once, before sending commands to BMC.

Where as removed **bmc_tty_init** function in chassisi.c, as functions in chassisi.c are called by specifically interested application only and in this case **bmc_tty_init** will never be called.