### PR TITLE
[quanta] modify qunata_eeprom for ascii format compatibility

### DIFF
--- a/packages/platforms/quanta/any/src/quanta_sys_eeprom/module/src/eeprom.c
+++ b/packages/platforms/quanta/any/src/quanta_sys_eeprom/module/src/eeprom.c
@@ -167,6 +167,11 @@ quanta_onie_sys_eeprom_custom_format(onlp_onie_info_t* onie)
         return -1;
     }
 
+    /* legacy format is four bytes long */
+    if(strlen(onie->diag_version) != 4) {
+        return 0;
+    }
+
     memset(buf, 0, sizeof(buf));
     sprintf(buf, "%d.%d.%d.%d (0x%02x%02x)",
         ((onie->diag_version[0] & 0xf0) >> 4),


### PR DESCRIPTION
add support for onie-eeprom diag version compatible with ascii format
legacy format is four bytes digits, which means diag version(2 bytes) and platform(2 bytes)
for better compatibility for onie eeprom definition, quanta use this field as ascii format