### PR TITLE
[Accton] as5916-54xks, fix fault of DMA Read by turning off intel_iommu at kernel.

### DIFF
--- a/packages/platforms/accton/x86-64/as5916-54xks/platform-config/r0/src/lib/x86-64-accton-as5916-54xks-r0.yml
+++ b/packages/platforms/accton/x86-64/as5916-54xks/platform-config/r0/src/lib/x86-64-accton-as5916-54xks-r0.yml
@@ -25,6 +25,7 @@ x86-64-accton-as5916-54xks-r0:
       console=ttyS0,115200n8
       tg3.short_preamble=1
       tg3.bcm5718s_reset=1
+      intel_iommu=off
 
   ##network:
   ##  interfaces:


### PR DESCRIPTION
Fix fault of DMA Read by turning off intel_iommu at kernel.
Signed-off-by: roylee123 <roy_lee@accton.com>