### PR TITLE
[device/accton] wedge100bf-32x: Fix some onlpi errors at onlpd.log

### DIFF
--- a/packages/platforms/accton/x86-64/wedge100bf-32x/onlp/builds/x86_64_accton_wedge100bf_32x/module/src/fani.c
+++ b/packages/platforms/accton/x86-64/wedge100bf-32x/onlp/builds/x86_64_accton_wedge100bf_32x/module/src/fani.c
@@ -73,7 +73,7 @@ onlp_fan_info_t finfo[] = {
 int
 onlp_fani_init(void)
 {
-    return ONLP_STATUS_OK;
+    return bmc_tty_init();
 }
 
 int

--- a/packages/platforms/accton/x86-64/wedge100bf-32x/onlp/builds/x86_64_accton_wedge100bf_32x/module/src/ledi.c
+++ b/packages/platforms/accton/x86-64/wedge100bf-32x/onlp/builds/x86_64_accton_wedge100bf_32x/module/src/ledi.c
@@ -105,7 +105,7 @@ static onlp_led_info_t linfo[] =
 int
 onlp_ledi_init(void)
 {
-    return ONLP_STATUS_OK;
+    return bmc_tty_init();
 }
 
 static int

--- a/packages/platforms/accton/x86-64/wedge100bf-32x/onlp/builds/x86_64_accton_wedge100bf_32x/module/src/platform_lib.c
+++ b/packages/platforms/accton/x86-64/wedge100bf-32x/onlp/builds/x86_64_accton_wedge100bf_32x/module/src/platform_lib.c
@@ -31,9 +31,9 @@
 
 #define TTY_DEVICE                      "/dev/ttyACM0"
 #define TTY_PROMPT                      "@bmc:"
-#define TTY_I2C_TIMEOUT                 55000
-#define TTY_BMC_LOGIN_TIMEOUT            1000000
-#define TTY_RETRY                       10
+#define TTY_I2C_TIMEOUT                 80000
+#define TTY_BMC_LOGIN_TIMEOUT           1000000
+#define TTY_RETRY                       20
 #define MAXIMUM_TTY_BUFFER_LENGTH       1024
 #define MAXIMUM_TTY_STRING_LENGTH       (MAXIMUM_TTY_BUFFER_LENGTH - 1)
 
@@ -89,6 +89,16 @@ static int tty_exec_buf(unsigned long udelay, const char *str)
     memset(tty_buf, 0, MAXIMUM_TTY_BUFFER_LENGTH);
     read(tty_fd, tty_buf, MAXIMUM_TTY_BUFFER_LENGTH);
     return (strstr(tty_buf, str) != NULL) ? 0 : -1;
+}
+
+/* Clear Rx buffer by reading it out */
+static int tty_clear_rxbuf(void) {
+    if (tty_fd < 0)
+        return ONLP_STATUS_E_GENERIC;
+
+    read(tty_fd, tty_buf, MAXIMUM_TTY_BUFFER_LENGTH);
+    memset(tty_buf, 0, MAXIMUM_TTY_BUFFER_LENGTH);
+    return ONLP_STATUS_OK;
 }
 
 static int tty_login(void)
@@ -275,31 +285,44 @@ int
 bmc_command_read_int(int* value, char *cmd, int base)
 {
     int len;
-    int i;
+    int i, j, ret;
     char *prev_str = NULL;
     char *current_str= NULL;
-    if (bmc_send_command(cmd) < 0) {
-        return ONLP_STATUS_E_INTERNAL;
-    }
-    len = (int)strlen(cmd);
-    prev_str = strstr(tty_buf, cmd);
-    if (prev_str == NULL) {
-        return -1;
-    }
-    for (i = 1; i <= TTY_RETRY; i++) {
-        current_str = strstr(prev_str + len, cmd);
-        if(current_str == NULL) {
-            if( !chk_numeric_char(prev_str + len, base) ){
-                return -1;
-            }
-            *value = strtoul(prev_str + len, NULL, base);
-            break;
-        }else {
-            prev_str = current_str;
+
+    ret = -1;
+    for (j = 1; j <= TTY_RETRY; j++) {
+        tty_clear_rxbuf();
+        if (bmc_send_command(cmd) < 0) {
+            return ONLP_STATUS_E_INTERNAL;
+        }
+
+        len = (int)strlen(cmd);
+        prev_str = strstr(tty_buf, cmd);
+        if (prev_str == NULL) {
+            ret = -1;
             continue;
         }
+
+        for (i = 1; i <= TTY_RETRY; i++) {
+            current_str = strstr(prev_str + len, cmd);
+            if(current_str == NULL) {
+                if( !chk_numeric_char(prev_str + len, base) ) {
+                    ret = -1;
+                    continue;
+                }
+                *value = strtoul(prev_str + len, NULL, base);
+                ret = 0;
+                goto exit;
+            } else {
+                prev_str = current_str;
+                ret = -1;
+                continue;
+            }
+        }
     }
-    return 0;
+
+exit:
+    return ret;
 }
 
 

--- a/packages/platforms/accton/x86-64/wedge100bf-32x/onlp/builds/x86_64_accton_wedge100bf_32x/module/src/platform_lib.c
+++ b/packages/platforms/accton/x86-64/wedge100bf-32x/onlp/builds/x86_64_accton_wedge100bf_32x/module/src/platform_lib.c
@@ -312,12 +312,16 @@ bmc_file_read_int(int* value, char *file, int base)
 }
 
 int
-bmc_i2c_readb(uint8_t bus, uint8_t devaddr, uint8_t addr)
+bmc_i2c_readb(uint8_t bus, uint8_t devaddr, int16_t addr)
 {
     int ret = 0, value;
     char cmd[64] = {0};
-
-    snprintf(cmd, sizeof(cmd), "i2cget -f -y %d 0x%x 0x%02x\r\n", bus, devaddr, addr);
+    if (addr < 0) {
+        snprintf(cmd, sizeof(cmd), "i2cget -f -y %d 0x%x\r\n", bus, devaddr);
+    } else {
+        snprintf(cmd, sizeof(cmd), "i2cget -f -y %d 0x%x 0x%02x\r\n", bus,
+                 devaddr, (uint8_t)addr);
+    }
     ret = bmc_command_read_int(&value, cmd, 16);
     return (ret < 0) ? ret : value;
 }

--- a/packages/platforms/accton/x86-64/wedge100bf-32x/onlp/builds/x86_64_accton_wedge100bf_32x/module/src/platform_lib.h
+++ b/packages/platforms/accton/x86-64/wedge100bf-32x/onlp/builds/x86_64_accton_wedge100bf_32x/module/src/platform_lib.h
@@ -60,7 +60,7 @@ enum onlp_thermal_id
 int bmc_send_command(char *cmd);
 int bmc_file_read_str(char *file, char *result, int slen);
 int bmc_file_read_int(int* value, char *file, int base);
-int bmc_i2c_readb(uint8_t bus, uint8_t devaddr, uint8_t addr);
+int bmc_i2c_readb(uint8_t bus, uint8_t devaddr, int16_t addr);
 int bmc_i2c_writeb(uint8_t bus, uint8_t devaddr, uint8_t addr, uint8_t value);
 int bmc_i2c_write_quick_mode(uint8_t bus, uint8_t devaddr, uint8_t value);
 int bmc_i2c_readw(uint8_t bus, uint8_t devaddr, uint8_t addr);

--- a/packages/platforms/accton/x86-64/wedge100bf-32x/onlp/builds/x86_64_accton_wedge100bf_32x/module/src/psui.c
+++ b/packages/platforms/accton/x86-64/wedge100bf-32x/onlp/builds/x86_64_accton_wedge100bf_32x/module/src/psui.c
@@ -66,7 +66,7 @@ static onlp_psu_info_t pinfo[] =
 int
 onlp_psui_init(void)
 {
-    return ONLP_STATUS_OK;
+    return bmc_tty_init();
 }
 
 static int

--- a/packages/platforms/accton/x86-64/wedge100bf-32x/onlp/builds/x86_64_accton_wedge100bf_32x/module/src/psui.c
+++ b/packages/platforms/accton/x86-64/wedge100bf-32x/onlp/builds/x86_64_accton_wedge100bf_32x/module/src/psui.c
@@ -39,15 +39,16 @@
 #define PSU1_ID 1
 #define PSU2_ID 2
 
+#define PSU_I2CBUS          7
 #define SYS_CPLD_PATH_FMT	"/sys/bus/i2c/drivers/syscpld/12-0031/%s"
 #define PSU_PRESENT_FMT		"psu%d_present"
 #define PSU_PWROK_FMT		"psu%d_output_pwr_sts"
 
-#define PSU_PFE1100_PATH_FMT	"/sys/bus/i2c/devices/7-%s/%s\r\n"
+#define PSU_PFE1100_PATH_FMT	"/sys/bus/i2c/devices/%d-00%02x/%s\r\n"
 #define PSU_PFE1100_MODEL	"mfr_model_label"
 #define PSU_PFE1100_SERIAL	"mfr_serial_label"
 
-static const char *psu_pfedrv_i2c_devaddr[] = {"0059", "005a"};
+static const uint8_t pmbus_addr[] = {0x5a, 0x59};
 
 /*
  * Get all information about the given PSU oid.
@@ -96,6 +97,7 @@ onlp_psui_info_get(onlp_oid_t id, onlp_psu_info_t* info)
     int pid, value, addr, ret = 0;
     char file[32] = {0};
     char path[80] = {0};
+    int bus = PSU_I2CBUS;
     
     VALIDATE(id);
 
@@ -124,9 +126,28 @@ onlp_psui_info_get(onlp_oid_t id, onlp_psu_info_t* info)
         return ONLP_STATUS_OK;
     }
     info->status |= ONLP_PSU_STATUS_PRESENT;
-    info->caps = ONLP_PSU_CAPS_AC; 
+    info->caps = ONLP_PSU_CAPS_AC;
 
-    /* Get power good status 
+
+    /* Get model name */
+    ret = snprintf(path, sizeof(path), PSU_PFE1100_PATH_FMT, bus,
+                   pmbus_addr[pid - PSU1_ID], PSU_PFE1100_MODEL);
+    if( ret >= sizeof(path) ) {
+        AIM_LOG_ERROR("path size overwrite (%d,%d)\r\n", ret, sizeof(path));
+        return ONLP_STATUS_E_INTERNAL;
+    }
+    bmc_file_read_str(path, info->model, sizeof(info->model));
+
+    /* Get serial number */
+    ret = snprintf(path, sizeof(path), PSU_PFE1100_PATH_FMT, bus,
+                   pmbus_addr[pid - PSU1_ID], PSU_PFE1100_SERIAL);
+    if( ret >= sizeof(path) ) {
+        AIM_LOG_ERROR("path size overwrite (%d,%d)\r\n", ret, sizeof(path));
+        return ONLP_STATUS_E_INTERNAL;
+    }
+    bmc_file_read_str(path, info->serial, sizeof(info->serial));
+
+    /* Get power good status
      */
     ret = snprintf(file, sizeof(file), PSU_PWROK_FMT, pid);
     if( ret >= sizeof(file) ){
@@ -148,26 +169,33 @@ onlp_psui_info_get(onlp_oid_t id, onlp_psu_info_t* info)
         return ONLP_STATUS_OK;
     }
 
-
-    /* Get input output power status
+    /* open i2c mux channels for PSUs
      */
-    value = (pid == PSU1_ID) ? 0x2 : 0x1; /* mux channel for psu */
-    if (bmc_i2c_write_quick_mode(7, 0x70, value) < 0) {
-        AIM_LOG_ERROR("Unable to set i2c device (7/0x70)\r\n");
+    addr = 0x70;
+    value = bmc_i2c_readb(bus, addr, -1);
+    if (value >= 0) {
+        value |= 0x03; /*Open both PSU channels.*/
+        if (bmc_i2c_write_quick_mode(bus, addr, value) < 0) {
+            AIM_LOG_ERROR("Unable to set i2c device (%d/0x%02x)\r\n",
+                          bus, addr);
+            return ONLP_STATUS_E_INTERNAL;
+        }
+    } else {
+        AIM_LOG_ERROR("Unable to get i2c device (%d/0x%02x)\r\n", bus, addr);
         return ONLP_STATUS_E_INTERNAL;
     }
     usleep(1200);
 
     /* Read vin */
-    addr  = (pid == PSU1_ID) ? 0x59 : 0x5a;
-    value = bmc_i2c_readw(7, addr, 0x88);
+    addr  = pmbus_addr[pid - PSU1_ID];
+    value = bmc_i2c_readw(bus, addr, 0x88);
     if (value >= 0) {
         info->mvin = pmbus_parse_literal_format(value);
         info->caps |= ONLP_PSU_CAPS_VIN;
     }
 
     /* Read iin */
-    value = bmc_i2c_readw(7, addr, 0x89);
+    value = bmc_i2c_readw(bus, addr, 0x89);
     if (value >= 0) {
         info->miin = pmbus_parse_literal_format(value);
         info->caps |= ONLP_PSU_CAPS_IIN;
@@ -180,14 +208,14 @@ onlp_psui_info_get(onlp_oid_t id, onlp_psu_info_t* info)
     }
 
     /* Read iout */
-    value = bmc_i2c_readw(7, addr, 0x8c);
+    value = bmc_i2c_readw(bus, addr, 0x8c);
     if (value >= 0) {
         info->miout = pmbus_parse_literal_format(value);
         info->caps |= ONLP_PSU_CAPS_IOUT;
     }
 
     /* Read pout */
-    value = bmc_i2c_readw(7, addr, 0x96);
+    value = bmc_i2c_readw(bus, addr, 0x96);
     if (value >= 0) {
         info->mpout = pmbus_parse_literal_format(value);
         info->caps |= ONLP_PSU_CAPS_POUT;
@@ -195,25 +223,10 @@ onlp_psui_info_get(onlp_oid_t id, onlp_psu_info_t* info)
 
     /* Get vout */
     if ((info->caps & ONLP_PSU_CAPS_IOUT) && (info->caps & ONLP_PSU_CAPS_POUT) && info->miout != 0) {
-            info->mvout = info->mpout / info->miout * 1000;
-            info->caps |= ONLP_PSU_CAPS_VOUT;
+        info->mvout = info->mpout / info->miout * 1000;
+        info->caps |= ONLP_PSU_CAPS_VOUT;
     }
 
-    /* Get model name */
-    ret = snprintf(path, sizeof(path), PSU_PFE1100_PATH_FMT, psu_pfedrv_i2c_devaddr[pid-1], PSU_PFE1100_MODEL);
-    if( ret >= sizeof(path) ){
-        AIM_LOG_ERROR("path size overwrite (%d,%d)\r\n", ret, sizeof(path));
-        return ONLP_STATUS_E_INTERNAL;
-    }
-    bmc_file_read_str(path, info->model, sizeof(info->model));
-
-    /* Get serial number */
-    ret = snprintf(path, sizeof(path), PSU_PFE1100_PATH_FMT, psu_pfedrv_i2c_devaddr[pid-1], PSU_PFE1100_SERIAL);
-    if( ret >= sizeof(path) ){
-        AIM_LOG_ERROR("path size overwrite (%d,%d)\r\n", ret, sizeof(path));
-        return ONLP_STATUS_E_INTERNAL;
-    }
-    bmc_file_read_str(path, info->serial, sizeof(info->serial));
     return ONLP_STATUS_OK;
 }
 

--- a/packages/platforms/accton/x86-64/wedge100bf-32x/onlp/builds/x86_64_accton_wedge100bf_32x/module/src/sfpi.c
+++ b/packages/platforms/accton/x86-64/wedge100bf-32x/onlp/builds/x86_64_accton_wedge100bf_32x/module/src/sfpi.c
@@ -50,7 +50,7 @@ int
 onlp_sfpi_init(void)
 {
     /* Called at initialization time */    
-    return ONLP_STATUS_OK;
+    return bmc_tty_init();
 }
 
 int

--- a/packages/platforms/accton/x86-64/wedge100bf-32x/onlp/builds/x86_64_accton_wedge100bf_32x/module/src/thermali.c
+++ b/packages/platforms/accton/x86-64/wedge100bf-32x/onlp/builds/x86_64_accton_wedge100bf_32x/module/src/thermali.c
@@ -93,7 +93,7 @@ static onlp_thermal_info_t linfo[] = {
 int
 onlp_thermali_init(void)
 {
-    return ONLP_STATUS_OK;
+    return bmc_tty_init();
 }
 
 /*


### PR DESCRIPTION
There are many error can be seen at  /var/log/onlpd.log a while after boot-up.
Most of error are caused by parted of BMC tty's response.
To solve that, add retries of whole transaction to BMC, it can give a clear /var/log/onlpd.log over-night .
But it still cannot guarantee no error while BMC is busy. 
It's a trade-off between response time and accuration.

Signed-off-by: roy_lee <roy_lee@edge-core.com>