### PR TITLE
[platform/accton] as7315-27xb: fix memory leaking

### DIFF
--- a/packages/platforms/accton/x86-64/as7315-27xb/onlp/builds/x86_64_accton_as7315_27xb/module/src/psui.c
+++ b/packages/platforms/accton/x86-64/as7315-27xb/onlp/builds/x86_64_accton_as7315_27xb/module/src/psui.c
@@ -88,7 +88,7 @@ onlp_psui_info_get(onlp_oid_t id, onlp_psu_info_t* info)
     int ret   = ONLP_STATUS_OK;
     int pid = ONLP_OID_ID_GET(id);
     int zid = pid - 1 ;   /*Turn to 0-base*/
-    char *string = NULL;
+    char *string;
 
     VALIDATE(id);
     if (pid >= AIM_ARRAYSIZE(pinfo) || pid == 0) {
@@ -130,12 +130,14 @@ onlp_psui_info_get(onlp_oid_t id, onlp_psu_info_t* info)
     }
 
     /* Read serial */
+    string = NULL;
     len = onlp_file_read_str(&string, PSU_SYSFS_PATH"psu_serial", bus, offset);
     if (string && len) {
         strncpy(info->serial, string, len);
+    }
+    if (string) {
         aim_free(string);
     }
-
     bus = pmbus_cfg[zid][0];
     offset = pmbus_cfg[zid][1];
 
@@ -159,11 +161,14 @@ onlp_psui_info_get(onlp_oid_t id, onlp_psu_info_t* info)
     }
 
     /* Read model */
+    string = NULL;
     len = onlp_file_read_str(&string, PSU_SYSFS_PATH"psu_mfr_model", bus, offset);
     if (string && len) {
         strncpy(info->model, string, len);
-        aim_free(string);
         info->caps |= get_DCorAC_cap (info->model);
+    }
+    if (string) {
+        aim_free(string);
     }
 
     /* Set the associated oid_table */

--- a/packages/platforms/accton/x86-64/as7315-27xb/onlp/builds/x86_64_accton_as7315_27xb/module/src/sfpi.c
+++ b/packages/platforms/accton/x86-64/as7315-27xb/onlp/builds/x86_64_accton_as7315_27xb/module/src/sfpi.c
@@ -140,8 +140,8 @@ onlp_sfpi_presence_bitmap_get(onlp_sfp_bitmap_t* dst)
             AIM_LOG_ERROR("Unable to read presence_bitmap\r\n");
             return ONLP_STATUS_E_INTERNAL;
         }
-        aim_free( string );
         bmp[i] = strtoul(string, NULL, 16);
+        aim_free( string );
     }
 
     presence_all = start = 0;

--- a/packages/platforms/accton/x86-64/as7315-27xb/onlp/builds/x86_64_accton_as7315_27xb/module/src/sfpi.c
+++ b/packages/platforms/accton/x86-64/as7315-27xb/onlp/builds/x86_64_accton_as7315_27xb/module/src/sfpi.c
@@ -39,13 +39,11 @@ enum port_type {
 #define NUM_SFP     24
 #define NUM_QSFP    3
 #define NUM_PORT    (NUM_SFP+NUM_QSFP)
-
-
 #define SIDE_BAND_PATH                  "/sys/bus/i2c/devices/%d-00%02x/"
 #define PORT_EEPROM_FORMAT              "/sys/bus/i2c/devices/%d-0050/eeprom"
 
-int PORT_NUM[PORT_TYPE_MAX] = {NUM_SFP, NUM_QSFP};
-int SB_CFG[PORT_TYPE_MAX][2] = {{8, 0x63}, {7, 0x64}};
+const int PORT_NUM[PORT_TYPE_MAX] = {NUM_SFP, NUM_QSFP};
+const int SB_CFG[PORT_TYPE_MAX][2] = {{8, 0x63}, {7, 0x64}};
 
 /************************************************************
  *
@@ -131,14 +129,18 @@ onlp_sfpi_presence_bitmap_get(onlp_sfp_bitmap_t* dst)
     uint64_t bmp[PORT_TYPE_MAX] = {0};
 
 
-    char *string = NULL;
     for (i = 0; i < PORT_TYPE_MAX; i++) {
+        char *string = NULL;
         bus = SB_CFG[i][0];
         offset = SB_CFG[i][1];
         if (onlp_file_read_str(&string, SIDE_BAND_PATH"module_present_all", bus, offset) < 0) {
+            if ( string ) {
+                aim_free( string );
+            }
             AIM_LOG_ERROR("Unable to read presence_bitmap\r\n");
             return ONLP_STATUS_E_INTERNAL;
         }
+        aim_free( string );
         bmp[i] = strtoul(string, NULL, 16);
     }
 
@@ -171,16 +173,19 @@ onlp_sfpi_rx_los_bitmap_get(onlp_sfp_bitmap_t* dst)
     uint64_t    all_bmp;
     uint64_t bmp[PORT_TYPE_MAX] = {0};
 
-
-    char *string = NULL;
     for (i = 0; i < PORT_TYPE_MAX; i++) {
+        char *string = NULL;
         bus = SB_CFG[i][0];
         offset = SB_CFG[i][1];
         if (onlp_file_read_str(&string, SIDE_BAND_PATH"rx_los_all", bus, offset) < 0) {
+            if (string) {
+                aim_free(string);
+            }
             AIM_LOG_ERROR("Unable to read presence_bitmap\r\n");
             return ONLP_STATUS_E_INTERNAL;
         }
         bmp[i] = strtoul(string, NULL, 16);
+        aim_free(string);
     }
 
     all_bmp = start = 0;
@@ -347,7 +352,7 @@ onlp_sfpi_control_get(int port, onlp_sfp_control_t control, int* value)
         attr = "low_power_mode";
         break;
     default:
-        return ONLP_STATUS_E_UNSUPPORTED;    
+        return ONLP_STATUS_E_UNSUPPORTED;
     }
 
     bus = SB_CFG[type][0];

--- a/packages/platforms/accton/x86-64/as7315-27xb/onlp/builds/x86_64_accton_as7315_27xb/module/src/sysi.c
+++ b/packages/platforms/accton/x86-64/as7315-27xb/onlp/builds/x86_64_accton_as7315_27xb/module/src/sysi.c
@@ -198,7 +198,7 @@ sysi_fanctrl_main_policy(onlp_fan_info_t fi[CHASSIS_FAN_COUNT],
                          onlp_thermal_info_t ti[CHASSIS_THERMAL_COUNT],
                          int *adjusted)
 {
-    int duty, curr_duty, thermal;
+    int duty, thermal;
     enum {E_DOWN, E_UP, E_THRESHS};
     enum {_LOW, _NORMAL, _MID, _HIGH, _MAX} static stage = _MID;
     const int duties[] = {20, 30, 60, FAN_DUTY_MAX};
@@ -206,11 +206,6 @@ sysi_fanctrl_main_policy(onlp_fan_info_t fi[CHASSIS_FAN_COUNT],
                                                {10000, 47000, 62000, INT_MAX}};
 
     thermal = get_ambient_thermal(ti);
-    /*Take fan 1 only.*/
-    if( fani_get_fan_duty(1, &curr_duty) != ONLP_STATUS_OK) {
-        *adjusted = 1;
-        return _set_all_fans_pwm(FAN_DUTY_MAX);
-    }
 
     switch(stage) {
     case _LOW:
@@ -227,12 +222,8 @@ sysi_fanctrl_main_policy(onlp_fan_info_t fi[CHASSIS_FAN_COUNT],
         stage = _HIGH;
     }
     duty = duties[stage];
-    if (curr_duty != duty) {
-        *adjusted = 1;
-        return _set_all_fans_pwm(duty);
-    }
-
-    return ONLP_STATUS_OK;
+    *adjusted = 1;
+    return _set_all_fans_pwm(duty);
 }
 
 static int


### PR DESCRIPTION
Signed-off-by: roy_lee <roy_lee@accton.com>

1. Add aim_free() after called onlp_file_read_str() to avoid memory leaking.
2.  After called onlp_file_read_str(), call aim_free() if and only the pointer is not NULL.
3. Remove unnecessary checking on fan control.