### PR TITLE
[Accton] Fix memory leak if PSU1 is not present

### DIFF
--- a/packages/platforms/accton/x86-64/as5835-54t/onlp/builds/x86_64_accton_as5835_54t/module/src/platform_lib.c
+++ b/packages/platforms/accton/x86-64/as5835-54t/onlp/builds/x86_64_accton_as5835_54t/module/src/platform_lib.c
@@ -33,22 +33,26 @@
 #define PSU_FAN_DIR_LEN         3
 #define PSU_MODEL_NAME_LEN 		11
 #define PSU_SERIAL_NUMBER_LEN	18
+#define AIM_FREE_IF_PTR(p) \
+    do \
+    { \
+        if (p) { \
+            aim_free(p); \
+            p = NULL; \
+        } \
+    } while (0)
 
 int get_psu_serial_number(int id, char *serial, int serial_len)
 {
     int   ret  = 0;
 	char *node = NULL;
-    char *sn = aim_zmalloc(PSU_SERIAL_NUMBER_LEN + 1);
+    char *sn = NULL;
 
-    if (!sn) {
-        return ONLP_STATUS_E_INTERNAL;
-    }
-    
     /* Read AC serial number */
     node = (id == PSU1_ID) ? PSU1_AC_HWMON_NODE(psu_serial_numer) : PSU2_AC_HWMON_NODE(psu_serial_numer);
     ret = onlp_file_read_str(&sn, node);
     if (ret <= 0 || ret > PSU_SERIAL_NUMBER_LEN) {
-        aim_free(sn);
+        AIM_FREE_IF_PTR(sn);
         return ONLP_STATUS_E_INVALID;
     }
 
@@ -56,7 +60,7 @@ int get_psu_serial_number(int id, char *serial, int serial_len)
         strncpy(serial, sn, PSU_SERIAL_NUMBER_LEN+1);
     }
 
-    aim_free(sn);
+    AIM_FREE_IF_PTR(sn);
 	return ONLP_STATUS_OK;
 }
 
@@ -64,28 +68,28 @@ psu_type_t get_psu_type(int id, char* modelname, int modelname_len)
 {
     int   ret = 0;
     char *node = NULL;
-    char *mn = aim_zmalloc(PSU_MODEL_NAME_LEN + 1);
+    char *mn = NULL;
     psu_type_t ptype = PSU_TYPE_UNKNOWN;
 
     /* Check AC model name */
     node = (id == PSU1_ID) ? PSU1_AC_HWMON_NODE(psu_model_name) : PSU2_AC_HWMON_NODE(psu_model_name);
     ret = onlp_file_read_str(&mn, node);
-    if (ret <= 0 || ret > PSU_MODEL_NAME_LEN) {
-        aim_free(mn);
+    if (ret <= 0 || ret > PSU_MODEL_NAME_LEN || mn == NULL) {
+        AIM_FREE_IF_PTR(mn);
         return PSU_TYPE_UNKNOWN;
     }
 
     if (modelname) {
         strncpy(modelname, mn, PSU_MODEL_NAME_LEN + 1);
     }
-    
+
     if (strncmp(mn, "YM-1401A", 8) == 0) {
-        char *fd = aim_zmalloc(PSU_FAN_DIR_LEN + 1 + 1);
-        
+        char *fd = NULL;
+
         node = (id == PSU1_ID) ? PSU1_AC_PMBUS_NODE(psu_fan_dir) : PSU2_AC_PMBUS_NODE(psu_fan_dir);
         ret = onlp_file_read_str(&fd, node);
 
-        if (ret <= 0 || ret > PSU_FAN_DIR_LEN) {
+        if (ret <= 0 || ret > PSU_FAN_DIR_LEN || fd == NULL) {
             ptype = PSU_TYPE_UNKNOWN;
         }
         else if (strncmp(fd, "B2F", PSU_FAN_DIR_LEN) == 0) {
@@ -95,7 +99,7 @@ psu_type_t get_psu_type(int id, char* modelname, int modelname_len)
             ptype = PSU_TYPE_AC_F2B;
         }
 
-        aim_free(fd);
+        AIM_FREE_IF_PTR(fd);
     }
     else if (strncmp(mn, "DPS400AB33A", PSU_MODEL_NAME_LEN) == 0) {
         ptype = PSU_TYPE_AC_F2B;
@@ -104,7 +108,7 @@ psu_type_t get_psu_type(int id, char* modelname, int modelname_len)
         ptype = PSU_TYPE_AC_B2F;
     }
 
-    aim_free(mn);
+    AIM_FREE_IF_PTR(mn);
     return ptype;
 }
 

--- a/packages/platforms/accton/x86-64/as5912-54x/onlp/builds/x86_64_accton_as5912_54x/module/src/platform_lib.c
+++ b/packages/platforms/accton/x86-64/as5912-54x/onlp/builds/x86_64_accton_as5912_54x/module/src/platform_lib.c
@@ -30,6 +30,14 @@
 #include "platform_lib.h"
 
 #define PSU_NODE_MAX_PATH_LEN 64
+#define AIM_FREE_IF_PTR(p) \
+    do \
+    { \
+        if (p) { \
+            aim_free(p); \
+            p = NULL; \
+        } \
+    } while (0)
 
 int _onlp_file_write(char *filename, char *buffer, int buf_size, int data_len)
 {
@@ -137,11 +145,12 @@ psu_type_t get_psu_type(int id, char* modelname, int modelname_len)
         {
             aim_strlcpy(modelname, model_name, sizeof(model_name));
         }
-        char *fan_str = aim_zmalloc(PSU_FAN_DIR_LEN + 1);
+
+        char *fan_str = NULL;
 
         node = (id == PSU1_ID) ? PSU1_AC_PMBUS_NODE(psu_fan_dir) : PSU2_AC_PMBUS_NODE(psu_fan_dir);
         ret = onlp_file_read_str(&fan_str, node);
-        if (ret <= 0 || ret > PSU_FAN_DIR_LEN)
+        if (ret <= 0 || ret > PSU_FAN_DIR_LEN || fan_str == NULL)
         {
             ptype = PSU_TYPE_UNKNOWN;
         }
@@ -154,7 +163,7 @@ psu_type_t get_psu_type(int id, char* modelname, int modelname_len)
             ptype = PSU_TYPE_AC_B2F;
         }
 
-        aim_free(fan_str);
+        AIM_FREE_IF_PTR(fan_str);
     }
     if (strncmp(model_name, "YM-2651V", 8) == 0)
     {
@@ -163,11 +172,11 @@ psu_type_t get_psu_type(int id, char* modelname, int modelname_len)
             aim_strlcpy(modelname, model_name, sizeof(model_name));
         }
 
-        char *fan_str = aim_zmalloc(PSU_FAN_DIR_LEN + 1);
-        
+        char *fan_str = NULL;
+
         node = (id == PSU1_ID) ? PSU1_AC_PMBUS_NODE(psu_fan_dir) : PSU2_AC_PMBUS_NODE(psu_fan_dir);
         ret = onlp_file_read_str(&fan_str, node);
-        if (ret <= 0 || ret > PSU_FAN_DIR_LEN)
+        if (ret <= 0 || ret > PSU_FAN_DIR_LEN || fan_str == NULL)
         {
             ptype = PSU_TYPE_UNKNOWN;
         }
@@ -180,7 +189,7 @@ psu_type_t get_psu_type(int id, char* modelname, int modelname_len)
             ptype = PSU_TYPE_DC_48V_B2F;
         }
 
-        aim_free(fan_str);
+        AIM_FREE_IF_PTR(fan_str);
     }
 
     return ptype;

--- a/packages/platforms/accton/x86-64/as5916-54xm/onlp/builds/x86_64_accton_as5916_54xm/module/src/platform_lib.c
+++ b/packages/platforms/accton/x86-64/as5916-54xm/onlp/builds/x86_64_accton_as5916_54xm/module/src/platform_lib.c
@@ -30,6 +30,14 @@
 #include "platform_lib.h"
 
 #define PSU_NODE_MAX_PATH_LEN 64
+#define AIM_FREE_IF_PTR(p) \
+    do \
+    { \
+        if (p) { \
+            aim_free(p); \
+            p = NULL; \
+        } \
+    } while (0)
 
 int onlp_file_write_integer(char *filename, int value)
 {
@@ -84,11 +92,12 @@ psu_type_t get_psu_type(int id, char* modelname, int modelname_len)
         {
             aim_strlcpy(modelname, model_name, sizeof(model_name));
         }
-        char *fan_str = aim_zmalloc(PSU_FAN_DIR_LEN + 1);
+
+        char *fan_str = NULL;
 
         node = (id == PSU1_ID) ? PSU1_AC_PMBUS_NODE(psu_fan_dir) : PSU2_AC_PMBUS_NODE(psu_fan_dir);
         ret = onlp_file_read_str(&fan_str, node);
-        if (ret <= 0 || ret > PSU_FAN_DIR_LEN)
+        if (ret <= 0 || ret > PSU_FAN_DIR_LEN || fan_str == NULL)
         {
             ptype = PSU_TYPE_UNKNOWN;
         }
@@ -101,7 +110,7 @@ psu_type_t get_psu_type(int id, char* modelname, int modelname_len)
             ptype = PSU_TYPE_AC_B2F;
         }
 
-        aim_free(fan_str);
+        AIM_FREE_IF_PTR(fan_str);
     }
     if (strncmp(model_name, "YM-2651V", 8) == 0)
     {
@@ -110,11 +119,11 @@ psu_type_t get_psu_type(int id, char* modelname, int modelname_len)
             aim_strlcpy(modelname, model_name, sizeof(model_name));
         }
 
-        char *fan_str = aim_zmalloc(PSU_FAN_DIR_LEN + 1);
-        
+        char *fan_str = NULL;
+
         node = (id == PSU1_ID) ? PSU1_AC_PMBUS_NODE(psu_fan_dir) : PSU2_AC_PMBUS_NODE(psu_fan_dir);
         ret = onlp_file_read_str(&fan_str, node);
-        if (ret <= 0 || ret > PSU_FAN_DIR_LEN)
+        if (ret <= 0 || ret > PSU_FAN_DIR_LEN || fan_str == NULL)
         {
             ptype = PSU_TYPE_UNKNOWN;
         }
@@ -126,7 +135,8 @@ psu_type_t get_psu_type(int id, char* modelname, int modelname_len)
         {
             ptype = PSU_TYPE_DC_48V_B2F;
         }
-        aim_free(fan_str);
+
+        AIM_FREE_IF_PTR(fan_str);
     }
 
     return ptype;

--- a/packages/platforms/accton/x86-64/as7312-54x/onlp/builds/x86_64_accton_as7312_54x/module/src/platform_lib.c
+++ b/packages/platforms/accton/x86-64/as7312-54x/onlp/builds/x86_64_accton_as7312_54x/module/src/platform_lib.c
@@ -6,6 +6,14 @@
 #include <onlp/platformi/sfpi.h>
 #include "x86_64_accton_as7312_54x_log.h"
 
+#define AIM_FREE_IF_PTR(p) \
+    do \
+    { \
+        if (p) { \
+            aim_free(p); \
+            p = NULL; \
+        } \
+    } while (0)
 
 static int _onlp_file_write(char *filename, char *buffer, int buf_size, int data_len)
 {
@@ -111,12 +119,12 @@ psu_type_t get_psu_type(int id, char* modelname, int modelname_len)
             aim_strlcpy(modelname, model_name, sizeof(model_name));
         }
 
-        char *fd = aim_zmalloc(PSU_FAN_DIR_LEN + 1);
+        char *fd = NULL;
         
         node = (id == PSU1_ID) ? PSU1_AC_PMBUS_NODE(psu_fan_dir) : PSU2_AC_PMBUS_NODE(psu_fan_dir);
         ret = onlp_file_read_str(&fd, node);
 
-        if (ret <= 0 || ret > PSU_FAN_DIR_LEN) {
+        if (ret <= 0 || ret > PSU_FAN_DIR_LEN || fd == NULL) {
             ptype = PSU_TYPE_UNKNOWN;
         }
         else if (strncmp(fd, "F2B", PSU_FAN_DIR_LEN) == 0) {
@@ -126,7 +134,7 @@ psu_type_t get_psu_type(int id, char* modelname, int modelname_len)
             ptype = PSU_TYPE_AC_B2F;
         }
 
-        aim_free(fd);
+        AIM_FREE_IF_PTR(fd);
     }
 
     if (strncmp(model_name, "YM-2651V", 8) == 0) {
@@ -134,12 +142,12 @@ psu_type_t get_psu_type(int id, char* modelname, int modelname_len)
             aim_strlcpy(modelname, model_name, sizeof(model_name));
         }
 
-        char *fd = aim_zmalloc(PSU_FAN_DIR_LEN + 1);
+        char *fd = NULL;
         
         node = (id == PSU1_ID) ? PSU1_AC_PMBUS_NODE(psu_fan_dir) : PSU2_AC_PMBUS_NODE(psu_fan_dir);
         ret = onlp_file_read_str(&fd, node);
 
-        if (ret <= 0 || ret > PSU_FAN_DIR_LEN) {
+        if (ret <= 0 || ret > PSU_FAN_DIR_LEN || fd == NULL) {
             ptype = PSU_TYPE_UNKNOWN;
         }
         else if (strncmp(fd, "F2B", PSU_FAN_DIR_LEN) == 0) {
@@ -149,7 +157,7 @@ psu_type_t get_psu_type(int id, char* modelname, int modelname_len)
             ptype = PSU_TYPE_DC_48V_B2F;
         }
 
-        aim_free(fd);
+        AIM_FREE_IF_PTR(fd);
     }
 
     return ptype;

--- a/packages/platforms/accton/x86-64/as7312-54xs/onlp/builds/x86_64_accton_as7312_54xs/module/src/platform_lib.c
+++ b/packages/platforms/accton/x86-64/as7312-54xs/onlp/builds/x86_64_accton_as7312_54xs/module/src/platform_lib.c
@@ -6,6 +6,14 @@
 #include <onlp/platformi/sfpi.h>
 #include "x86_64_accton_as7312_54xs_log.h"
 
+#define AIM_FREE_IF_PTR(p) \
+    do \
+    { \
+        if (p) { \
+            aim_free(p); \
+            p = NULL; \
+        } \
+    } while (0)
 
 static int _onlp_file_write(char *filename, char *buffer, int buf_size, int data_len)
 {
@@ -111,12 +119,12 @@ psu_type_t get_psu_type(int id, char* modelname, int modelname_len)
             aim_strlcpy(modelname, model_name, sizeof(model_name));
         }
 
-        char *fd = aim_zmalloc(PSU_FAN_DIR_LEN + 1);
+        char *fd = NULL;
         
         node = (id == PSU1_ID) ? PSU1_AC_PMBUS_NODE(psu_fan_dir) : PSU2_AC_PMBUS_NODE(psu_fan_dir);
         ret = onlp_file_read_str(&fd, node);
 
-        if (ret <= 0 || ret > PSU_FAN_DIR_LEN) {
+        if (ret <= 0 || ret > PSU_FAN_DIR_LEN || fd == NULL) {
             ptype = PSU_TYPE_UNKNOWN;
         }
         else if (strncmp(fd, "F2B", PSU_FAN_DIR_LEN) == 0) {
@@ -126,7 +134,7 @@ psu_type_t get_psu_type(int id, char* modelname, int modelname_len)
             ptype = PSU_TYPE_AC_B2F;
         }
 
-        aim_free(fd);
+        AIM_FREE_IF_PTR(fd);
     }
 
     if (strncmp(model_name, "YM-2651V", 8) == 0) {
@@ -134,12 +142,12 @@ psu_type_t get_psu_type(int id, char* modelname, int modelname_len)
             aim_strlcpy(modelname, model_name, sizeof(model_name));
         }
 
-        char *fd = aim_zmalloc(PSU_FAN_DIR_LEN + 1);
+        char *fd = NULL;
         
         node = (id == PSU1_ID) ? PSU1_AC_PMBUS_NODE(psu_fan_dir) : PSU2_AC_PMBUS_NODE(psu_fan_dir);
         ret = onlp_file_read_str(&fd, node);
 
-        if (ret <= 0 || ret > PSU_FAN_DIR_LEN) {
+        if (ret <= 0 || ret > PSU_FAN_DIR_LEN || fd == NULL) {
             ptype = PSU_TYPE_UNKNOWN;
         }
         else if (strncmp(fd, "F2B", PSU_FAN_DIR_LEN) == 0) {
@@ -149,7 +157,7 @@ psu_type_t get_psu_type(int id, char* modelname, int modelname_len)
             ptype = PSU_TYPE_DC_48V_B2F;
         }
 
-        aim_free(fd);
+        AIM_FREE_IF_PTR(fd);
     }
 
     return ptype;

--- a/packages/platforms/accton/x86-64/as9926-24d/onlp/builds/x86_64_accton_as9926_24d/module/src/platform_lib.c
+++ b/packages/platforms/accton/x86-64/as9926-24d/onlp/builds/x86_64_accton_as9926_24d/module/src/platform_lib.c
@@ -34,11 +34,20 @@
 #define PSU_MODEL_NAME_LEN 		11
 #define PSU_SERIAL_NUMBER_LEN	18
 
+#define AIM_FREE_IF_PTR(p) \
+    do \
+    { \
+        if (p) { \
+            aim_free(p); \
+            p = NULL; \
+        } \
+    } while (0)
+
 int get_psu_serial_number(int id, char *serial, int serial_len)
 {
     int   ret  = 0;
 	char *node = NULL;
-    char *sn = aim_zmalloc(PSU_SERIAL_NUMBER_LEN + 1);
+    char *sn = NULL;
 
     if (!sn) {
         return ONLP_STATUS_E_INTERNAL;
@@ -47,8 +56,8 @@ int get_psu_serial_number(int id, char *serial, int serial_len)
     /* Read AC serial number */
     node = (id == PSU1_ID) ? PSU1_AC_HWMON_NODE(psu_serial_numer) : PSU2_AC_HWMON_NODE(psu_serial_numer);
     ret = onlp_file_read_str(&sn, node);
-    if (ret <= 0 || ret > PSU_SERIAL_NUMBER_LEN) {
-        aim_free(sn);
+    if (ret <= 0 || ret > PSU_SERIAL_NUMBER_LEN || sn == NULL) {
+        AIM_FREE_IF_PTR(sn);
         return ONLP_STATUS_E_INVALID;
     }
 
@@ -56,7 +65,7 @@ int get_psu_serial_number(int id, char *serial, int serial_len)
         strncpy(serial, sn, PSU_SERIAL_NUMBER_LEN+1);
     }
 
-    aim_free(sn);
+    AIM_FREE_IF_PTR(sn);
 	return ONLP_STATUS_OK;
 }
 
@@ -64,14 +73,14 @@ psu_type_t get_psu_type(int id, char* modelname, int modelname_len)
 {
     int   ret = 0;
     char *node = NULL;
-    char *mn = aim_zmalloc(PSU_MODEL_NAME_LEN + 1);
+    char *mn = NULL;
     psu_type_t ptype = PSU_TYPE_UNKNOWN;
 
     /* Check AC model name */
     node = (id == PSU1_ID) ? PSU1_AC_HWMON_NODE(psu_model_name) : PSU2_AC_HWMON_NODE(psu_model_name);
     ret = onlp_file_read_str(&mn, node);
-    if (ret <= 0 || ret > PSU_MODEL_NAME_LEN) {
-        aim_free(mn);
+    if (ret <= 0 || ret > PSU_MODEL_NAME_LEN || mn == NULL) {
+        AIM_FREE_IF_PTR(mn);
         return PSU_TYPE_UNKNOWN;
     }
 
@@ -83,7 +92,7 @@ psu_type_t get_psu_type(int id, char* modelname, int modelname_len)
         ptype = PSU_TYPE_AC_F2B;
     }
 
-    aim_free(mn);
+    AIM_FREE_IF_PTR(mn);
     return ptype;
 }
 


### PR DESCRIPTION
The memory leak occurs on several accton platforms. It occurs on switches
that do not have PSU1 present. The memory leak is caused due to an allocated,
but empty string being returned from the onlp_file_read_str() function. The
code calling the onlp_file_read_str() function would free the returned
allocated string only if the string was not NULL and not empty.

#822 contain 7 platforms with memory leak:
         as5916-26xb / as5916-54xks / as5916-54xl / as7315-27xb / as7316-26xb / as7712-32x / asgvolt64
#824 is for the rest platforms which also use onlp_file_read_str() but not release memory precisely:
        as5835-54t / as5835-54x / as5912-54x / as5916-54xm / as7312-54x / as7312-54xs / as9926-24d

Signed-off-by: Brandon Chuang <brandon_chuang@edge-core.com>