### PR TITLE
[as7326-56x] support eeprom at addr 0x56 and 0x57

### DIFF
--- a/packages/platforms/accton/x86-64/as7326-56x/onlp/builds/x86_64_accton_as7326_56x/module/src/platform_lib.h
+++ b/packages/platforms/accton/x86-64/as7326-56x/onlp/builds/x86_64_accton_as7326_56x/module/src/platform_lib.h
@@ -55,7 +55,8 @@
 #define FAN_BOARD_PATH	"/sys/bus/i2c/devices/11-0066/"
 #define FAN_NODE(node)	FAN_BOARD_PATH#node
 
-#define IDPROM_PATH "/sys/class/i2c-adapter/i2c-0/0-0056/eeprom"
+#define IDPROM_PATH_1 "/sys/bus/i2c/devices/0-0056/eeprom"
+#define IDPROM_PATH_2 "/sys/bus/i2c/devices/0-0057/eeprom"
 
 int onlp_file_write_integer(char *filename, int value);
 int onlp_file_read_binary(char *filename, char *buffer, int buf_size, int data_len);

--- a/packages/platforms/accton/x86-64/as7326-56x/onlp/builds/x86_64_accton_as7326_56x/module/src/sysi.c
+++ b/packages/platforms/accton/x86-64/as7326-56x/onlp/builds/x86_64_accton_as7326_56x/module/src/sysi.c
@@ -65,15 +65,24 @@ onlp_sysi_platform_get(void)
 int
 onlp_sysi_onie_data_get(uint8_t** data, int* size)
 {
-    uint8_t* rdata = aim_zmalloc(256);
-
-    if(onlp_file_read(rdata, 256, size, IDPROM_PATH) == ONLP_STATUS_OK) {
-        if(*size == 256) {
-            *data = rdata;
-            return ONLP_STATUS_OK;
+    const int len = 256;
+    uint8_t* rdata = aim_zmalloc(len);
+    char *paths[] = {IDPROM_PATH_2, IDPROM_PATH_1};
+    int  ret = ONLP_STATUS_OK;
+    int i;
+    
+    for (i = 0 ; i < AIM_ARRAYSIZE(paths); i++ ){
+        ret = onlp_file_open(O_RDONLY, 0, paths[i]);
+        if (ret >= 0) {
+            close(ret);
+            if(onlp_file_read(rdata, len, size, paths[i]) == ONLP_STATUS_OK) {
+                if(*size == len) {
+                    *data = rdata;
+                    return ONLP_STATUS_OK;
+                }
+            }
         }
     }
-
     aim_free(rdata);
     *size = 0;
     return ONLP_STATUS_E_INTERNAL;


### PR DESCRIPTION
Due to the HW change, make eeprom access compatible with both new and
old conditions.

Signed-off-by: Sean Wu <sean_wu@edge-core.com>