### PR TITLE
[Accton] Fix memory leak if PSU1 is not present

### DIFF
--- a/packages/platforms/accton/x86-64/as5916-26xb/onlp/builds/x86_64_accton_as5916_26xb/module/src/psui.c
+++ b/packages/platforms/accton/x86-64/as5916-26xb/onlp/builds/x86_64_accton_as5916_26xb/module/src/psui.c
@@ -155,15 +155,23 @@ onlp_psui_info_get(onlp_oid_t id, onlp_psu_info_t* info)
     int len = onlp_file_read_str(&string, "%s""psu%d_model", PSU_SYSFS_PATH, pid);
     if (string && len) {
         aim_strlcpy(info->model, string, len);
-        aim_free(string);
         info->caps |= get_DCorAC_cap (info->model);
+    }
+
+    if (string) {
+        aim_free(string);
+        string = NULL;
     }
 
     /* Read serial */
     len = onlp_file_read_str(&string, "%s""psu%d_serial", PSU_SYSFS_PATH, pid);
     if (string && len) {
         aim_strlcpy(info->serial, string, len);
+    }
+
+    if (string) {
         aim_free(string);
+        string = NULL;
     }
 
     return ret;

--- a/packages/platforms/accton/x86-64/as5916-54xks/onlp/builds/x86_64_accton_as5916_54xks/module/src/psui.c
+++ b/packages/platforms/accton/x86-64/as5916-54xks/onlp/builds/x86_64_accton_as5916_54xks/module/src/psui.c
@@ -140,7 +140,11 @@ onlp_psui_info_get(onlp_oid_t id, onlp_psu_info_t* info)
     if (string && len) {
         memcpy(info->model, string, len);
         info->model[len] = '\0';
+    }
+
+    if (string) {
         aim_free(string);
+        string = NULL;
     }
 
     /* Read serial */
@@ -148,7 +152,11 @@ onlp_psui_info_get(onlp_oid_t id, onlp_psu_info_t* info)
     if (string && len) {
         memcpy(info->serial, string, len);
         info->serial[len] = '\0';
+    }
+
+    if (string) {
         aim_free(string);
+        string = NULL;
     }
 
     return ret;

--- a/packages/platforms/accton/x86-64/as5916-54xl/onlp/builds/x86_64_accton_as5916_54xl/module/src/psui.c
+++ b/packages/platforms/accton/x86-64/as5916-54xl/onlp/builds/x86_64_accton_as5916_54xl/module/src/psui.c
@@ -140,7 +140,11 @@ onlp_psui_info_get(onlp_oid_t id, onlp_psu_info_t* info)
     if (string && len) {
         memcpy(info->model, string, len);
         info->model[len] = '\0';
+    }
+
+    if (string) {
         aim_free(string);
+        string = NULL;
     }
 
     /* Read serial */
@@ -148,7 +152,11 @@ onlp_psui_info_get(onlp_oid_t id, onlp_psu_info_t* info)
     if (string && len) {
         memcpy(info->serial, string, len);
         info->serial[len] = '\0';
+    }
+
+    if (string) {
         aim_free(string);
+        string = NULL;
     }
 
     return ret;

--- a/packages/platforms/accton/x86-64/as7315-27xb/onlp/builds/x86_64_accton_as7315_27xb/module/src/psui.c
+++ b/packages/platforms/accton/x86-64/as7315-27xb/onlp/builds/x86_64_accton_as7315_27xb/module/src/psui.c
@@ -135,8 +135,10 @@ onlp_psui_info_get(onlp_oid_t id, onlp_psu_info_t* info)
     if (string && len) {
         strncpy(info->serial, string, len);
     }
+
     if (string) {
         aim_free(string);
+        string = NULL;
     }
     bus = pmbus_cfg[zid][0];
     offset = pmbus_cfg[zid][1];
@@ -167,8 +169,10 @@ onlp_psui_info_get(onlp_oid_t id, onlp_psu_info_t* info)
         strncpy(info->model, string, len);
         info->caps |= get_DCorAC_cap (info->model);
     }
+
     if (string) {
         aim_free(string);
+        string = NULL;
     }
 
     /* Set the associated oid_table */

--- a/packages/platforms/accton/x86-64/as7315-27xb/onlp/builds/x86_64_accton_as7315_27xb/module/src/sfpi.c
+++ b/packages/platforms/accton/x86-64/as7315-27xb/onlp/builds/x86_64_accton_as7315_27xb/module/src/sfpi.c
@@ -140,8 +140,10 @@ onlp_sfpi_presence_bitmap_get(onlp_sfp_bitmap_t* dst)
             AIM_LOG_ERROR("Unable to read presence_bitmap\r\n");
             return ONLP_STATUS_E_INTERNAL;
         }
-        bmp[i] = strtoul(string, NULL, 16);
-        aim_free( string );
+        if (string) {
+            bmp[i] = strtoul(string, NULL, 16);
+            aim_free(string);
+        }
     }
 
     presence_all = start = 0;
@@ -184,8 +186,10 @@ onlp_sfpi_rx_los_bitmap_get(onlp_sfp_bitmap_t* dst)
             AIM_LOG_ERROR("Unable to read presence_bitmap\r\n");
             return ONLP_STATUS_E_INTERNAL;
         }
-        bmp[i] = strtoul(string, NULL, 16);
-        aim_free(string);
+        if (string) {
+            bmp[i] = strtoul(string, NULL, 16);
+            aim_free(string);
+        }
     }
 
     all_bmp = start = 0;

--- a/packages/platforms/accton/x86-64/as7316-26xb/onlp/builds/x86_64_accton_as7316_26xb/module/src/psui.c
+++ b/packages/platforms/accton/x86-64/as7316-26xb/onlp/builds/x86_64_accton_as7316_26xb/module/src/psui.c
@@ -150,8 +150,12 @@ onlp_psui_info_get(onlp_oid_t id, onlp_psu_info_t* info)
     if (string && len) {
         strncpy(info->model, string, len);
         info->model[len] = '\0';
-        aim_free(string);
         info->caps |= get_DCorAC_cap (info->model);
+    }
+
+    if (string) {
+        aim_free(string);
+        string = NULL;
     }
 
     /* Read serial */
@@ -159,7 +163,11 @@ onlp_psui_info_get(onlp_oid_t id, onlp_psu_info_t* info)
     if (string && len) {
         strncpy(info->serial, string, len);
         info->serial[len] = '\0';
+    }
+
+    if (string) {
         aim_free(string);
+        string = NULL;
     }
 
     return ret;

--- a/packages/platforms/accton/x86-64/as7712-32x/onlp/builds/x86_64_accton_as7712_32x/module/src/platform_lib.c
+++ b/packages/platforms/accton/x86-64/as7712-32x/onlp/builds/x86_64_accton_as7712_32x/module/src/platform_lib.c
@@ -208,6 +208,9 @@ psu_type_t get_psu_type(int id, char* modelname, int modelname_len)
         char *prefix = (id == PSU1_ID) ? PSU1_AC_PMBUS_PREFIX : PSU2_AC_PMBUS_PREFIX;
         int len = onlp_file_read_str(&string, "%s""psu_fan_dir", prefix);
         if (!string || len <= 0) {
+            if (string) {
+                aim_free(string);
+            }
             return PSU_TYPE_UNKNOWN;
         }
 
@@ -256,6 +259,9 @@ int psu_acbel_serial_number_get(int id, char *serial, int serial_len)
     
     int len = onlp_file_read_str(&serial_number, "%s""psu_serial_number", prefix);
     if (!serial_number || len <= 0) {
+        if (serial_number) {
+            aim_free(serial_number);
+        }
         return ONLP_STATUS_E_INTERNAL;
     }
 

--- a/packages/platforms/accton/x86-64/asgvolt64/onlp/builds/x86_64_accton_asgvolt64/module/src/psui.c
+++ b/packages/platforms/accton/x86-64/asgvolt64/onlp/builds/x86_64_accton_asgvolt64/module/src/psui.c
@@ -138,14 +138,22 @@ onlp_psui_info_get(onlp_oid_t id, onlp_psu_info_t* info)
     int len = onlp_file_read_str(&string, "%s""psu%d_model", PSU_SYSFS_PATH, pid);
     if (string && len) {
         aim_strlcpy(info->model, string, len);
+    }
+
+    if (string) {
         aim_free(string);
+        string = NULL;
     }
 
     /* Read serial */
     len = onlp_file_read_str(&string, "%s""psu%d_serial", PSU_SYSFS_PATH, pid);
     if (string && len) {
         aim_strlcpy(info->serial, string, len);
+    }
+
+    if (string) {
         aim_free(string);
+        string = NULL;
     }
 
     return ret;


### PR DESCRIPTION
The memory leak occurs on several accton platforms. It occurs on switches
that do not have PSU1 present. The memory leak is caused due to an allocated,
but empty string being returned from the onlp_file_read_str() function. The
code calling the onlp_file_read_str() function would free the returned
allocated string only if the string was not NULL and not empty.

#822 contain 7 platforms with memory leak:
as5916-26xb / as5916-54xks / as5916-54xl / as7315-27xb / as7316-26xb / as7712-32x / asgvolt64
#824 is for the rest platforms which also use onlp_file_read_str() but not release memory precisely:
as5835-54t / as5835-54x / as5912-54x / as5916-54xm / as7312-54x / as7312-54xs / as9926-24d