### PR TITLE
Upgrade kernel to 4.14 and debug ONLP for D10056

### DIFF
--- a/packages/platforms/inventec/x86-64/d10056/modules/PKG.yml
+++ b/packages/platforms/inventec/x86-64/d10056/modules/PKG.yml
@@ -1,1 +1,1 @@
-!include $ONL_TEMPLATES/platform-modules.yml VENDOR=inventec BASENAME=x86-64-inventec-d10056 ARCH=amd64 KERNELS="onl-kernel-3.16-lts-x86-64-all:amd64"
+!include $ONL_TEMPLATES/platform-modules.yml VENDOR=inventec BASENAME=x86-64-inventec-d10056 ARCH=amd64 KERNELS="onl-kernel-4.14-lts-x86-64-all:amd64"

--- a/packages/platforms/inventec/x86-64/d10056/modules/builds/Makefile
+++ b/packages/platforms/inventec/x86-64/d10056/modules/builds/Makefile
@@ -1,4 +1,4 @@
-KERNELS := onl-kernel-3.16-lts-x86-64-all:amd64
+KERNELS := onl-kernel-4.14-lts-x86-64-all:amd64
 KMODULES := src
 VENDOR := inventec
 BASENAME := x86-64-inventec-d10056

--- a/packages/platforms/inventec/x86-64/d10056/modules/builds/src/Makefile
+++ b/packages/platforms/inventec/x86-64/d10056/modules/builds/src/Makefile
@@ -1,11 +1,12 @@
 obj-m += gpio-ich.o
 obj-m += i2c-gpio.o
 obj-m += inv_cpld.o
-obj-m += inv_mux.o
 obj-m += inv_platform.o
 obj-m += inv_psoc.o
-obj-m += inv_swps.o
-obj-m += inv_vpd.o
-obj-m += io_expander.o
-obj-m += onie_tlvinfo.o
-obj-m += transceiver.o
+
+obj-m += swps.o
+swps-objs := inv_swps.o inv_mux.o io_expander.o transceiver.o
+
+obj-m += vpd.o
+vpd-objs := inv_vpd.o onie_tlvinfo.o
+

--- a/packages/platforms/inventec/x86-64/d10056/modules/builds/src/gpio-ich.c
+++ b/packages/platforms/inventec/x86-64/d10056/modules/builds/src/gpio-ich.c
@@ -20,6 +20,7 @@
 
 #define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
 
+#include <linux/ioport.h>
 #include <linux/module.h>
 #include <linux/pci.h>
 #include <linux/gpio.h>
@@ -108,7 +109,7 @@ static struct {
 	int outlvl_cache[3];	/* cached output values */
 } ichx_priv;
 
-static int modparam_gpiobase = -1;	/* dynamic */
+static int modparam_gpiobase = 0;	/*  Default: -1 dynamic */
 module_param_named(gpiobase, modparam_gpiobase, int, 0444);
 MODULE_PARM_DESC(gpiobase, "The GPIO number base. -1 means dynamic, "
 			   "which is the default.");
@@ -171,6 +172,11 @@ static int ichx_read_bit(int reg, unsigned nr)
 static bool ichx_gpio_check_available(struct gpio_chip *gpio, unsigned nr)
 {
 	return !!(ichx_priv.use_gpio & (1 << (nr / 32)));
+}
+
+static int ichx_gpio_get_direction(struct gpio_chip *gpio, unsigned nr)
+{
+	return ichx_read_bit(GPIO_IO_SEL, nr) ? GPIOF_DIR_IN : GPIOF_DIR_OUT;
 }
 
 static int ichx_gpio_direction_input(struct gpio_chip *gpio, unsigned nr)
@@ -277,7 +283,7 @@ static void ichx_gpiolib_setup(struct gpio_chip *chip)
 {
 	chip->owner = THIS_MODULE;
 	chip->label = DRV_NAME;
-	chip->dev = &ichx_priv.dev->dev;
+	chip->parent = &ichx_priv.dev->dev;
 
 	/* Allow chip-specific overrides of request()/get() */
 	chip->request = ichx_priv.desc->request ?
@@ -286,6 +292,7 @@ static void ichx_gpiolib_setup(struct gpio_chip *chip)
 		ichx_priv.desc->get : ichx_gpio_get;
 
 	chip->set = ichx_gpio_set;
+	chip->get_direction = ichx_gpio_get_direction;
 	chip->direction_input = ichx_gpio_direction_input;
 	chip->direction_output = ichx_gpio_direction_output;
 	chip->base = modparam_gpiobase;
@@ -378,8 +385,8 @@ static struct ichx_desc avoton_desc = {
 	.use_outlvl_cache = true,
 };
 
-static int ichx_gpio_request_regions(struct resource *res_base,
-						const char *name, u8 use_gpio)
+static int ichx_gpio_request_regions(struct device *dev,
+	struct resource *res_base, const char *name, u8 use_gpio)
 {
 	int i;
 
@@ -389,34 +396,12 @@ static int ichx_gpio_request_regions(struct resource *res_base,
 	for (i = 0; i < ARRAY_SIZE(ichx_priv.desc->regs[0]); i++) {
 		if (!(use_gpio & (1 << i)))
 			continue;
-		if (!request_region(
+		if (!devm_request_region(dev,
 				res_base->start + ichx_priv.desc->regs[0][i],
 				ichx_priv.desc->reglen[i], name))
-			goto request_err;
+			return -EBUSY;
 	}
 	return 0;
-
-request_err:
-	/* Clean up: release already requested regions, if any */
-	for (i--; i >= 0; i--) {
-		if (!(use_gpio & (1 << i)))
-			continue;
-		release_region(res_base->start + ichx_priv.desc->regs[0][i],
-			       ichx_priv.desc->reglen[i]);
-	}
-	return -EBUSY;
-}
-
-static void ichx_gpio_release_regions(struct resource *res_base, u8 use_gpio)
-{
-	int i;
-
-	for (i = 0; i < ARRAY_SIZE(ichx_priv.desc->regs[0]); i++) {
-		if (!(use_gpio & (1 << i)))
-			continue;
-		release_region(res_base->start + ichx_priv.desc->regs[0][i],
-			       ichx_priv.desc->reglen[i]);
-	}
 }
 
 static int ichx_gpio_probe(struct platform_device *pdev)
@@ -462,7 +447,7 @@ static int ichx_gpio_probe(struct platform_device *pdev)
 	spin_lock_init(&ichx_priv.lock);
 	res_base = platform_get_resource(pdev, IORESOURCE_IO, ICH_RES_GPIO);
 	ichx_priv.use_gpio = ich_info->use_gpio;
-	err = ichx_gpio_request_regions(res_base, pdev->name,
+	err = ichx_gpio_request_regions(&pdev->dev, res_base, pdev->name,
 					ichx_priv.use_gpio);
 	if (err)
 		return err;
@@ -483,8 +468,8 @@ static int ichx_gpio_probe(struct platform_device *pdev)
 		goto init;
 	}
 
-	if (!request_region(res_pm->start, resource_size(res_pm),
-			pdev->name)) {
+	if (!devm_request_region(&pdev->dev, res_pm->start,
+			resource_size(res_pm), pdev->name)) {
 		pr_warn("ACPI BAR is busy, GPI 0 - 15 unavailable\n");
 		goto init;
 	}
@@ -493,47 +478,27 @@ static int ichx_gpio_probe(struct platform_device *pdev)
 
 init:
 	ichx_gpiolib_setup(&ichx_priv.chip);
-	err = gpiochip_add(&ichx_priv.chip);
+	err = gpiochip_add_data(&ichx_priv.chip, NULL);
 	if (err) {
 		pr_err("Failed to register GPIOs\n");
-		goto add_err;
+		return err;
 	}
 
 	pr_info("GPIO from %d to %d on %s\n", ichx_priv.chip.base,
 	       ichx_priv.chip.base + ichx_priv.chip.ngpio - 1, DRV_NAME);
 
 	return 0;
-
-add_err:
-	ichx_gpio_release_regions(ichx_priv.gpio_base, ichx_priv.use_gpio);
-	if (ichx_priv.pm_base)
-		release_region(ichx_priv.pm_base->start,
-				resource_size(ichx_priv.pm_base));
-	return err;
 }
 
 static int ichx_gpio_remove(struct platform_device *pdev)
 {
-	int err;
-
-	err = gpiochip_remove(&ichx_priv.chip);
-	if (err) {
-		dev_err(&pdev->dev, "%s failed, %d\n",
-				"gpiochip_remove()", err);
-		return err;
-	}
-
-	ichx_gpio_release_regions(ichx_priv.gpio_base, ichx_priv.use_gpio);
-	if (ichx_priv.pm_base)
-		release_region(ichx_priv.pm_base->start,
-				resource_size(ichx_priv.pm_base));
+	gpiochip_remove(&ichx_priv.chip);
 
 	return 0;
 }
 
 static struct platform_driver ichx_gpio_driver = {
 	.driver		= {
-		.owner	= THIS_MODULE,
 		.name	= DRV_NAME,
 	},
 	.probe		= ichx_gpio_probe,

--- a/packages/platforms/inventec/x86-64/d10056/modules/builds/src/inv_platform.c
+++ b/packages/platforms/inventec/x86-64/d10056/modules/builds/src/inv_platform.c
@@ -5,7 +5,9 @@
 #include <linux/slab.h>
 #include <linux/platform_device.h>
 #include <linux/delay.h>
-#include <linux/i2c/pca954x.h>
+#include <linux/platform_data/pca954x.h>
+
+#define GPIO_BASE   0 // in kernel 4.x GPIO_BASE =0 ; in kernel 3.16.x , GPIO_BASE=180
 
 struct inv_i2c_board_info {
     int ch;
@@ -148,8 +150,8 @@ static struct inv_i2c_board_info i2cdev_list[] = {
 /////////////////////////////////////////////////////////////////////////////////////////
 static struct   platform_device         *device_i2c_gpio0;
 static struct 	i2c_gpio_platform_data 	i2c_gpio_platdata0 = {
-	.scl_pin = 494, //58
-	.sda_pin = 511, //75
+	.scl_pin = GPIO_BASE + 58, 
+	.sda_pin = GPIO_BASE + 75, 
     
 	.udelay  = 5, //5:100kHz
 	.sda_is_open_drain = 0,

--- a/packages/platforms/inventec/x86-64/d10056/modules/builds/src/inv_psoc.c
+++ b/packages/platforms/inventec/x86-64/d10056/modules/builds/src/inv_psoc.c
@@ -913,7 +913,8 @@ static void check_switch_temp(void)
         if(IS_ERR(f)) {
                 return;
         }
-        else {
+// It is not used in Gulmohar and Lavender platform.
+/*        else {
                 char temp_str[]={0,0,0,0,0,0,0};
                 loff_t pos = 0;
                 u16 temp2 = 0;
@@ -922,7 +923,7 @@ static void check_switch_temp(void)
                 vfs_read(f, temp_str,6,&pos);
                 temp2 = ((simple_strtoul(temp_str,NULL,10)/1000) <<8 ) & 0xFF00 ;
                 psoc_ipmi_write((u8*)&temp2, SWITCH_TMP_OFFSET, 2);
-        }
+        }*/
         filp_close(f,NULL);
         set_fs(old_fs);
 }

--- a/packages/platforms/inventec/x86-64/d10056/modules/builds/src/inv_swps.h
+++ b/packages/platforms/inventec/x86-64/d10056/modules/builds/src/inv_swps.h
@@ -207,7 +207,7 @@ struct inv_ioexp_layout_s magnolia_ioexp_layout[] = {
 };
 
 struct inv_port_layout_s magnolia_port_layout[] = {
-    /* Port_ID / Chan_ID / IOEXP_ID / IOEXP_VIRT_OFFSET / TRANSCEIVER_TYPE / BCM_CHIP_TYPE / LANE_ID */
+    /* Port_ID / Chan_ID / IOEXP_ID / IOEXP_VIRT_OFFSET / TRANSCEIVER_TYPE / CHIP_TYPE / LANE_ID */
     { 0,  10,  0,  0, TRANSVR_TYPE_SFP,  CHIP_TYPE_MAGNOLIA, { 16} },
     { 1,  11,  0,  1, TRANSVR_TYPE_SFP,  CHIP_TYPE_MAGNOLIA, { 15} },
     { 2,  12,  0,  2, TRANSVR_TYPE_SFP,  CHIP_TYPE_MAGNOLIA, { 14} },
@@ -294,7 +294,7 @@ struct inv_ioexp_layout_s redwood_ioexp_layout[] = {
 };
 
 struct inv_port_layout_s redwood_port_layout[] = {
-    /* Port_ID / Chan_ID / IOEXP_ID / IOEXP_VIRT_OFFSET / TRANSCEIVER_TYPE / BCM_CHIP_TYPE / LANE_ID */
+    /* Port_ID / Chan_ID / IOEXP_ID / IOEXP_VIRT_OFFSET / TRANSCEIVER_TYPE / CHIP_TYPE / LANE_ID */
     { 0,  22,  0,  0, TRANSVR_TYPE_QSFP_28, CHIP_TYPE_REDWOOD, {  1,  2,  3,  4} },
     { 1,  23,  0,  1, TRANSVR_TYPE_QSFP_28, CHIP_TYPE_REDWOOD, {  5,  6,  7,  8} },
     { 2,  24,  0,  2, TRANSVR_TYPE_QSFP_28, CHIP_TYPE_REDWOOD, {  9, 10, 11, 12} },
@@ -359,7 +359,7 @@ struct inv_ioexp_layout_s hudson32iga_ioexp_layout[] = {
 };
 
 struct inv_port_layout_s hudson32iga_port_layout[] = {
-    /* Port_ID / Chan_ID / IOEXP_ID / IOEXP_VIRT_OFFSET / TRANSCEIVER_TYPE / BCM_CHIP_TYPE / LANE_ID */
+    /* Port_ID / Chan_ID / IOEXP_ID / IOEXP_VIRT_OFFSET / TRANSCEIVER_TYPE / CHIP_TYPE / LANE_ID */
     { 0,   6,  0,  0, TRANSVR_TYPE_QSFP_PLUS, CHIP_TYPE_MAGNOLIA, {  1,  2,  3,  4} },
     { 1,   7,  0,  1, TRANSVR_TYPE_QSFP_PLUS, CHIP_TYPE_MAGNOLIA, {  5,  6,  7,  8} },
     { 2,   8,  0,  2, TRANSVR_TYPE_QSFP_PLUS, CHIP_TYPE_MAGNOLIA, {  9, 10, 11, 12} },
@@ -411,7 +411,7 @@ struct inv_ioexp_layout_s spruce_ioexp_layout[] = {
 };
 
 struct inv_port_layout_s spruce_port_layout[] = {
-    /* Port_ID / Chan_ID / IOEXP_ID / IOEXP_VIRT_OFFSET / TRANSCEIVER_TYPE / BCM_CHIP_TYPE / LANE_ID */
+    /* Port_ID / Chan_ID / IOEXP_ID / IOEXP_VIRT_OFFSET / TRANSCEIVER_TYPE / CHIP_TYPE / LANE_ID */
     { 0,   6,  0,  0, TRANSVR_TYPE_QSFP_PLUS, CHIP_TYPE_MAGNOLIA, { 81, 82, 83, 84} },
     { 1,   7,  0,  1, TRANSVR_TYPE_QSFP_PLUS, CHIP_TYPE_MAGNOLIA, { 77, 78, 79, 80} },
     { 2,   8,  0,  2, TRANSVR_TYPE_QSFP_PLUS, CHIP_TYPE_MAGNOLIA, { 97, 98, 99,100} },
@@ -462,7 +462,7 @@ struct inv_ioexp_layout_s cypress_ga1_ioexp_layout[] = {
 };
 
 struct inv_port_layout_s cypress_ga1_port_layout[] = {
-    /* Port_ID / Chan_ID / IOEXP_ID / IOEXP_VIRT_OFFSET / TRANSCEIVER_TYPE / BCM_CHIP_TYPE / LANE_ID */
+    /* Port_ID / Chan_ID / IOEXP_ID / IOEXP_VIRT_OFFSET / TRANSCEIVER_TYPE / CHIP_TYPE / LANE_ID */
     { 0,  10,  0,  0, TRANSVR_TYPE_SFP,     CHIP_TYPE_REDWOOD, {  1} },
     { 1,  11,  0,  1, TRANSVR_TYPE_SFP,     CHIP_TYPE_REDWOOD, {  2} },
     { 2,  12,  0,  2, TRANSVR_TYPE_SFP,     CHIP_TYPE_REDWOOD, {  3} },
@@ -561,7 +561,7 @@ struct inv_ioexp_layout_s cypress_ga2_ioexp_layout[] = {
 };
 
 struct inv_port_layout_s cypress_ga2_port_layout[] = {
-    /* Port_ID / Chan_ID / IOEXP_ID / IOEXP_VIRT_OFFSET / TRANSCEIVER_TYPE / BCM_CHIP_TYPE / LANE_ID */
+    /* Port_ID / Chan_ID / IOEXP_ID / IOEXP_VIRT_OFFSET / TRANSCEIVER_TYPE / CHIP_TYPE / LANE_ID */
     { 0,  11,  0,  1, TRANSVR_TYPE_SFP,     CHIP_TYPE_REDWOOD, {  2} },
     { 1,  10,  0,  0, TRANSVR_TYPE_SFP,     CHIP_TYPE_REDWOOD, {  1} },
     { 2,  13,  0,  3, TRANSVR_TYPE_SFP,     CHIP_TYPE_REDWOOD, {  4} },
@@ -660,7 +660,7 @@ struct inv_ioexp_layout_s cypress_b_ioexp_layout[] = {
 };
 
 struct inv_port_layout_s cypress_b_port_layout[] = {
-    /* Port_ID / Chan_ID / IOEXP_ID / IOEXP_VIRT_OFFSET / TRANSCEIVER_TYPE / BCM_CHIP_TYPE / LANE_ID */
+    /* Port_ID / Chan_ID / IOEXP_ID / IOEXP_VIRT_OFFSET / TRANSCEIVER_TYPE / CHIP_TYPE / LANE_ID */
     { 1,  11,  0,  1, TRANSVR_TYPE_SFP,     CHIP_TYPE_REDWOOD, {  2} },
     { 2,  10,  0,  0, TRANSVR_TYPE_SFP,     CHIP_TYPE_REDWOOD, {  1} },
     { 3,  13,  0,  3, TRANSVR_TYPE_SFP,     CHIP_TYPE_REDWOOD, {  4} },
@@ -748,7 +748,7 @@ struct inv_ioexp_layout_s redwood_fsl_ioexp_layout[] = {
 
 
 struct inv_port_layout_s redwood_fsl_port_layout[] = {
-    /* Port_ID / Chan_ID / IOEXP_ID / IOEXP_VIRT_OFFSET / TRANSCEIVER_TYPE / BCM_CHIP_TYPE / LANE_ID */
+    /* Port_ID / Chan_ID / IOEXP_ID / IOEXP_VIRT_OFFSET / TRANSCEIVER_TYPE / CHIP_TYPE / LANE_ID */
     { 0,  22,  0,  0, TRANSVR_TYPE_QSFP_28, CHIP_TYPE_REDWOOD, {  1,  2,  3,  4} },
     { 1,  23,  0,  1, TRANSVR_TYPE_QSFP_28, CHIP_TYPE_REDWOOD, {  5,  6,  7,  8} },
     { 2,  24,  0,  2, TRANSVR_TYPE_QSFP_28, CHIP_TYPE_REDWOOD, {  9, 10, 11, 12} },
@@ -804,7 +804,7 @@ struct inv_ioexp_layout_s tahoe_ioexp_layout[] = {
 
 
 struct inv_port_layout_s tahoe_port_layout[] = {
-    /* Port_ID / Chan_ID / IOEXP_ID / IOEXP_VIRT_OFFSET / TRANSCEIVER_TYPE / BCM_CHIP_TYPE / LANE_ID */
+    /* Port_ID / Chan_ID / IOEXP_ID / IOEXP_VIRT_OFFSET / TRANSCEIVER_TYPE / CHIP_TYPE / LANE_ID */
     { 0,  12,  1,  2, TRANSVR_TYPE_QSFP_28, CHIP_TYPE_REDWOOD, { 65,  66,  67,  68} },
     { 1,  11,  1,  1, TRANSVR_TYPE_QSFP_28, CHIP_TYPE_REDWOOD, { 53,  54,  55,  56} },
     { 2,  22,  0,  5, TRANSVR_TYPE_QSFP_28, CHIP_TYPE_REDWOOD, { 69,  70,  71,  72} },
@@ -864,7 +864,7 @@ struct inv_ioexp_layout_s sequoia_ioexp_layout[] = {
 
 
 struct inv_port_layout_s sequoia_port_layout[] = {
-    /* Port_ID / Chan_ID / IOEXP_ID / IOEXP_VIRT_OFFSET / TRANSCEIVER_TYPE / BCM_CHIP_TYPE / LANE_ID */
+    /* Port_ID / Chan_ID / IOEXP_ID / IOEXP_VIRT_OFFSET / TRANSCEIVER_TYPE / CHIP_TYPE / LANE_ID */
     { 0,   9,  0,  0, TRANSVR_TYPE_QSFP_28, CHIP_TYPE_REDWOOD, {  9,  10,  11,  12} },
     { 1,  10,  0,  1, TRANSVR_TYPE_QSFP_28, CHIP_TYPE_REDWOOD, {  1,   2,   3,   4} },
     { 2,  11,  0,  2, TRANSVR_TYPE_QSFP_28, CHIP_TYPE_REDWOOD, { 25,  26,  27,  28} },
@@ -984,7 +984,7 @@ struct inv_ioexp_layout_s lavender_ioexp_layout[] = {
 
 
 struct inv_port_layout_s lavender_port_layout[] = {
-    /* Port_ID / Chan_ID / IOEXP_ID / IOEXP_VIRT_OFFSET / TRANSCEIVER_TYPE / BCM_CHIP_TYPE / LANE_ID */
+    /* Port_ID / Chan_ID / IOEXP_ID / IOEXP_VIRT_OFFSET / TRANSCEIVER_TYPE / CHIP_TYPE / LANE_ID */
     { 0,  17,  0,  0, TRANSVR_TYPE_QSFP_28, CHIP_TYPE_LAVENDER, {188, 189, 190, 191} },
     { 1,  18,  0,  1, TRANSVR_TYPE_QSFP_28, CHIP_TYPE_LAVENDER, {184, 185, 186, 187} },
     { 2,  19,  0,  2, TRANSVR_TYPE_QSFP_28, CHIP_TYPE_LAVENDER, {180, 181, 182, 183} },
@@ -1069,7 +1069,7 @@ struct inv_ioexp_layout_s cottonwood_rangeley_ioexp_layout[] = {
 
 
 struct inv_port_layout_s cottonwood_rangeley_port_layout[] = {
-    /* Port_ID / Chan_ID / IOEXP_ID / IOEXP_VIRT_OFFSET / TRANSCEIVER_TYPE / BCM_CHI_TYPE / LANE_ID */
+    /* Port_ID / Chan_ID / IOEXP_ID / IOEXP_VIRT_OFFSET / TRANSCEIVER_TYPE / CHI_TYPE / LANE_ID */
     { 0,  2,  0,  0, TRANSVR_TYPE_SFP, CHIP_TYPE_REDWOOD, { 75} },
     { 1,  3,  0,  1, TRANSVR_TYPE_SFP, CHIP_TYPE_REDWOOD, { 77} },
     { 2,  4,  0,  2, TRANSVR_TYPE_SFP, CHIP_TYPE_REDWOOD, { 79} },
@@ -1117,7 +1117,7 @@ struct inv_ioexp_layout_s maple_ga_ioexp_layout[] = {
 };
 
 struct inv_port_layout_s maple_ga_port_layout[] = {
-    /* Port_ID / Chan_ID / IOEXP_ID / IOEXP_VIRT_OFFSET / TRANSCEIVER_TYPE / BCM_CHIP_TYPE / LANE_ID */
+    /* Port_ID / Chan_ID / IOEXP_ID / IOEXP_VIRT_OFFSET / TRANSCEIVER_TYPE / CHIP_TYPE / LANE_ID */
     { 0,  18,  1,  0, TRANSVR_TYPE_SFP,     CHIP_TYPE_MAPLE, {  1} },
     { 1,  19,  1,  1, TRANSVR_TYPE_SFP,     CHIP_TYPE_MAPLE, {  2} },
     { 2,  20,  1,  2, TRANSVR_TYPE_SFP,     CHIP_TYPE_MAPLE, {  3} },
@@ -1217,7 +1217,7 @@ struct inv_ioexp_layout_s maple_b_ioexp_layout[] = {
 };
 
 struct inv_port_layout_s maple_b_port_layout[] = {
-    /* Port_ID / Chan_ID / IOEXP_ID / IOEXP_VIRT_OFFSET / TRANSCEIVER_TYPE / BCM_CHIP_TYPE / LANE_ID */
+    /* Port_ID / Chan_ID / IOEXP_ID / IOEXP_VIRT_OFFSET / TRANSCEIVER_TYPE / CHIP_TYPE / LANE_ID */
     { 1,  23,  1,  1, TRANSVR_TYPE_SFP,     CHIP_TYPE_MAPLE, {  2} },
     { 2,  22,  1,  0, TRANSVR_TYPE_SFP,     CHIP_TYPE_MAPLE, {  1} },
     { 3,  25,  1,  3, TRANSVR_TYPE_SFP,     CHIP_TYPE_MAPLE, {  4} },
@@ -1320,7 +1320,7 @@ struct inv_ioexp_layout_s gulmohar_ioexp_layout[] = {
 
 
 struct inv_port_layout_s gulmohar_port_layout[] = {
-    /* Port_ID / Chan_ID / IOEXP_ID / IOEXP_VIRT_OFFSET / TRANSCEIVER_TYPE / BCM_CHIP_TYPE / LANE_ID */
+    /* Port_ID / Chan_ID / IOEXP_ID / IOEXP_VIRT_OFFSET / TRANSCEIVER_TYPE / CHIP_TYPE / LANE_ID */
     { 0,  10,  0,  0, TRANSVR_TYPE_SFP,     CHIP_TYPE_LAVENDER, {  1} },
     { 1,  11,  0,  1, TRANSVR_TYPE_SFP,     CHIP_TYPE_LAVENDER, {  2} },
     { 2,  12,  0,  2, TRANSVR_TYPE_SFP,     CHIP_TYPE_LAVENDER, {  3} },
@@ -1384,7 +1384,7 @@ struct inv_port_layout_s gulmohar_port_layout[] = {
  * ==========================================
  */
 #ifdef SWPS_GULMOHAR_2T_EVT1
-unsigned gulmohar_2t_evt1_gpio_rest_mux = MUX_RST_GPIO_505_PCA9548;
+unsigned gulmohar_2t_evt1_gpio_rest_mux = MUX_RST_GPIO_69_PCA9548;
 
 struct inv_ioexp_layout_s gulmohar_2t_evt1_ioexp_layout[] = {
     /* IOEXP_ID / IOEXP_TYPE / { Chan_ID, Chip_addr, Read_offset, Write_offset, config_offset, data_default, conf_default } */
@@ -1421,7 +1421,7 @@ struct inv_ioexp_layout_s gulmohar_2t_evt1_ioexp_layout[] = {
 
 
 struct inv_port_layout_s gulmohar_2t_evt1_port_layout[] = {
-    /* Port_ID / Chan_ID / IOEXP_ID / IOEXP_VIRT_OFFSET / TRANSCEIVER_TYPE / BCM_CHIP_TYPE / LANE_ID */
+    /* Port_ID / Chan_ID / IOEXP_ID / IOEXP_VIRT_OFFSET / TRANSCEIVER_TYPE / CHIP_TYPE / LANE_ID */
     { 0,  10,  0,  0, TRANSVR_TYPE_SFP,     CHIP_TYPE_LAVENDER, {-99} },
     { 1,  11,  0,  1, TRANSVR_TYPE_SFP,     CHIP_TYPE_LAVENDER, {-99} },
     { 2,  12,  0,  2, TRANSVR_TYPE_SFP,     CHIP_TYPE_LAVENDER, {-99} },
@@ -1522,7 +1522,7 @@ struct inv_ioexp_layout_s peony_sfp_ioexp_layout[] = {
 };
 
 struct inv_port_layout_s peony_sfp_port_layout[] = {
-    /* Port_ID / Chan_ID / IOEXP_ID / IOEXP_VIRT_OFFSET / TRANSCEIVER_TYPE / BCM_CHIP_TYPE / LANE_ID */
+    /* Port_ID / Chan_ID / IOEXP_ID / IOEXP_VIRT_OFFSET / TRANSCEIVER_TYPE / CHIP_TYPE / LANE_ID */
     { 0,  20,  1,  0, TRANSVR_TYPE_SFP,     CHIP_TYPE_MAPLE, {  1} },
     { 1,  21,  1,  1, TRANSVR_TYPE_SFP,     CHIP_TYPE_MAPLE, {  2} },
     { 2,  22,  1,  2, TRANSVR_TYPE_SFP,     CHIP_TYPE_MAPLE, {  3} },
@@ -1597,7 +1597,7 @@ struct inv_ioexp_layout_s peony_copper_ioexp_layout[] = {
 };
 
 struct inv_port_layout_s peony_copper_port_layout[] = {
-    /* Port_ID / Chan_ID / IOEXP_ID / IOEXP_VIRT_OFFSET / TRANSCEIVER_TYPE / BCM_CHIP_TYPE / LANE_ID */
+    /* Port_ID / Chan_ID / IOEXP_ID / IOEXP_VIRT_OFFSET / TRANSCEIVER_TYPE / CHIP_TYPE / LANE_ID */
     {48,  4,  0,  0, TRANSVR_TYPE_QSFP_28, CHIP_TYPE_MAPLE, { 49, 50, 51, 52} },
     {49,  5,  0,  1, TRANSVR_TYPE_QSFP_28, CHIP_TYPE_MAPLE, { 57, 58, 59, 60} },
     {50,  6,  0,  2, TRANSVR_TYPE_QSFP_28, CHIP_TYPE_MAPLE, { 61, 62, 63, 64} },

--- a/packages/platforms/inventec/x86-64/d10056/modules/builds/src/inv_vpd.c
+++ b/packages/platforms/inventec/x86-64/d10056/modules/builds/src/inv_vpd.c
@@ -20,12 +20,7 @@ static DEFINE_MUTEX(vpd_mutex);
 
 static int
 __swp_match(struct device *dev,
-#ifdef VPD_KERN_VER_AF_3_10
-
             const void *data){
-#else
-            void *data){
-#endif
 
     char *name = (char *)data;
     if (strcmp(dev_name(dev), name) == 0)

--- a/packages/platforms/inventec/x86-64/d10056/modules/builds/src/transceiver.c
+++ b/packages/platforms/inventec/x86-64/d10056/modules/builds/src/transceiver.c
@@ -5918,7 +5918,7 @@ _sfp_detect_if_type(struct transvr_obj_s* self,
 
         case CHIP_TYPE_LAVENDER:
             return _sfp_set_lavender_if_type(self, detect_cls, result);
-            
+
         default:
             SWPS_INFO("%s: non-defined chipset_type:%d <port>:%s\n",
                       __func__, self->chipset_type, self->swp_name);

--- a/packages/platforms/inventec/x86-64/d10056/modules/builds/src/transceiver.h
+++ b/packages/platforms/inventec/x86-64/d10056/modules/builds/src/transceiver.h
@@ -203,7 +203,7 @@
 #define VAL_OPTICAL_WAVELENGTH_LR       (1310)
 #define VAL_OPTICAL_WAVELENGTH_ER       (1550)
 
-/* BCM chip type define */
+/* chip type define */
 #define CHIP_TYPE_MAGNOLIA              (31001)  /* Magnolia, Hudson32i, Spruce */
 #define CHIP_TYPE_REDWOOD               (31002)  /* Redwood, Cypress, Sequoia */
 #define CHIP_TYPE_MAPLE                 (31003)  /* Maple */

--- a/packages/platforms/inventec/x86-64/d10056/platform-config/r0/src/lib/x86-64-inventec-d10056-r0.yml
+++ b/packages/platforms/inventec/x86-64/d10056/platform-config/r0/src/lib/x86-64-inventec-d10056-r0.yml
@@ -18,7 +18,7 @@ x86-64-inventec-d10056-r0:
       --stop=1
 
     kernel:
-      <<: *kernel-3-16
+      <<: *kernel-4-14
 
     args: >-
       nopat

--- a/packages/platforms/inventec/x86-64/d10056/platform-config/r0/src/python/x86_64_inventec_d10056_r0/__init__.py
+++ b/packages/platforms/inventec/x86-64/d10056/platform-config/r0/src/python/x86_64_inventec_d10056_r0/__init__.py
@@ -2,10 +2,10 @@ from onl.platform.base import *
 from onl.platform.inventec import *
 
 class OnlPlatform_x86_64_inventec_d10056_r0(OnlPlatformInventec,
-                                              OnlPlatformPortConfig_32x100):
+                                              OnlPlatformPortConfig_48x25_8x100):
     PLATFORM='x86-64-inventec-d10056-r0'
-    MODEL="D5256"
-    SYS_OBJECT_ID=".1.32"
+    MODEL="D10056"
+    SYS_OBJECT_ID=".10056.1"
 
     def baseconfig(self):
         os.system("insmod /lib/modules/`uname -r`/onl/inventec/x86-64-inventec-d10056/gpio-ich.ko")
@@ -15,12 +15,8 @@ class OnlPlatform_x86_64_inventec_d10056_r0(OnlPlatformInventec,
         self.insmod('inv_psoc')
         os.system("echo inv_cpld 0x77 > /sys/bus/i2c/devices/i2c-0/new_device")
         self.insmod('inv_cpld')
-        self.insmod('inv_mux')
-        self.insmod('io_expander')
-        self.insmod('transceiver')
-        self.insmod('inv_swps')
-        self.insmod('onie_tlvinfo')
-        self.insmod('inv_vpd')
+        self.insmod('swps')
+        self.insmod('vpd')
         os.system("/lib/platform-config/x86-64-inventec-d10056-r0/onl/healthstatus.sh &")
 
         return True


### PR DESCRIPTION
the detail of fixes this time are listed below

- Upgrade kernel to 4.14

- ONLP debug

1) Fix wrong rxlos and reset state value
2) Use inv_eeprom to read eeprom data

And attached is the test report
[d10056_upstream.pdf](https://github.com/opencomputeproject/OpenNetworkLinux/files/4039340/d10056_upstream.pdf)
