### PR TITLE
[as4630_54pe] Fix platform port config

### DIFF
--- a/packages/base/all/vendor-config-onl/src/python/onl/platform/base.py
+++ b/packages/base/all/vendor-config-onl/src/python/onl/platform/base.py
@@ -612,3 +612,7 @@ class OnlPlatformPortConfig_6x400_48x50(object):
 class OnlPlatformPortConfig_10x400_18x100_2x10(object):
     PORT_COUNT=30
     PORT_CONFIG="10x400 + 18x100 + 2x10"
+
+class OnlPlatformPortConfig_48x1_4x25_2x100(object):
+    PORT_COUNT=54
+    PORT_CONFIG="48x1 + 4x25 + 2x100"

--- a/packages/platforms/accton/x86-64/as4630-54pe/platform-config/r0/src/python/x86_64_accton_as4630_54pe_r0/__init__.py
+++ b/packages/platforms/accton/x86-64/as4630-54pe/platform-config/r0/src/python/x86_64_accton_as4630_54pe_r0/__init__.py
@@ -2,7 +2,7 @@ from onl.platform.base import *
 from onl.platform.accton import *
 
 class OnlPlatform_x86_64_accton_as4630_54pe_r0(OnlPlatformAccton,
-                                              OnlPlatformPortConfig_48x25_6x100):
+                                              OnlPlatformPortConfig_48x1_4x25_2x100):
 
     PLATFORM='x86-64-accton-as4630-54pe-r0'
     MODEL="AS4630-54PE"


### PR DESCRIPTION
The correct port configuration of as4630_54pe is as below:
root@localhost:~# onl-platform-show
Model: AS4630-54PE
Manufacturer: Accton
Ports: 54 (48x1 + 4x25 + 2x100)

Signed-off-by: Brandon Chuang <brandon_chuang@edge-core.com>