### PR TITLE
[Mellanox]  Extend size of QSFP EEPROM for the cable type SSF8436, SFF8636 from 256 to 612 bytes

### DIFF
--- a/packages/base/any/kernels/4.9-lts/patches/0033-mlxsw-minimal-Provide-optimization-for-module-number.patch
+++ b/packages/base/any/kernels/4.9-lts/patches/0033-mlxsw-minimal-Provide-optimization-for-module-number.patch
@@ -1,0 +1,530 @@
+From 1a2d774224abf9536be53031f476a1d0411b7f63 Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@mellanox.com>
+Date: Wed, 7 Aug 2019 09:57:18 +0000
+Subject: [PATCH 5.3 backport 2/3] mlxsw: minimal: Provide optimization for
+ module number detection
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Use new filed ‘num_of_modules’ in MGPIR register in order to get
+the number of modules supported by system directly from system
+configuration, instead of getting it from port to module mapping info.
+
+Taking this info through MGPIR register is faster and also does not
+depend on possible dynamic re-configuration of ports.
+In case of port dynamic re-configuration some modules can logically
+“disappeared” or “appeared” as a result of port split and un-spilt
+operations, which can cause missing of some modules, in case this info
+is taken from port to module mapping info.
+
+Signed-off-by: Vadim Pasternak <vadimp@mellanox.com>
+---
+ drivers/net/ethernet/mellanox/mlxsw/core_hwmon.c   |  55 +++++------
+ drivers/net/ethernet/mellanox/mlxsw/core_thermal.c |  44 +++++----
+ drivers/net/ethernet/mellanox/mlxsw/minimal.c      | 104 +++++----------------
+ drivers/net/ethernet/mellanox/mlxsw/qsfp_sysfs.c   |  41 ++++++--
+ drivers/net/ethernet/mellanox/mlxsw/reg.h          |  23 +++--
+ 5 files changed, 112 insertions(+), 155 deletions(-)
+
+diff --git a/drivers/net/ethernet/mellanox/mlxsw/core_hwmon.c b/drivers/net/ethernet/mellanox/mlxsw/core_hwmon.c
+index 5bd08650e0fc..9cb19ec47e4d 100644
+--- a/drivers/net/ethernet/mellanox/mlxsw/core_hwmon.c
++++ b/drivers/net/ethernet/mellanox/mlxsw/core_hwmon.c
+@@ -528,56 +528,47 @@ static int mlxsw_hwmon_fans_init(struct mlxsw_hwmon *mlxsw_hwmon)
+ 
+ static int mlxsw_hwmon_module_init(struct mlxsw_hwmon *mlxsw_hwmon)
+ {
+-	unsigned int module_count = mlxsw_core_max_ports(mlxsw_hwmon->core);
+-	u8 width, module, last_module = module_count;
+-	char pmlp_pl[MLXSW_REG_PMLP_LEN] = {0};
+-	int i, index;
++	char mgpir_pl[MLXSW_REG_MGPIR_LEN];
++	int index, i;
+ 	int err;
+ 
+ 	if (!mlxsw_core_res_query_enabled(mlxsw_hwmon->core))
+ 		return 0;
+ 
++	mlxsw_reg_mgpir_pack(mgpir_pl);
++	err = mlxsw_reg_query(mlxsw_hwmon->core, MLXSW_REG(mgpir), mgpir_pl);
++	if (err)
++		return err;
++
++	mlxsw_reg_mgpir_unpack(mgpir_pl, NULL, NULL, NULL,
++			       &mlxsw_hwmon->module_sensor_count);
++	if (!mlxsw_hwmon->module_sensor_count)
++		return 0;
++
+ 	/* Add extra attributes for module temperature. Sensor index is
+ 	 * assigned to sensor_count value, while all indexed before
+ 	 * sensor_count are already utilized by the sensors connected through
+ 	 * mtmp register by mlxsw_hwmon_temp_init().
+ 	 */
+-	index = mlxsw_hwmon->sensor_count;
+-	for (i = 1; i < module_count; i++) {
+-		mlxsw_reg_pmlp_pack(pmlp_pl, i);
+-		err = mlxsw_reg_query(mlxsw_hwmon->core, MLXSW_REG(pmlp),
+-				      pmlp_pl);
+-		if (err) {
+-			dev_err(mlxsw_hwmon->bus_info->dev, "Failed to read module index %d\n",
+-				i);
+-			return err;
+-		}
+-		width = mlxsw_reg_pmlp_width_get(pmlp_pl);
+-		if (!width)
+-			continue;
+-		module = mlxsw_reg_pmlp_module_get(pmlp_pl, 0);
+-		/* Skip, if port belongs to the cluster */
+-		if (module == last_module)
+-			continue;
+-		last_module = module;
++	index = mlxsw_hwmon->sensor_count + mlxsw_hwmon->module_sensor_count;
++	mlxsw_hwmon->module_sensor_count += mlxsw_hwmon->sensor_count;
++	for (i = mlxsw_hwmon->sensor_count;
++	     i < mlxsw_hwmon->module_sensor_count; i++) {
+ 		mlxsw_hwmon_attr_add(mlxsw_hwmon,
+-				     MLXSW_HWMON_ATTR_TYPE_TEMP_MODULE, index,
+-				     index);
++				     MLXSW_HWMON_ATTR_TYPE_TEMP_MODULE, i, i);
+ 		mlxsw_hwmon_attr_add(mlxsw_hwmon,
+ 				     MLXSW_HWMON_ATTR_TYPE_TEMP_MODULE_FAULT,
+-				     index, index);
++				     i, i);
+ 		mlxsw_hwmon_attr_add(mlxsw_hwmon,
+-				     MLXSW_HWMON_ATTR_TYPE_TEMP_MODULE_CRIT,
+-				     index, index);
++				     MLXSW_HWMON_ATTR_TYPE_TEMP_MODULE_CRIT, i,
++				     i);
+ 		mlxsw_hwmon_attr_add(mlxsw_hwmon,
+ 				     MLXSW_HWMON_ATTR_TYPE_TEMP_MODULE_EMERG,
+-				     index, index);
++				     i, i);
+ 		mlxsw_hwmon_attr_add(mlxsw_hwmon,
+ 				     MLXSW_HWMON_ATTR_TYPE_TEMP_MODULE_LABEL,
+-				     index, index);
+-		index++;
++				     i, i);
+ 	}
+-	mlxsw_hwmon->module_sensor_count = index;
+ 
+ 	return 0;
+ }
+@@ -595,7 +586,7 @@ static int mlxsw_hwmon_gearbox_init(struct mlxsw_hwmon *mlxsw_hwmon)
+ 	if (err)
+ 		return 0;
+ 
+-	mlxsw_reg_mgpir_unpack(mgpir_pl, &gbox_num, NULL, NULL);
++	mlxsw_reg_mgpir_unpack(mgpir_pl, &gbox_num, NULL, NULL, NULL);
+ 	if (!gbox_num)
+ 		return 0;
+ 
+diff --git a/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c b/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c
+index 8051b62af38a..17a340aa9f75 100644
+--- a/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c
++++ b/drivers/net/ethernet/mellanox/mlxsw/core_thermal.c
+@@ -111,6 +111,7 @@ struct mlxsw_thermal {
+ 	struct mlxsw_thermal_trip trips[MLXSW_THERMAL_NUM_TRIPS];
+ 	enum thermal_device_mode mode;
+ 	struct mlxsw_thermal_module *tz_module_arr;
++	u8 tz_module_num;
+ 	struct mlxsw_thermal_module *tz_gearbox_arr;
+ 	u8 tz_gearbox_num;
+ 	unsigned int tz_highest_score;
+@@ -720,23 +721,10 @@ static void mlxsw_thermal_module_tz_fini(struct thermal_zone_device *tzdev)
+ 
+ static int
+ mlxsw_thermal_module_init(struct device *dev, struct mlxsw_core *core,
+-			  struct mlxsw_thermal *thermal, u8 local_port)
++			  struct mlxsw_thermal *thermal, u8 module)
+ {
+ 	struct mlxsw_thermal_module *module_tz;
+-	char pmlp_pl[MLXSW_REG_PMLP_LEN];
+-	u8 width, module;
+-	int err;
+-
+-	mlxsw_reg_pmlp_pack(pmlp_pl, local_port);
+-	err = mlxsw_reg_query(core, MLXSW_REG(pmlp), pmlp_pl);
+-	if (err)
+-		return err;
+ 
+-	width = mlxsw_reg_pmlp_width_get(pmlp_pl);
+-	if (!width)
+-		return 0;
+-
+-	module = mlxsw_reg_pmlp_module_get(pmlp_pl, 0);
+ 	module_tz = &thermal->tz_module_arr[module];
+ 	/* Skip if parent is already set (case of port split). */
+ 	if (module_tz->parent)
+@@ -764,26 +752,36 @@ static int
+ mlxsw_thermal_modules_init(struct device *dev, struct mlxsw_core *core,
+ 			   struct mlxsw_thermal *thermal)
+ {
+-	unsigned int module_count = mlxsw_core_max_ports(core);
++	char mgpir_pl[MLXSW_REG_MGPIR_LEN];
+ 	struct mlxsw_thermal_module *module_tz;
+ 	int i, err;
+ 
+ 	if (!mlxsw_core_res_query_enabled(core))
+ 		return 0;
+ 
+-	thermal->tz_module_arr = kcalloc(module_count,
++	mlxsw_reg_mgpir_pack(mgpir_pl);
++	err = mlxsw_reg_query(core, MLXSW_REG(mgpir), mgpir_pl);
++	if (err)
++		return err;
++
++	mlxsw_reg_mgpir_unpack(mgpir_pl, NULL, NULL, NULL,
++			       &thermal->tz_module_num);
++	if (!thermal->tz_module_num)
++		return 0;
++
++	thermal->tz_module_arr = kcalloc(thermal->tz_module_num,
+ 					 sizeof(*thermal->tz_module_arr),
+ 					 GFP_KERNEL);
+ 	if (!thermal->tz_module_arr)
+ 		return -ENOMEM;
+ 
+-	for (i = 1; i < module_count; i++) {
++	for (i = 0; i < thermal->tz_module_num; i++) {
+ 		err = mlxsw_thermal_module_init(dev, core, thermal, i);
+ 		if (err)
+ 			goto err_unreg_tz_module_arr;
+ 	}
+ 
+-	for (i = 0; i < module_count - 1; i++) {
++	for (i = 0; i < thermal->tz_module_num; i++) {
+ 		module_tz = &thermal->tz_module_arr[i];
+ 		if (!module_tz->parent)
+ 			continue;
+@@ -795,7 +793,7 @@ mlxsw_thermal_modules_init(struct device *dev, struct mlxsw_core *core,
+ 	return 0;
+ 
+ err_unreg_tz_module_arr:
+-	for (i = module_count - 1; i >= 0; i--)
++	for (i = thermal->tz_module_num - 1; i >= 0; i--)
+ 		mlxsw_thermal_module_fini(&thermal->tz_module_arr[i]);
+ 	kfree(thermal->tz_module_arr);
+ 	return err;
+@@ -804,13 +802,12 @@ mlxsw_thermal_modules_init(struct device *dev, struct mlxsw_core *core,
+ static void
+ mlxsw_thermal_modules_fini(struct mlxsw_thermal *thermal)
+ {
+-	unsigned int module_count = mlxsw_core_max_ports(thermal->core);
+ 	int i;
+ 
+ 	if (!mlxsw_core_res_query_enabled(thermal->core))
+ 		return;
+ 
+-	for (i = module_count - 1; i >= 0; i--)
++	for (i = thermal->tz_module_num - 1; i >= 0; i--)
+ 		mlxsw_thermal_module_fini(&thermal->tz_module_arr[i]);
+ 	kfree(thermal->tz_module_arr);
+ }
+@@ -858,7 +855,8 @@ mlxsw_thermal_gearboxes_init(struct device *dev, struct mlxsw_core *core,
+ 	if (err)
+ 		return 0;
+ 
+-	mlxsw_reg_mgpir_unpack(mgpir_pl, &thermal->tz_gearbox_num, NULL, NULL);
++	mlxsw_reg_mgpir_unpack(mgpir_pl, &thermal->tz_gearbox_num, NULL, NULL,
++			       NULL);
+ 	if (!thermal->tz_gearbox_num)
+ 		return 0;
+ 
+@@ -995,7 +993,7 @@ int mlxsw_thermal_init(struct mlxsw_core *core,
+ 	if (err)
+ 		goto err_unreg_modules_tzdev;
+ 
+-	thermal->mode = THERMAL_DEVICE_ENABLED;
++	thermal->mode = THERMAL_DEVICE_DISABLED;
+ 	*p_thermal = thermal;
+ 	return 0;
+ 
+diff --git a/drivers/net/ethernet/mellanox/mlxsw/minimal.c b/drivers/net/ethernet/mellanox/mlxsw/minimal.c
+index 0aa3abc974ff..564b85c06a9a 100644
+--- a/drivers/net/ethernet/mellanox/mlxsw/minimal.c
++++ b/drivers/net/ethernet/mellanox/mlxsw/minimal.c
+@@ -89,23 +89,6 @@ static const struct ethtool_ops mlxsw_m_port_ethtool_ops = {
+ };
+ 
+ static int
+-mlxsw_m_port_module_info_get(struct mlxsw_m *mlxsw_m, u8 local_port,
+-			     u8 *p_module, u8 *p_width)
+-{
+-	char pmlp_pl[MLXSW_REG_PMLP_LEN];
+-	int err;
+-
+-	mlxsw_reg_pmlp_pack(pmlp_pl, local_port);
+-	err = mlxsw_reg_query(mlxsw_m->core, MLXSW_REG(pmlp), pmlp_pl);
+-	if (err)
+-		return err;
+-	*p_module = mlxsw_reg_pmlp_module_get(pmlp_pl, 0);
+-	*p_width = mlxsw_reg_pmlp_width_get(pmlp_pl);
+-
+-	return 0;
+-}
+-
+-static int
+ mlxsw_m_port_dev_addr_get(struct mlxsw_m_port *mlxsw_m_port)
+ {
+ 	struct mlxsw_m *mlxsw_m = mlxsw_m_port->mlxsw_m;
+@@ -158,7 +141,7 @@ mlxsw_m_port_create(struct mlxsw_m *mlxsw_m, u8 local_port, u8 module)
+ 	mlxsw_m_port = netdev_priv(dev);
+ 	mlxsw_m_port->dev = dev;
+ 	mlxsw_m_port->mlxsw_m = mlxsw_m;
+-	mlxsw_m_port->local_port = local_port;
++	mlxsw_m_port->local_port = module;
+ 	mlxsw_m_port->module = module;
+ 
+ 	dev->netdev_ops = &mlxsw_m_port_netdev_ops;
+@@ -205,87 +188,48 @@ static void mlxsw_m_port_remove(struct mlxsw_m *mlxsw_m, u8 local_port)
+ 	mlxsw_core_port_fini(mlxsw_m->core, local_port);
+ }
+ 
+-static int mlxsw_m_port_module_map(struct mlxsw_m *mlxsw_m, u8 local_port,
+-				   u8 *last_module)
++static int mlxsw_m_ports_create(struct mlxsw_m *mlxsw_m)
+ {
+-	u8 module, width;
++	char mgpir_pl[MLXSW_REG_MGPIR_LEN];
++	int i;
+ 	int err;
+ 
+-	/* Fill out to local port mapping array */
+-	err = mlxsw_m_port_module_info_get(mlxsw_m, local_port, &module,
+-					   &width);
++	mlxsw_reg_mgpir_pack(mgpir_pl);
++	err = mlxsw_reg_query(mlxsw_m->core, MLXSW_REG(mgpir), mgpir_pl);
+ 	if (err)
+ 		return err;
+ 
+-	if (!width)
++	mlxsw_reg_mgpir_unpack(mgpir_pl, NULL, NULL, NULL,
++			       &mlxsw_m->max_ports);
++	if (!mlxsw_m->max_ports)
+ 		return 0;
+-	/* Skip, if port belongs to the cluster */
+-	if (module == *last_module)
+-		return 0;
+-	*last_module = module;
+-	mlxsw_m->module_to_port[module] = ++mlxsw_m->max_ports;
+-
+-	return 0;
+-}
+ 
+-static void mlxsw_m_port_module_unmap(struct mlxsw_m *mlxsw_m, u8 module)
+-{
+-	mlxsw_m->module_to_port[module] = -1;
+-}
+-
+-static int mlxsw_m_ports_create(struct mlxsw_m *mlxsw_m)
+-{
+-	unsigned int max_ports = mlxsw_core_max_ports(mlxsw_m->core);
+-	u8 last_module = max_ports;
+-	int i;
+-	int err;
+-
+-	mlxsw_m->ports = kcalloc(max_ports, sizeof(*mlxsw_m->ports),
++	mlxsw_m->ports = kcalloc(mlxsw_m->max_ports, sizeof(*mlxsw_m->ports),
+ 				 GFP_KERNEL);
+ 	if (!mlxsw_m->ports)
+ 		return -ENOMEM;
+ 
+-	mlxsw_m->module_to_port = kmalloc_array(max_ports, sizeof(int),
++	mlxsw_m->module_to_port = kmalloc_array(mlxsw_m->max_ports, sizeof(int),
+ 						GFP_KERNEL);
+ 	if (!mlxsw_m->module_to_port) {
+ 		err = -ENOMEM;
+ 		goto err_module_to_port_alloc;
+ 	}
+ 
+-	/* Invalidate the entries of module to local port mapping array */
+-	for (i = 0; i < max_ports; i++)
+-		mlxsw_m->module_to_port[i] = -1;
+-
+-	/* Fill out module to local port mapping array */
+-	for (i = 1; i < max_ports; i++) {
+-		err = mlxsw_m_port_module_map(mlxsw_m, i, &last_module);
+-		if (err)
+-			goto err_module_to_port_map;
+-	}
+-
+ 	/* Create port objects for each valid entry */
+-	for (i = 0; i < max_ports; i++) {
+-		if (mlxsw_m->module_to_port[i] > 0) {
+-			err = mlxsw_m_port_create(mlxsw_m,
+-						  mlxsw_m->module_to_port[i],
+-						  i);
+-			if (err)
+-				goto err_module_to_port_create;
+-		}
++	for (i = 0; i < mlxsw_m->max_ports; i++) {
++		mlxsw_m->module_to_port[i] = i;
++		err = mlxsw_m_port_create(mlxsw_m, mlxsw_m->module_to_port[i],
++					  i);
++		if (err)
++			goto err_module_to_port_create;
+ 	}
+ 
+ 	return 0;
+ 
+ err_module_to_port_create:
+-	for (i--; i >= 0; i--) {
+-		if (mlxsw_m->module_to_port[i] > 0)
+-			mlxsw_m_port_remove(mlxsw_m,
+-					    mlxsw_m->module_to_port[i]);
+-	}
+-	i = max_ports;
+-err_module_to_port_map:
+-	for (i--; i > 0; i--)
+-		mlxsw_m_port_module_unmap(mlxsw_m, i);
++	for (i--; i >= 0; i--)
++		mlxsw_m_port_remove(mlxsw_m, mlxsw_m->module_to_port[i]);
+ 	kfree(mlxsw_m->module_to_port);
+ err_module_to_port_alloc:
+ 	kfree(mlxsw_m->ports);
+@@ -294,16 +238,10 @@ static int mlxsw_m_ports_create(struct mlxsw_m *mlxsw_m)
+ 
+ static void mlxsw_m_ports_remove(struct mlxsw_m *mlxsw_m)
+ {
+-	unsigned int max_ports = mlxsw_core_max_ports(mlxsw_m->core);
+ 	int i;
+ 
+-	for (i = 0; i < max_ports; i++) {
+-		if (mlxsw_m->module_to_port[i] > 0) {
+-			mlxsw_m_port_remove(mlxsw_m,
+-					    mlxsw_m->module_to_port[i]);
+-			mlxsw_m_port_module_unmap(mlxsw_m, i);
+-		}
+-	}
++	for (i = 0; i < mlxsw_m->max_ports; i++)
++		mlxsw_m_port_remove(mlxsw_m, mlxsw_m->module_to_port[i]);
+ 
+ 	kfree(mlxsw_m->module_to_port);
+ 	kfree(mlxsw_m->ports);
+diff --git a/drivers/net/ethernet/mellanox/mlxsw/qsfp_sysfs.c b/drivers/net/ethernet/mellanox/mlxsw/qsfp_sysfs.c
+index fdf2b796e724..49563a703d75 100644
+--- a/drivers/net/ethernet/mellanox/mlxsw/qsfp_sysfs.c
++++ b/drivers/net/ethernet/mellanox/mlxsw/qsfp_sysfs.c
+@@ -279,16 +279,36 @@ static const struct dmi_system_id mlxsw_qsfp_dmi_table[] = {
+ };
+ MODULE_DEVICE_TABLE(dmi, mlxsw_qsfp_dmi_table);
+ 
++static int mlxsw_qsfp_set_module_num(struct mlxsw_qsfp *mlxsw_qsfp)
++{
++	char pmlp_pl[MLXSW_REG_PMLP_LEN];
++	u8 width;
++	int i, err;
++
++	for (i = 1; i <= mlxsw_qsfp_num; i++) {
++		mlxsw_reg_pmlp_pack(pmlp_pl, i);
++		err = mlxsw_reg_query(mlxsw_qsfp->core, MLXSW_REG(pmlp),
++				      pmlp_pl);
++		if (err)
++			return err;
++		width = mlxsw_reg_pmlp_width_get(pmlp_pl);
++		if (!width)
++			continue;
++		mlxsw_qsfp->module_count++;
++	}
++
++	return 0;
++}
++
+ int mlxsw_qsfp_init(struct mlxsw_core *mlxsw_core,
+ 		    const struct mlxsw_bus_info *mlxsw_bus_info,
+ 		    struct mlxsw_qsfp **p_qsfp)
+ {
+ 	struct device_attribute *dev_attr, *cpld_dev_attr;
+-	char pmlp_pl[MLXSW_REG_PMLP_LEN];
++	char mgpir_pl[MLXSW_REG_MGPIR_LEN];
+ 	struct mlxsw_qsfp *mlxsw_qsfp;
+ 	struct bin_attribute *eeprom;
+ 	int i, count;
+-	u8 width;
+ 	int err;
+ 
+ 	if (!strcmp(mlxsw_bus_info->device_kind, "i2c"))
+@@ -305,16 +325,17 @@ int mlxsw_qsfp_init(struct mlxsw_core *mlxsw_core,
+ 	mlxsw_qsfp->bus_info = mlxsw_bus_info;
+ 	mlxsw_bus_info->dev->platform_data = mlxsw_qsfp;
+ 
+-	for (i = 1; i <= mlxsw_qsfp_num; i++) {
+-		mlxsw_reg_pmlp_pack(pmlp_pl, i);
+-		err = mlxsw_reg_query(mlxsw_qsfp->core, MLXSW_REG(pmlp),
+-				      pmlp_pl);
++	mlxsw_reg_mgpir_pack(mgpir_pl);
++	err = mlxsw_reg_query(mlxsw_qsfp->core, MLXSW_REG(mgpir), mgpir_pl);
++	if (err) {
++		err = mlxsw_qsfp_set_module_num(mlxsw_qsfp);
+ 		if (err)
+ 			return err;
+-		width = mlxsw_reg_pmlp_width_get(pmlp_pl);
+-		if (!width)
+-			continue;
+-		mlxsw_qsfp->module_count++;
++	} else {
++		mlxsw_reg_mgpir_unpack(mgpir_pl, NULL, NULL, NULL,
++			       &mlxsw_qsfp->module_count);
++		if (!mlxsw_qsfp->module_count)
++			return 0;
+ 	}
+ 
+ 	count = mlxsw_qsfp->module_count + 1;
+diff --git a/drivers/net/ethernet/mellanox/mlxsw/reg.h b/drivers/net/ethernet/mellanox/mlxsw/reg.h
+index 31296d888fb8..a8cd53f068ce 100644
+--- a/drivers/net/ethernet/mellanox/mlxsw/reg.h
++++ b/drivers/net/ethernet/mellanox/mlxsw/reg.h
+@@ -8593,6 +8593,11 @@ static inline void mlxsw_reg_mprs_pack(char *payload, u16 parsing_depth,
+ 
+ MLXSW_REG_DEFINE(mgpir, MLXSW_REG_MGPIR_ID, MLXSW_REG_MGPIR_LEN);
+ 
++enum mlxsw_reg_mgpir_device_type {
++	MLXSW_REG_MGPIR_DEVICE_TYPE_NONE,
++	MLXSW_REG_MGPIR_DEVICE_TYPE_GEARBOX_DIE,
++};
++
+ /* device_type
+  * Access: RO
+  */
+@@ -8610,19 +8615,21 @@ MLXSW_ITEM32(reg, mgpir, devices_per_flash, 0x00, 16, 8);
+  */
+ MLXSW_ITEM32(reg, mgpir, num_of_devices, 0x00, 0, 8);
+ 
+-enum mlxsw_reg_mgpir_device_type {
+-	MLXSW_REG_MGPIR_TYPE_NONE,
+-	MLXSW_REG_MGPIR_TYPE_GEARBOX_DIE,
+-};
++/* num_of_modules
++ * Number of modules.
++ * Access: RO
++ */
++MLXSW_ITEM32(reg, mgpir, num_of_modules, 0x04, 0, 8);
+ 
+ static inline void mlxsw_reg_mgpir_pack(char *payload)
+ {
+ 	MLXSW_REG_ZERO(mgpir, payload);
+ }
+ 
+-static inline void mlxsw_reg_mgpir_unpack(char *payload, u8 *num_of_devices,
+-					  u8 *device_type,
+-					  u8 *devices_per_flash)
++static inline void
++mlxsw_reg_mgpir_unpack(char *payload, u8 *num_of_devices,
++		       enum mlxsw_reg_mgpir_device_type *device_type,
++		       u8 *devices_per_flash, u8 *num_of_modules)
+ {
+ 	if (num_of_devices)
+ 		*num_of_devices = mlxsw_reg_mgpir_num_of_devices_get(payload);
+@@ -8631,6 +8638,8 @@ static inline void mlxsw_reg_mgpir_unpack(char *payload, u8 *num_of_devices,
+ 	if (devices_per_flash)
+ 		*devices_per_flash =
+ 				mlxsw_reg_mgpir_devices_per_flash_get(payload);
++	if (num_of_modules)
++		*num_of_modules = mlxsw_reg_mgpir_num_of_modules_get(payload);
+ }
+ 
+ /* TNGCR - Tunneling NVE General Configuration Register
+-- 
+2.11.0
+

--- a/packages/base/any/kernels/4.9-lts/patches/0034-mlxsw-minimal-Add-validation-for-FW-version.patch
+++ b/packages/base/any/kernels/4.9-lts/patches/0034-mlxsw-minimal-Add-validation-for-FW-version.patch
@@ -1,0 +1,109 @@
+From 3b3986744bb9fb8635adf13575534f271fa58676 Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@mellanox.com>
+Date: Sun, 11 Aug 2019 07:00:03 +0000
+Subject: [PATCH v1 1/1] mlxsw: minimal: Add validation for FW version
+
+Add validation for FW version in order to prevent driver initialization
+in case FW version is older than expected.
+
+Signed-off-by: Vadim Pasternak <vadimp@mellanox.com>
+---
+ drivers/net/ethernet/mellanox/mlxsw/core.c    | 17 +++++++++--------
+ drivers/net/ethernet/mellanox/mlxsw/minimal.c | 25 +++++++++++++++++++++++++
+ 2 files changed, 34 insertions(+), 8 deletions(-)
+
+diff --git a/drivers/net/ethernet/mellanox/mlxsw/core.c b/drivers/net/ethernet/mellanox/mlxsw/core.c
+index 9a74ae8beb43..a127e0b01e4e 100644
+--- a/drivers/net/ethernet/mellanox/mlxsw/core.c
++++ b/drivers/net/ethernet/mellanox/mlxsw/core.c
+@@ -987,6 +987,12 @@ int mlxsw_core_bus_device_register(const struct mlxsw_bus_info *mlxsw_bus_info,
+ 			goto err_devlink_register;
+ 	}
+ 
++	if (mlxsw_driver->init) {
++		err = mlxsw_driver->init(mlxsw_core, mlxsw_bus_info);
++		if (err)
++			goto err_driver_init;
++	}
++
+ 	err = mlxsw_hwmon_init(mlxsw_core, mlxsw_bus_info, &mlxsw_core->hwmon);
+ 	if (err)
+ 		goto err_hwmon_init;
+@@ -1001,21 +1007,16 @@ int mlxsw_core_bus_device_register(const struct mlxsw_bus_info *mlxsw_bus_info,
+ 	if (err)
+ 		goto err_qsfp_init;
+ 
+-	if (mlxsw_driver->init) {
+-		err = mlxsw_driver->init(mlxsw_core, mlxsw_bus_info);
+-		if (err)
+-			goto err_driver_init;
+-	}
+-
+ 	return 0;
+ 
+-err_driver_init:
+-	mlxsw_qsfp_fini(mlxsw_core->qsfp);
+ err_qsfp_init:
+ 	mlxsw_thermal_fini(mlxsw_core->thermal);
+ err_thermal_init:
+ 	mlxsw_hwmon_fini(mlxsw_core->hwmon);
+ err_hwmon_init:
++	if (mlxsw_core->driver->fini)
++		mlxsw_core->driver->fini(mlxsw_core);
++err_driver_init:
+ 	if (!reload)
+ 		devlink_unregister(devlink);
+ err_devlink_register:
+diff --git a/drivers/net/ethernet/mellanox/mlxsw/minimal.c b/drivers/net/ethernet/mellanox/mlxsw/minimal.c
+index 564b85c06a9a..504db124ee2f 100644
+--- a/drivers/net/ethernet/mellanox/mlxsw/minimal.c
++++ b/drivers/net/ethernet/mellanox/mlxsw/minimal.c
+@@ -17,6 +17,9 @@
+ 
+ static const char mlxsw_m_driver_name[] = "mlxsw_minimal";
+ 
++#define MLXSW_M_FWREV_MINOR	2000
++#define MLXSW_M_FWREV_SUBMINOR	1886
++
+ struct mlxsw_m_port;
+ 
+ struct mlxsw_m {
+@@ -117,6 +120,24 @@ static void mlxsw_m_port_switchdev_fini(struct mlxsw_m_port *mlxsw_m_port)
+ {
+ }
+ 
++static int mlxsw_m_fw_rev_validate(struct mlxsw_m *mlxsw_m)
++{
++	const struct mlxsw_fw_rev *rev = &mlxsw_m->bus_info->fw_rev;
++
++	dev_info(mlxsw_m->bus_info->dev, "The firmware version %d.%d.%d\n",
++		 rev->major, rev->minor, rev->subminor);
++	/* Validate driver & FW are compatible */
++	if (rev->minor >= MLXSW_M_FWREV_MINOR &&
++	    rev->subminor >= MLXSW_M_FWREV_SUBMINOR)
++		return 0;
++
++	dev_info(mlxsw_m->bus_info->dev, "The firmware version %d.%d.%d is incompatible with the driver (required >= %d.%d.%d)\n",
++		 rev->major, rev->minor, rev->subminor, rev->major,
++		 MLXSW_M_FWREV_MINOR, MLXSW_M_FWREV_SUBMINOR);
++
++	return -EINVAL;
++}
++
+ static int
+ mlxsw_m_port_create(struct mlxsw_m *mlxsw_m, u8 local_port, u8 module)
+ {
+@@ -256,6 +277,10 @@ static int mlxsw_m_init(struct mlxsw_core *mlxsw_core,
+ 	mlxsw_m->core = mlxsw_core;
+ 	mlxsw_m->bus_info = mlxsw_bus_info;
+ 
++	err = mlxsw_m_fw_rev_validate(mlxsw_m);
++	if (err)
++		return err;
++
+ 	err = mlxsw_m_ports_create(mlxsw_m);
+ 	if (err) {
+ 		dev_err(mlxsw_m->bus_info->dev, "Failed to create ports\n");
+-- 
+2.11.0
+

--- a/packages/base/any/kernels/4.9-lts/patches/0035-mlxsw-core-Extend-QSFP-EEPROM-supported-size-for-eth.patch
+++ b/packages/base/any/kernels/4.9-lts/patches/0035-mlxsw-core-Extend-QSFP-EEPROM-supported-size-for-eth.patch
@@ -1,0 +1,168 @@
+From 701662a1dc781e18341974ec6cece31bead06fbd Mon Sep 17 00:00:00 2001
+From: Vadim Pasternak <vadimp@mellanox.com>
+Date: Mon, 12 Aug 2019 07:31:57 +0300
+Subject: [PATCH v1 1/1] mlxsw: core: Extend QSFP EEPROM supported size for
+ ethtool
+
+Extend size of QSFP EEPROM for the cable type SSF8436, SFF8636 from 256
+to 612 bytes in order to make available all the pages.
+
+Signed-off-by: Vadim Pasternak <vadimp@mellanox.com>
+---
+ drivers/net/ethernet/mellanox/mlxsw/core_env.c | 40 ++++++++++++++++++--------
+ drivers/net/ethernet/mellanox/mlxsw/reg.h      |  5 ++++
+ include/uapi/linux/ethtool.h                   |  3 ++
+ 3 files changed, 36 insertions(+), 12 deletions(-)
+
+diff --git a/drivers/net/ethernet/mellanox/mlxsw/core_env.c b/drivers/net/ethernet/mellanox/mlxsw/core_env.c
+index d2c7ce67c300..0a5495f9f4c7 100644
+--- a/drivers/net/ethernet/mellanox/mlxsw/core_env.c
++++ b/drivers/net/ethernet/mellanox/mlxsw/core_env.c
+@@ -44,12 +44,13 @@ static int mlxsw_env_validate_cable_ident(struct mlxsw_core *core, int id,
+ 
+ static int
+ mlxsw_env_query_module_eeprom(struct mlxsw_core *mlxsw_core, int module,
+-			      u16 offset, u16 size, void *data,
++			      u16 offset, u16 size, bool qsfp, void *data,
+ 			      unsigned int *p_read_size)
+ {
+ 	char eeprom_tmp[MLXSW_REG_MCIA_EEPROM_SIZE];
+ 	char mcia_pl[MLXSW_REG_MCIA_LEN];
+ 	u16 i2c_addr;
++	u8 page = 0;
+ 	int status;
+ 	int err;
+ 
+@@ -62,11 +63,19 @@ mlxsw_env_query_module_eeprom(struct mlxsw_core *mlxsw_core, int module,
+ 
+ 	i2c_addr = MLXSW_REG_MCIA_I2C_ADDR_LOW;
+ 	if (offset >= MLXSW_REG_MCIA_EEPROM_PAGE_LENGTH) {
+-		i2c_addr = MLXSW_REG_MCIA_I2C_ADDR_HIGH;
+-		offset -= MLXSW_REG_MCIA_EEPROM_PAGE_LENGTH;
++		if (qsfp) {
++			page = MLXSW_REG_MCIA_PAGE_GET(offset);
++			offset -= MLXSW_REG_MCIA_EEPROM_UP_PAGE_LENGTH * page;
++			if (offset + size > MLXSW_REG_MCIA_EEPROM_PAGE_LENGTH)
++				size = MLXSW_REG_MCIA_EEPROM_PAGE_LENGTH -
++				       offset;
++		} else {
++			i2c_addr = MLXSW_REG_MCIA_I2C_ADDR_HIGH;
++			offset -= MLXSW_REG_MCIA_EEPROM_PAGE_LENGTH;
++		}
+ 	}
+ 
+-	mlxsw_reg_mcia_pack(mcia_pl, module, 0, 0, offset, size, i2c_addr);
++	mlxsw_reg_mcia_pack(mcia_pl, module, 0, page, offset, size, i2c_addr);
+ 
+ 	err = mlxsw_reg_query(mlxsw_core, MLXSW_REG(mcia), mcia_pl);
+ 	if (err)
+@@ -152,10 +161,11 @@ int mlxsw_env_get_module_info(struct mlxsw_core *mlxsw_core, int module,
+ 	u16 offset = MLXSW_REG_MCIA_EEPROM_MODULE_INFO_SIZE;
+ 	u8 module_rev_id, module_id, diag_mon;
+ 	unsigned int read_size;
++	bool unused = false;
+ 	int err;
+ 
+ 	err = mlxsw_env_query_module_eeprom(mlxsw_core, module, 0, offset,
+-					    module_info, &read_size);
++					    unused, module_info, &read_size);
+ 	if (err)
+ 		return err;
+ 
+@@ -168,7 +178,7 @@ int mlxsw_env_get_module_info(struct mlxsw_core *mlxsw_core, int module,
+ 	switch (module_id) {
+ 	case MLXSW_REG_MCIA_EEPROM_MODULE_INFO_ID_QSFP:
+ 		modinfo->type       = ETH_MODULE_SFF_8436;
+-		modinfo->eeprom_len = ETH_MODULE_SFF_8436_LEN;
++		modinfo->eeprom_len = ETH_MODULE_SFF_8436_MAX_LEN;
+ 		break;
+ 	case MLXSW_REG_MCIA_EEPROM_MODULE_INFO_ID_QSFP_PLUS: /* fall-through */
+ 	case MLXSW_REG_MCIA_EEPROM_MODULE_INFO_ID_QSFP28:
+@@ -176,17 +186,17 @@ int mlxsw_env_get_module_info(struct mlxsw_core *mlxsw_core, int module,
+ 		    module_rev_id >=
+ 		    MLXSW_REG_MCIA_EEPROM_MODULE_INFO_REV_ID_8636) {
+ 			modinfo->type       = ETH_MODULE_SFF_8636;
+-			modinfo->eeprom_len = ETH_MODULE_SFF_8636_LEN;
++			modinfo->eeprom_len = ETH_MODULE_SFF_8636_MAX_LEN;
+ 		} else {
+ 			modinfo->type       = ETH_MODULE_SFF_8436;
+-			modinfo->eeprom_len = ETH_MODULE_SFF_8436_LEN;
++			modinfo->eeprom_len = ETH_MODULE_SFF_8436_MAX_LEN;
+ 		}
+ 		break;
+ 	case MLXSW_REG_MCIA_EEPROM_MODULE_INFO_ID_SFP:
+ 		/* Verify if transceiver provides diagnostic monitoring page */
+ 		err = mlxsw_env_query_module_eeprom(mlxsw_core, module,
+-						    SFP_DIAGMON, 1, &diag_mon,
+-						    &read_size);
++						    SFP_DIAGMON, 1, unused,
++						    &diag_mon, &read_size);
+ 		if (err)
+ 			return err;
+ 
+@@ -213,6 +223,7 @@ int mlxsw_env_get_module_eeprom(struct net_device *netdev,
+ {
+ 	int offset = ee->offset;
+ 	unsigned int read_size;
++	bool qsfp;
+ 	int i = 0;
+ 	int err;
+ 
+@@ -221,10 +232,15 @@ int mlxsw_env_get_module_eeprom(struct net_device *netdev,
+ 
+ 	memset(data, 0, ee->len);
+ 
++	/* Validate module identifier type. */
++	err = mlxsw_env_validate_cable_ident(mlxsw_core, module, &qsfp);
++	if (err)
++		return err;
++
+ 	while (i < ee->len) {
+ 		err = mlxsw_env_query_module_eeprom(mlxsw_core, module, offset,
+-						    ee->len - i, data + i,
+-						    &read_size);
++						    ee->len - i, qsfp,
++						    data + i, &read_size);
+ 		if (err) {
+ 			netdev_err(netdev, "Eeprom query failed\n");
+ 			return err;
+diff --git a/drivers/net/ethernet/mellanox/mlxsw/reg.h b/drivers/net/ethernet/mellanox/mlxsw/reg.h
+index a8cd53f068ce..8d7a58472799 100644
+--- a/drivers/net/ethernet/mellanox/mlxsw/reg.h
++++ b/drivers/net/ethernet/mellanox/mlxsw/reg.h
+@@ -7823,6 +7823,7 @@ MLXSW_ITEM32(reg, mcia, device_address, 0x04, 0, 16);
+ MLXSW_ITEM32(reg, mcia, size, 0x08, 0, 16);
+ 
+ #define MLXSW_REG_MCIA_EEPROM_PAGE_LENGTH	256
++#define MLXSW_REG_MCIA_EEPROM_UP_PAGE_LENGTH	128
+ #define MLXSW_REG_MCIA_EEPROM_SIZE		48
+ #define MLXSW_REG_MCIA_I2C_ADDR_LOW		0x50
+ #define MLXSW_REG_MCIA_I2C_ADDR_HIGH		0x51
+@@ -7858,6 +7859,10 @@ enum mlxsw_reg_mcia_eeprom_module_info {
+  */
+ MLXSW_ITEM_BUF(reg, mcia, eeprom, 0x10, MLXSW_REG_MCIA_EEPROM_SIZE);
+ 
++#define MLXSW_REG_MCIA_PAGE_GET(off) (((off) - \
++				MLXSW_REG_MCIA_EEPROM_PAGE_LENGTH) / \
++				MLXSW_REG_MCIA_EEPROM_UP_PAGE_LENGTH + 1)
++
+ static inline void mlxsw_reg_mcia_pack(char *payload, u8 module, u8 lock,
+ 				       u8 page_number, u16 device_addr,
+ 				       u8 size, u8 i2c_device_addr)
+diff --git a/include/uapi/linux/ethtool.h b/include/uapi/linux/ethtool.h
+index 8e547231c1b7..b868569344d1 100644
+--- a/include/uapi/linux/ethtool.h
++++ b/include/uapi/linux/ethtool.h
+@@ -1595,6 +1595,9 @@ static inline int ethtool_validate_duplex(__u8 duplex)
+ #define ETH_MODULE_SFF_8436		0x4
+ #define ETH_MODULE_SFF_8436_LEN		256
+ 
++#define ETH_MODULE_SFF_8636_MAX_LEN     640
++#define ETH_MODULE_SFF_8436_MAX_LEN     640
++
+ /* Reset flags */
+ /* The reset() operation must clear the flags for the components which
+  * were actually reset.  On successful return, the flags indicate the
+-- 
+2.11.0
+

--- a/packages/base/any/kernels/4.9-lts/patches/series
+++ b/packages/base/any/kernels/4.9-lts/patches/series
@@ -33,3 +33,5 @@ driver-add-the-support-max6620.patch
 0030-mlxsw-minimal-Provide-optimization-for-I2C-bus-acces.patch
 0031-mlxsw-core-Skip-port-split-entries-in-hwmon-subsyste.patch
 0032-mellanox-platform-Backporting-Melanox-drivers-from-v.patch
+0033-mlxsw-minimal-Provide-optimization-for-module-number.patch
+0034-mlxsw-minimal-Add-validation-for-FW-version.patch

--- a/packages/base/any/kernels/4.9-lts/patches/series
+++ b/packages/base/any/kernels/4.9-lts/patches/series
@@ -35,3 +35,4 @@ driver-add-the-support-max6620.patch
 0032-mellanox-platform-Backporting-Melanox-drivers-from-v.patch
 0033-mlxsw-minimal-Provide-optimization-for-module-number.patch
 0034-mlxsw-minimal-Add-validation-for-FW-version.patch
+0035-mlxsw-core-Extend-QSFP-EEPROM-supported-size-for-eth.patch


### PR DESCRIPTION
Mellanox: extend size of QSFP EEPROM for the cable type SSF8436, SFF8636 from 256 to 612 bytes in order to make available all the pages.