### PR TITLE
Issue 673: Link onlp-snmpd to C math library

### DIFF
--- a/packages/base/any/onlp-snmpd/builds/Makefile
+++ b/packages/base/any/onlp-snmpd/builds/Makefile
@@ -26,7 +26,7 @@ GLOBAL_CFLAGS += -g
 
 LIBONLP := $(shell $(ONLPM) --find-file onlp:$(ARCH) libonlp.so)
 
-GLOBAL_LINK_LIBS += -lpthread $(LIBONLP)
+GLOBAL_LINK_LIBS += -lm -lpthread $(LIBONLP)
 GLOBAL_LINK_LIBS += -Wl,--unresolved-symbols=ignore-in-shared-libs
 
 .DEFAULT_GOAL := onlp-snmpd


### PR DESCRIPTION
Fixes #673 

Link the onlp-snmpd binary to the C math library `-lm`

Tested with a Stordis switch (platform code not public yet), I don't have a test report as such, but, it built. Apologies if this is inappropriate.