### PR TITLE
[device/accton] AS4630-54PE: Validate tx_disable function of 4 SFP+ ports.

### DIFF
--- a/packages/platforms/accton/x86-64/as4630-54pe/modules/builds/x86-64-accton-as4630-54pe-cpld.c
+++ b/packages/platforms/accton/x86-64/as4630-54pe/modules/builds/x86-64-accton-as4630-54pe-cpld.c
@@ -261,7 +261,7 @@ static ssize_t show_status(struct device *dev, struct device_attribute *da,
             break;       
         case MODULE_TXDISABLE_49 ... MODULE_TXDISABLE_50:
             reg=0x5;
-            mask=0x1 << (attr->index==MODULE_TXFAULT_49?7:3);
+            mask=0x1 << (attr->index==MODULE_TXDISABLE_49?7:3);
             break;
             
         case MODULE_RXLOS_51 ... MODULE_RXLOS_52:
@@ -278,7 +278,7 @@ static ssize_t show_status(struct device *dev, struct device_attribute *da,
             break;       
         case MODULE_TXDISABLE_51 ... MODULE_TXDISABLE_52:
             reg=0x6;
-            mask=0x1 << (attr->index==MODULE_TXFAULT_51?7:3);
+            mask=0x1 << (attr->index==MODULE_TXDISABLE_51?7:3);
             break;
         case MODULE_PRESENT_53 ... MODULE_PRESENT_54:
             reg=0x21;
@@ -321,16 +321,15 @@ static ssize_t set_tx_disable(struct device *dev, struct device_attribute *da,
 	if (status) {
 		return status;
 	}
-    reg  = 0x9;
     switch (attr->index)
     {
          case MODULE_TXDISABLE_49 ... MODULE_TXDISABLE_50:
             reg=0x5;
-            mask=0x1 << (attr->index==MODULE_TXFAULT_49?7:3);
+            mask=0x1 << (attr->index==MODULE_TXDISABLE_49?7:3);
             break;
         case MODULE_TXDISABLE_51 ... MODULE_TXDISABLE_52:
             reg=0x6;
-            mask=0x1 << (attr->index==MODULE_TXFAULT_51?7:3);
+            mask=0x1 << (attr->index==MODULE_TXDISABLE_51?7:3);
             break;
      
 	    default:
@@ -344,7 +343,7 @@ static ssize_t set_tx_disable(struct device *dev, struct device_attribute *da,
 		goto exit;
 	}
 	/* Update tx_disable status */
-	if (disable) {
+	if (!disable) {
 		status &= ~mask;
 	}
 	else {

--- a/packages/platforms/accton/x86-64/as4630-54pe/onlp/builds/x86_64_accton_as4630_54pe/module/src/sfpi.c
+++ b/packages/platforms/accton/x86-64/as4630-54pe/onlp/builds/x86_64_accton_as4630_54pe/module/src/sfpi.c
@@ -233,7 +233,7 @@ onlp_sfpi_control_set(int port, onlp_sfp_control_t control, int value)
         case ONLP_SFP_CONTROL_TX_DISABLE:
             {
                 if(port>=48 && port<=51) {
-                    if (onlp_file_write_int(0, MODULE_TXDISABLE_FORMAT, bus, addr, (port+1)) < 0) {
+                    if (onlp_file_write_int(value, MODULE_TXDISABLE_FORMAT, bus, addr, (port+1)) < 0) {
                         AIM_LOG_ERROR("Unable to set tx_disable status to port(%d)\r\n", port);
                         rv = ONLP_STATUS_E_INTERNAL;
                     }


### PR DESCRIPTION
Validate tx_disable function of 4 SFP+ ports and test by 
Change tx_disable by 'onlp_sfpi_control_set()' and read by `onlpdump`.

Signed-off-by: roy_lee <roy_lee@edge-core.com>

Partial test log: 
root@localhost:~# onlpdump
....
SFPs:
  Presence Bitmap: 48 49 51
  RX_LOS Bitmap: 48 49 50 51

Port 48: Present, Status = 0x00000014 [ RX_LOS,TX_DISABLE ]
eeprom:
....
Port 49: Present, Status = 0x00000004 [ RX_LOS ]
eeprom:
....
