### PR TITLE
Add support 0x57 and 0x56 eeprom sysfs for as9716

### DIFF
--- a/packages/platforms/accton/x86-64/as9716_32d/onlp/builds/x86_64_accton_as9716_32d/module/src/platform_lib.h
+++ b/packages/platforms/accton/x86-64/as9716_32d/onlp/builds/x86_64_accton_as9716_32d/module/src/platform_lib.h
@@ -61,7 +61,9 @@
 #define FAN_BOARD_PATH	"/sys/bus/i2c/devices/17-0066/"
 #define FAN_NODE(node)	FAN_BOARD_PATH#node
 
-#define IDPROM_PATH "/sys/class/i2c-adapter/i2c-0/0-0056/eeprom"
+/*Old board's eeprom i2c-addr is 0x56, new board eeprom i2c-addr is 0x57*/
+#define IDPROM_PATH_1 "/sys/class/i2c-adapter/i2c-0/0-0057/eeprom"
+#define IDPROM_PATH_2 "/sys/class/i2c-adapter/i2c-0/0-0056/eeprom"
 
 int onlp_file_write_integer(char *filename, int value);
 int onlp_file_read_binary(char *filename, char *buffer, int buf_size, int data_len);

--- a/packages/platforms/accton/x86-64/as9716_32d/platform-config/r0/src/python/x86_64_accton_as9716_32d_r0/__init__.py
+++ b/packages/platforms/accton/x86-64/as9716_32d/platform-config/r0/src/python/x86_64_accton_as9716_32d_r0/__init__.py
@@ -3,6 +3,12 @@ from onl.platform.accton import *
 
 import commands
 
+
+def eeprom_check():
+    cmd = "i2cget -y 0 0x57"
+    status, output = commands.getstatusoutput(cmd)
+    return status
+
 #IR3570A chip casue problem when read eeprom by i2c-block mode.
 #It happen when read 16th-byte offset that value is 0x8. So disable chip 
 def disable_i2c_ir3570a(addr):
@@ -104,6 +110,12 @@ class OnlPlatform_x86_64_accton_as9716_32d_r0(OnlPlatformAccton,
             
             subprocess.call('echo port%d > /sys/bus/i2c/devices/%d-0050/port_name' % (port, port+24), shell=True)
        
-        ir3570_check()
+        #Dut to new board eeprom i2c-addr is 0x57, old board eeprom i2c-addr is 0x56. So need to check and set correct i2c-addr sysfs
+        ret=eeprom_check()
+        if ret==0:
+            self.new_i2c_device('24c02', 0x57, 0)
+        else:
+            ir3570_check()
+            self.new_i2c_device('24c02', 0x56, 0)
       
         return True


### PR DESCRIPTION
New board eeprom addr is 0x57. Old board is 0x56. Modify code to support two board eeprom-sysfs.