### PR TITLE
stx60d0-062f issue fix

### DIFF
--- a/packages/platforms/alphanetworks/x86-64/stx60d0-062f/onlp/builds/x86_64_alphanetworks_stx60d0_062f/module/src/fani.c
+++ b/packages/platforms/alphanetworks/x86-64/stx60d0-062f/onlp/builds/x86_64_alphanetworks_stx60d0_062f/module/src/fani.c
@@ -43,7 +43,7 @@
 #define CPLD_FAN4_SPEED_ADDR_OFFSET   0x17
 
 #define BMC_FAN1_SENSOR_NUM                 0x34 //0x31
-#define BMC_FAN2_SENSOR_NUM                 0x32//0x32
+#define BMC_FAN2_SENSOR_NUM                 0x33//0x32
 #define BMC_FAN3_SENSOR_NUM                 0x32 //0x33
 #define BMC_FAN4_SENSOR_NUM                 0x31 //0x34
 

--- a/packages/platforms/alphanetworks/x86-64/stx60d0-062f/onlp/builds/x86_64_alphanetworks_stx60d0_062f/module/src/sysi.c
+++ b/packages/platforms/alphanetworks/x86-64/stx60d0-062f/onlp/builds/x86_64_alphanetworks_stx60d0_062f/module/src/sysi.c
@@ -251,6 +251,10 @@ onlp_sysi_platform_manage_fans(void)
     onlp_thermal_info_t thermal_info;
     onlp_fan_info_t fan_info;
 
+
+    /********    FAN control only by BMC.  ********/
+    return ONLP_STATUS_OK;
+
     if (diag_debug_pause_platform_manage_check() == 1) //diag test mode
     {
         return ONLP_STATUS_OK;

--- a/packages/platforms/alphanetworks/x86-64/stx60d0-062f/platform-config/r0/src/lib/x86-64-alphanetworks-stx60d0-062f-r0.yml
+++ b/packages/platforms/alphanetworks/x86-64/stx60d0-062f/platform-config/r0/src/lib/x86-64-alphanetworks-stx60d0-062f-r0.yml
@@ -23,7 +23,7 @@ x86-64-alphanetworks-stx60d0-062f-r0:
     args: >-
       nopat
       i2c-ismt.enable=0
-      console=ttyS0,115200n8
+      console=ttyS1,115200n8
 
   ##network
   ##  interfaces:


### PR DESCRIPTION
[stx60d0-062f] Modify to use ttyS1 for sync with BIOS and ONIE, and FAN management mechanism is only controlled by BMC.