### PR TITLE
[platform/accton] as7936-22xke: Add missed OnlPlatformPortConfig

### DIFF
--- a/packages/base/all/vendor-config-onl/src/python/onl/platform/base.py
+++ b/packages/base/all/vendor-config-onl/src/python/onl/platform/base.py
@@ -604,3 +604,7 @@ class OnlPlatformPortConfig_32x400_2x10(object):
 class OnlPlatformPortConfig_6x400_48x50(object):
     PORT_COUNT=54
     PORT_CONFIG="6x400 + 48x50"
+
+class OnlPlatformPortConfig_10x400_18x100_2x10(object):
+    PORT_COUNT=30
+    PORT_CONFIG="10x400 + 18x100 + 2x10"


### PR DESCRIPTION
Signed-off-by: roy_lee <roy_lee@edge-core.com>


Add OnlPlatformPortConfig for as7936-22xke, the PortConfig_10x400_18x100_2x10.