### PR TITLE
[ag9032v2] Add kernel modules probe to platform init script.

### DIFF
--- a/packages/platforms/delta/x86-64/ag9032v2/platform-config/r0/src/python/x86_64_delta_ag9032v2_r0/__init__.py
+++ b/packages/platforms/delta/x86-64/ag9032v2/platform-config/r0/src/python/x86_64_delta_ag9032v2_r0/__init__.py
@@ -9,8 +9,27 @@ class OnlPlatform_x86_64_delta_ag9032v2_r0(OnlPlatformDelta,
 
 
     def baseconfig(self):
+        # kernel module i2c_ismt realpath
+        # /lib/modules/4.9.75-OpenNetworkLinux/kernel/drivers/i2c/busses
+        ret = False
+
+        findcmd = "find /lib/modules/%s/kernel -iname 'i2c*ismt.ko'" % os.uname()[2]
+        module_p = subprocess.check_output(findcmd, shell=True).strip()
+
+        if (os.path.exists(module_p)):
+            subprocess.check_call("insmod %s" % module_p, shell=True);
+            ret = True
+        else:
+            msg("Kernel module could not be found.\n")
+            ret = False
+
+        if ret:
+            # self.insmod('i2c_ismt')
+            cmd = "echo 'blacklist delta_i2c_ismt' > /etc/modprobe.d/blacklist.conf"
+            subprocess.check_call(cmd, shell=True);
 
         #IDEEPROM modulize
+        os.system("modprobe at24")
         self.new_i2c_device('24c02', 0x53, 1)
 
         return True


### PR DESCRIPTION
Add kernel modules probe to platform init script. [ag9032v2]
1. i2c_ismt
2. at24


