### PR TITLE
[Accton] Support ACBEL FSF019 PSUs

### DIFF
--- a/packages/platforms/accton/x86-64/as7326-56x/modules/builds/x86-64-accton-as7326-56x-psu.c
+++ b/packages/platforms/accton/x86-64/as7326-56x/modules/builds/x86-64-accton-as7326-56x-psu.c
@@ -34,14 +34,24 @@
 #include <linux/delay.h>
 #include <linux/dmi.h>
 
+#define MAX_MODEL_NAME          16
+#define MAX_SERIAL_NUMBER       19
+
 static ssize_t show_status(struct device *dev, struct device_attribute *da, char *buf);
-static ssize_t show_model_name(struct device *dev, struct device_attribute *da, char *buf);
+static ssize_t show_string(struct device *dev, struct device_attribute *da, char *buf);
 static int as7326_56x_psu_read_block(struct i2c_client *client, u8 command, u8 *data,int data_len);
 extern int as7326_56x_cpld_read(unsigned short cpld_addr, u8 reg);
 
 /* Addresses scanned
  */
 static const unsigned short normal_i2c[] = { 0x50, 0x53, I2C_CLIENT_END };
+
+enum psu_type {
+    PSU_TYPE_AC_110V,
+    PSU_TYPE_DC_48V,
+    PSU_TYPE_DC_12V,
+    PSU_TYPE_AC_ACBEL_FSF019
+};
 
 /* Each client has this additional data
  */
@@ -52,7 +62,9 @@ struct as7326_56x_psu_data {
     unsigned long       last_updated;    /* In jiffies */
     u8  index;           /* PSU index */
     u8  status;          /* Status(present/power_good) register read from CPLD */
-    char model_name[9]; /* Model name, read from eeprom */
+    char model_name[MAX_MODEL_NAME+1]; /* Model name, read from eeprom */
+    char serial_number[MAX_SERIAL_NUMBER];
+    enum psu_type       type;
 };
 
 static struct as7326_56x_psu_data *as7326_56x_psu_update_device(struct device *dev);
@@ -60,18 +72,21 @@ static struct as7326_56x_psu_data *as7326_56x_psu_update_device(struct device *d
 enum as7326_56x_psu_sysfs_attributes {
     PSU_PRESENT,
     PSU_MODEL_NAME,
+    PSU_SERIAL_NUMBER, /* For ACBEL PSU only */
     PSU_POWER_GOOD
 };
 
 /* sysfs attributes for hwmon
  */
 static SENSOR_DEVICE_ATTR(psu_present,    S_IRUGO, show_status,    NULL, PSU_PRESENT);
-static SENSOR_DEVICE_ATTR(psu_model_name, S_IRUGO, show_model_name,NULL, PSU_MODEL_NAME);
+static SENSOR_DEVICE_ATTR(psu_model_name, S_IRUGO, show_string, NULL, PSU_MODEL_NAME);
+static SENSOR_DEVICE_ATTR(psu_serial_number, S_IRUGO, show_string, NULL, PSU_SERIAL_NUMBER);
 static SENSOR_DEVICE_ATTR(psu_power_good, S_IRUGO, show_status,    NULL, PSU_POWER_GOOD);
 
 static struct attribute *as7326_56x_psu_attributes[] = {
     &sensor_dev_attr_psu_present.dev_attr.attr,
     &sensor_dev_attr_psu_model_name.dev_attr.attr,
+    &sensor_dev_attr_psu_serial_number.dev_attr.attr,
     &sensor_dev_attr_psu_power_good.dev_attr.attr,
     NULL
 };
@@ -103,21 +118,36 @@ static ssize_t show_status(struct device *dev, struct device_attribute *da,
     return sprintf(buf, "%d\n", status);
 }
 
-static ssize_t show_model_name(struct device *dev, struct device_attribute *da,
-                               char *buf)
+static ssize_t show_string(struct device *dev, struct device_attribute *da,
+             char *buf)
 {
 	struct i2c_client *client = to_i2c_client(dev);
 	struct as7326_56x_psu_data *data = i2c_get_clientdata(client);
+    struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
+    char *ptr = NULL;
+
     mutex_lock(&data->update_lock);
 
     data = as7326_56x_psu_update_device(dev);
-	if (!data->valid) {
+    if (!data->valid) {
         mutex_unlock(&data->update_lock);
-		return 0;
-	}
+        return -EIO;
+    }
+
+    switch (attr->index) {
+    case PSU_MODEL_NAME:
+        ptr = data->model_name;
+        break;
+    case PSU_SERIAL_NUMBER:
+        ptr = data->serial_number;
+        break;
+    default:
+        mutex_unlock(&data->update_lock);
+        return -EINVAL;
+    }
 
     mutex_unlock(&data->update_lock);
-    return sprintf(buf, "%s\n", data->model_name);
+    return sprintf(buf, "%s\n", ptr);
 }
 
 static const struct attribute_group as7326_56x_psu_group = {
@@ -239,6 +269,83 @@ static int as7326_56x_psu_read_block(struct i2c_client *client, u8 command, u8 *
     return result;
 }
 
+struct model_name_info {
+    enum psu_type type;
+    u8 offset;
+    u8 length;
+    u8 chk_length;
+    char* model_name;
+};
+
+static int acbel_psu_serial_number_get(struct device *dev)
+{
+    struct i2c_client *client = to_i2c_client(dev);
+    struct as7326_56x_psu_data *data = i2c_get_clientdata(client);
+    int status;
+
+    memset(data->serial_number, 0, sizeof(data->serial_number));
+
+    /* Read from offset 0x2e ~ 0x3d (16 bytes) */
+    status = as7326_56x_psu_read_block(client, 0x2e,data->serial_number, 16);
+    if (status < 0) {
+        data->serial_number[0] = '\0';
+        dev_dbg(&client->dev, "unable to read model name from (0x%x) offset(0x2e)\n", client->addr);
+        return status;
+    }
+
+    /* Read from offset 0x4f ~ 0x50 (2 bytes) */
+    status = as7326_56x_psu_read_block(client, 0x4f, data->serial_number + 16, 2);
+    if (status < 0) {
+        data->serial_number[0] = '\0';
+        dev_dbg(&client->dev, "unable to read model name from (0x%x) offset(0x4f)\n", client->addr);
+        return status;
+    }
+
+    return 0;
+}
+
+struct model_name_info models[] = {
+{PSU_TYPE_AC_110V, 0x20, 8, 8,  "YM-2651Y"},
+{PSU_TYPE_DC_48V,  0x20, 8, 8,  "YM-2651V"},
+{PSU_TYPE_DC_12V,  0x00, 11, 11, "PSU-12V-750"},
+{PSU_TYPE_AC_ACBEL_FSF019, 0x15, 10, 7, "FSF019-"}
+};
+
+static int as7326_56x_psu_model_name_get(struct device *dev)
+{
+    struct i2c_client *client = to_i2c_client(dev);
+    struct as7326_56x_psu_data *data = i2c_get_clientdata(client);
+    int i, status;
+
+    for (i = 0; i < ARRAY_SIZE(models); i++) {
+        memset(data->model_name, 0, sizeof(data->model_name));
+
+        status = as7326_56x_psu_read_block(client, models[i].offset,
+                                           data->model_name, models[i].length);
+        if (status < 0) {
+            data->model_name[0] = '\0';
+            dev_dbg(&client->dev, "unable to read model name from (0x%x) offset(0x%x)\n",
+                                  client->addr, models[i].offset);
+            return status;
+        }
+        else {
+            data->model_name[models[i].length] = '\0';
+        }
+
+        /* Determine if the model name is known, if not, read next index
+         */
+        if (strncmp(data->model_name, models[i].model_name, models[i].chk_length) == 0) {
+            data->type = models[i].type;
+            return 0;
+        }
+        else {
+            data->model_name[0] = '\0';
+        }
+    }
+
+    return -ENODATA;
+}
+
 static struct as7326_56x_psu_data *as7326_56x_psu_update_device(struct device *dev)
 {
     struct i2c_client *client = to_i2c_client(dev);
@@ -249,6 +356,7 @@ static struct as7326_56x_psu_data *as7326_56x_psu_update_device(struct device *d
         int status;
         int power_good = 0;
 
+        data->valid = 0;
         dev_dbg(&client->dev, "Starting as7326_56x update\n");
 
         /* Read psu status */
@@ -256,6 +364,7 @@ static struct as7326_56x_psu_data *as7326_56x_psu_update_device(struct device *d
 
         if (status < 0) {
             dev_dbg(&client->dev, "cpld reg 0x60 err %d\n", status);
+            goto exit;
         }
         else {
             data->status = status;
@@ -266,15 +375,12 @@ static struct as7326_56x_psu_data *as7326_56x_psu_update_device(struct device *d
         power_good = (data->status >> (3-data->index) & 0x1);
 
         if (power_good) {
-            status = as7326_56x_psu_read_block(client, 0x20, data->model_name,
-                                               ARRAY_SIZE(data->model_name)-1);
-
-            if (status < 0) {
-                data->model_name[0] = '\0';
-                dev_dbg(&client->dev, "unable to read model name from (0x%x)\n", client->addr);
+            if (as7326_56x_psu_model_name_get(dev) < 0) {
+                goto exit;
             }
-            else {
-                data->model_name[ARRAY_SIZE(data->model_name)-1] = '\0';
+            if (data->type == PSU_TYPE_AC_ACBEL_FSF019 &&
+                acbel_psu_serial_number_get(dev) < 0) {
+                goto exit;
             }
         }
 
@@ -282,6 +388,7 @@ static struct as7326_56x_psu_data *as7326_56x_psu_update_device(struct device *d
         data->valid = 1;
     }
 
+exit:
     return data;
 }
 

--- a/packages/platforms/accton/x86-64/as7326-56x/onlp/builds/x86_64_accton_as7326_56x/module/src/fani.c
+++ b/packages/platforms/accton/x86-64/as7326-56x/onlp/builds/x86_64_accton_as7326_56x/module/src/fani.c
@@ -183,11 +183,17 @@ _onlp_get_fan_direction_on_psu(void)
             continue;
         }
 
-        if (PSU_TYPE_AC_F2B == psu_type) {
-            return ONLP_FAN_STATUS_F2B;
-        }
-        else {
-            return ONLP_FAN_STATUS_B2F;
+        switch (psu_type) {
+            case PSU_TYPE_AC_F2B_3YPOWER:
+            case PSU_TYPE_AC_F2B_ACBEL:
+            case PSU_TYPE_DC_48V_F2B:
+                return ONLP_FAN_STATUS_F2B;
+            case PSU_TYPE_AC_B2F_3YPOWER:
+            case PSU_TYPE_AC_B2F_ACBEL:
+            case PSU_TYPE_DC_48V_B2F:
+                return ONLP_FAN_STATUS_B2F;
+            default:
+                return 0;
         }
     }
 
@@ -207,13 +213,13 @@ _onlp_fani_info_get_fan_on_psu(int pid, onlp_fan_info_t* info)
 
     /* get fan fault status
      */
-    if (psu_ym2651y_pmbus_info_get(pid, "psu_fan1_fault", &val) == ONLP_STATUS_OK) {
+    if (psu_pmbus_info_get(pid, "psu_fan1_fault", &val) == ONLP_STATUS_OK) {
         info->status |= (val > 0) ? ONLP_FAN_STATUS_FAILED : 0;
     }
 
     /* get fan speed
      */
-    if (psu_ym2651y_pmbus_info_get(pid, "psu_fan1_speed_rpm", &val) == ONLP_STATUS_OK) {
+    if (psu_pmbus_info_get(pid, "psu_fan1_speed_rpm", &val) == ONLP_STATUS_OK) {
         info->rpm = val;
 	    info->percentage = (info->rpm * 100) / MAX_PSU_FAN_SPEED;	    
     }
@@ -304,9 +310,9 @@ onlp_fani_percentage_set(onlp_oid_t id, int p)
     switch (fid)
 	{
         case FAN_1_ON_PSU_1:
-			return psu_ym2651y_pmbus_info_set(PSU1_ID, "psu_fan_duty_cycle_percentage", p);
+            return psu_pmbus_info_set(PSU1_ID, "psu_fan_duty_cycle_percentage", p);
         case FAN_1_ON_PSU_2:
-			return psu_ym2651y_pmbus_info_set(PSU2_ID, "psu_fan_duty_cycle_percentage", p);
+            return psu_pmbus_info_set(PSU2_ID, "psu_fan_duty_cycle_percentage", p);
         case FAN_1_ON_FAN_BOARD:
         case FAN_2_ON_FAN_BOARD:
         case FAN_3_ON_FAN_BOARD:

--- a/packages/platforms/accton/x86-64/as7326-56x/onlp/builds/x86_64_accton_as7326_56x/module/src/platform_lib.h
+++ b/packages/platforms/accton/x86-64/as7326-56x/onlp/builds/x86_64_accton_as7326_56x/module/src/platform_lib.h
@@ -62,23 +62,29 @@ int onlp_file_read_binary(char *filename, char *buffer, int buf_size, int data_l
 int onlp_file_read_string(char *filename, char *buffer, int buf_size, int data_len);
 
 
-int psu_ym2651y_pmbus_info_get(int id, char *node, int *value);
-int psu_ym2651y_pmbus_info_set(int id, char *node, int value);
+int psu_pmbus_info_get(int id, char *node, int *value);
+int psu_pmbus_info_set(int id, char *node, int value);
 
 typedef enum psu_type {
     PSU_TYPE_UNKNOWN,
-    PSU_TYPE_AC_F2B,
-    PSU_TYPE_AC_B2F
+    PSU_TYPE_AC_F2B_3YPOWER,
+    PSU_TYPE_AC_B2F_3YPOWER,
+    PSU_TYPE_AC_F2B_ACBEL,
+    PSU_TYPE_AC_B2F_ACBEL,
+    PSU_TYPE_DC_48V_F2B,
+    PSU_TYPE_DC_48V_B2F
 } psu_type_t;
 
 psu_type_t get_psu_type(int id, char* modelname, int modelname_len);
+int psu_pmbus_serial_number_get(int id, char *serial, int serial_len);
+int psu_acbel_serial_number_get(int id, char *serial, int serial_len);
 
 //#define DEBUG_MODE 1
 
 #if (DEBUG_MODE == 1)
     #define DEBUG_PRINT(format, ...)   printf(format, __VA_ARGS__)
 #else
-    #define DEBUG_PRINT(format, ...)  
+    #define DEBUG_PRINT(format, ...)
 #endif
 
 #endif  /* __PLATFORM_LIB_H__ */

--- a/packages/platforms/accton/x86-64/as7716-32x/onlp/builds/x86_64_accton_as7716_32x/module/src/fani.c
+++ b/packages/platforms/accton/x86-64/as7716-32x/onlp/builds/x86_64_accton_as7716_32x/module/src/fani.c
@@ -149,11 +149,13 @@ _onlp_fani_info_get_psu_fan_direction(void)
         }
 
 		switch (psu_type) {
-			case PSU_TYPE_AC_F2B:
+			case PSU_TYPE_AC_F2B_3YPOWER:
+            case PSU_TYPE_AC_F2B_ACBEL:
 			case PSU_TYPE_DC_48V_F2B:
 			case PSU_TYPE_DC_12V_F2B:
 				return ONLP_FAN_STATUS_F2B;
-			case PSU_TYPE_AC_B2F:
+			case PSU_TYPE_AC_B2F_3YPOWER:
+            case PSU_TYPE_AC_B2F_ACBEL:
 			case PSU_TYPE_DC_48V_B2F:
 			case PSU_TYPE_DC_12V_B2F:
 				return ONLP_FAN_STATUS_B2F;

--- a/packages/platforms/accton/x86-64/as7716-32x/onlp/builds/x86_64_accton_as7716_32x/module/src/platform_lib.h
+++ b/packages/platforms/accton/x86-64/as7716-32x/onlp/builds/x86_64_accton_as7716_32x/module/src/platform_lib.h
@@ -54,8 +54,10 @@ int deviceNodeReadString(char *filename, char *buffer, int buf_size, int data_le
 
 typedef enum psu_type {
     PSU_TYPE_UNKNOWN,
-    PSU_TYPE_AC_F2B,
-    PSU_TYPE_AC_B2F,
+    PSU_TYPE_AC_F2B_3YPOWER,
+    PSU_TYPE_AC_B2F_3YPOWER,
+    PSU_TYPE_AC_F2B_ACBEL,
+    PSU_TYPE_AC_B2F_ACBEL,
     PSU_TYPE_DC_48V_F2B,
     PSU_TYPE_DC_48V_B2F,
     PSU_TYPE_DC_12V_FANLESS,
@@ -64,7 +66,8 @@ typedef enum psu_type {
 } psu_type_t;
 
 psu_type_t get_psu_type(int id, char* modelname, int modelname_len);
-int psu_serial_number_get(int id, char *serial, int serial_len);
+int psu_pmbus_serial_number_get(int id, char *serial, int serial_len);
+int psu_acbel_serial_number_get(int id, char *serial, int serial_len);
 
 #define DEBUG_MODE 0
 

--- a/packages/platforms/accton/x86-64/as7716-32x/onlp/builds/x86_64_accton_as7716_32x/module/src/psui.c
+++ b/packages/platforms/accton/x86-64/as7716-32x/onlp/builds/x86_64_accton_as7716_32x/module/src/psui.c
@@ -68,7 +68,7 @@ psu_status_info_get(int id, char *node, int *value)
 }
 
 static int
-psu_ym2651_pmbus_info_get(int id, char *node, int *value)
+psu_pmbus_info_get(int id, char *node, int *value)
 {
     int  ret = 0;
     char buf[PSU_NODE_MAX_INT_LEN + 1]    = {0};
@@ -113,22 +113,57 @@ psu_ym2651_info_get(onlp_psu_info_t* info)
     info->hdr.coids[1] = ONLP_THERMAL_ID_CREATE(index + CHASSIS_THERMAL_COUNT);
 
     /* Read voltage, current and power */
-    if (psu_ym2651_pmbus_info_get(index, "psu_v_out", &val) == 0) {
+    if (psu_pmbus_info_get(index, "psu_v_out", &val) == 0) {
         info->mvout = val;
         info->caps |= ONLP_PSU_CAPS_VOUT;
     }
 
-    if (psu_ym2651_pmbus_info_get(index, "psu_i_out", &val) == 0) {
+    if (psu_pmbus_info_get(index, "psu_i_out", &val) == 0) {
         info->miout = val;
         info->caps |= ONLP_PSU_CAPS_IOUT;
     }
 
-    if (psu_ym2651_pmbus_info_get(index, "psu_p_out", &val) == 0) {
+    if (psu_pmbus_info_get(index, "psu_p_out", &val) == 0) {
         info->mpout = val;
         info->caps |= ONLP_PSU_CAPS_POUT;
     } 
 
-    psu_serial_number_get(index, info->serial, sizeof(info->serial));
+    psu_pmbus_serial_number_get(index, info->serial, sizeof(info->serial));
+
+    return ONLP_STATUS_OK;
+}
+
+static int
+psu_acbel_info_get(onlp_psu_info_t* info)
+{
+    int val   = 0;
+    int index = ONLP_OID_ID_GET(info->hdr.id);
+
+    if (info->status & ONLP_PSU_STATUS_FAILED) {
+        return ONLP_STATUS_OK;
+    }
+
+    /* Set the associated oid_table */
+    info->hdr.coids[0] = ONLP_FAN_ID_CREATE(index + CHASSIS_FAN_COUNT);
+    info->hdr.coids[1] = ONLP_THERMAL_ID_CREATE(index + CHASSIS_THERMAL_COUNT);
+
+    /* Read voltage, current and power */
+    if (psu_pmbus_info_get(index, "psu_v_out", &val) == 0) {
+        info->mvout = val;
+        info->caps |= ONLP_PSU_CAPS_VOUT;
+    }
+
+    if (psu_pmbus_info_get(index, "psu_i_out", &val) == 0) {
+        info->miout = val;
+        info->caps |= ONLP_PSU_CAPS_IOUT;
+    }
+
+    if (psu_pmbus_info_get(index, "psu_p_out", &val) == 0) {
+        info->mpout = val;
+        info->caps |= ONLP_PSU_CAPS_POUT;
+    }
+
+    psu_acbel_serial_number_get(index, info->serial, sizeof(info->serial));
 
     return ONLP_STATUS_OK;
 }
@@ -237,10 +272,15 @@ onlp_psui_info_get(onlp_oid_t id, onlp_psu_info_t* info)
     psu_type = get_psu_type(index, info->model, sizeof(info->model));
 
     switch (psu_type) {
-        case PSU_TYPE_AC_F2B:
-        case PSU_TYPE_AC_B2F:
+        case PSU_TYPE_AC_F2B_3YPOWER:
+        case PSU_TYPE_AC_B2F_3YPOWER:
             info->caps = ONLP_PSU_CAPS_AC;
             ret = psu_ym2651_info_get(info);
+            break;
+        case PSU_TYPE_AC_F2B_ACBEL:
+        case PSU_TYPE_AC_B2F_ACBEL:
+            info->caps = ONLP_PSU_CAPS_AC;
+            ret = psu_acbel_info_get(info);
             break;
 		case PSU_TYPE_DC_48V_F2B:
 		case PSU_TYPE_DC_48V_B2F:

--- a/packages/platforms/accton/x86-64/as7726-32x/onlp/builds/x86_64_accton_as7726_32x/module/src/fani.c
+++ b/packages/platforms/accton/x86-64/as7726-32x/onlp/builds/x86_64_accton_as7726_32x/module/src/fani.c
@@ -182,11 +182,17 @@ _onlp_get_fan_direction_on_psu(void)
             continue;
         }
 
-        if (PSU_TYPE_AC_F2B == psu_type) {
-            return ONLP_FAN_STATUS_F2B;
-        }
-        else {
-            return ONLP_FAN_STATUS_B2F;
+        switch (psu_type) {
+            case PSU_TYPE_AC_F2B_3YPOWER:
+            case PSU_TYPE_AC_F2B_ACBEL:
+            case PSU_TYPE_DC_48V_F2B:
+                return ONLP_FAN_STATUS_F2B;
+            case PSU_TYPE_AC_B2F_3YPOWER:
+            case PSU_TYPE_AC_B2F_ACBEL:
+            case PSU_TYPE_DC_48V_B2F:
+                return ONLP_FAN_STATUS_B2F;
+            default:
+                return 0;
         }
     }
 
@@ -206,15 +212,15 @@ _onlp_fani_info_get_fan_on_psu(int pid, onlp_fan_info_t* info)
 
     /* get fan fault status
      */
-    if (psu_ym2651y_pmbus_info_get(pid, "psu_fan1_fault", &val) == ONLP_STATUS_OK) {
+    if (psu_pmbus_info_get(pid, "psu_fan1_fault", &val) == ONLP_STATUS_OK) {
         info->status |= (val > 0) ? ONLP_FAN_STATUS_FAILED : 0;
     }
 
     /* get fan speed
      */
-    if (psu_ym2651y_pmbus_info_get(pid, "psu_fan1_speed_rpm", &val) == ONLP_STATUS_OK) {
+    if (psu_pmbus_info_get(pid, "psu_fan1_speed_rpm", &val) == ONLP_STATUS_OK) {
         info->rpm = val;
-	    info->percentage = (info->rpm * 100) / MAX_PSU_FAN_SPEED;	    
+	    info->percentage = (info->rpm * 100) / MAX_PSU_FAN_SPEED;
     }
 
     return ONLP_STATUS_OK;
@@ -303,9 +309,9 @@ onlp_fani_percentage_set(onlp_oid_t id, int p)
     switch (fid)
 	{
         case FAN_1_ON_PSU_1:
-			return psu_ym2651y_pmbus_info_set(PSU1_ID, "psu_fan_duty_cycle_percentage", p);
+            return psu_pmbus_info_set(PSU1_ID, "psu_fan_duty_cycle_percentage", p);
         case FAN_1_ON_PSU_2:
-			return psu_ym2651y_pmbus_info_set(PSU2_ID, "psu_fan_duty_cycle_percentage", p);
+            return psu_pmbus_info_set(PSU2_ID, "psu_fan_duty_cycle_percentage", p);
         case FAN_1_ON_FAN_BOARD:
         case FAN_2_ON_FAN_BOARD:
         case FAN_3_ON_FAN_BOARD:

--- a/packages/platforms/accton/x86-64/as7726-32x/onlp/builds/x86_64_accton_as7726_32x/module/src/platform_lib.c
+++ b/packages/platforms/accton/x86-64/as7726-32x/onlp/builds/x86_64_accton_as7726_32x/module/src/platform_lib.c
@@ -90,9 +90,9 @@ int onlp_file_read_string(char *filename, char *buffer, int buf_size, int data_l
     return ret;
 }
 
-#define I2C_PSU_MODEL_NAME_LEN 9
+#define I2C_PSU_MODEL_NAME_LEN 11
 #define I2C_PSU_FAN_DIR_LEN    3
-
+#include <ctype.h>
 psu_type_t get_psu_type(int id, char* modelname, int modelname_len)
 {
     char *node = NULL;
@@ -101,38 +101,83 @@ psu_type_t get_psu_type(int id, char* modelname, int modelname_len)
 
 
     /* Check AC model name */
-    node = (id == PSU1_ID) ? PSU1_AC_PMBUS_NODE(psu_mfr_model) : PSU2_AC_PMBUS_NODE(psu_mfr_model);
+    node = (id == PSU1_ID) ? PSU1_AC_HWMON_NODE(psu_model_name) : PSU2_AC_HWMON_NODE(psu_model_name);
+
     if (onlp_file_read_string(node, model_name, sizeof(model_name), 0) != 0) {
         return PSU_TYPE_UNKNOWN;
     }
 
-    if (strncmp(model_name, "YM-2651Y", strlen("YM-2651Y")) != 0 &&
-        strncmp(model_name, "FSF019", strlen("FSF019")) != 0) {
-        return PSU_TYPE_UNKNOWN;
+    if(isspace(model_name[strlen(model_name)-1])) {
+        model_name[strlen(model_name)-1] = 0;
     }
 
-    if (modelname) {
-        aim_strlcpy(modelname, model_name, modelname_len-1);
+    if (strncmp(model_name, "YM-2651Y", 8) == 0) {
+        if (modelname) {
+            aim_strlcpy(modelname, model_name, 8+1);
+        }
+
+        node = (id == PSU1_ID) ? PSU1_AC_PMBUS_NODE(psu_fan_dir) : PSU2_AC_PMBUS_NODE(psu_fan_dir);
+        if (onlp_file_read_string(node, fan_dir, sizeof(fan_dir), 0) != 0) {
+            return PSU_TYPE_UNKNOWN;
+        }
+
+        if (strncmp(fan_dir, "F2B", strlen("F2B")) == 0) {
+            return PSU_TYPE_AC_F2B_3YPOWER;
+        }
+
+        if (strncmp(fan_dir, "B2F", strlen("B2F")) == 0) {
+            return PSU_TYPE_AC_B2F_3YPOWER;
+        }
     }
 
-    node = (id == PSU1_ID) ? PSU1_AC_PMBUS_NODE(psu_fan_dir) : PSU2_AC_PMBUS_NODE(psu_fan_dir);
+    if (strncmp(model_name, "YM-2651V", 8) == 0) {
+        if (modelname) {
+            aim_strlcpy(modelname, model_name, 8+1);
+        }
 
-    if (onlp_file_read_string(node, fan_dir, sizeof(fan_dir), 0) != 0) {
-        return PSU_TYPE_UNKNOWN;
+        node = (id == PSU1_ID) ? PSU1_AC_PMBUS_NODE(psu_fan_dir) : PSU2_AC_PMBUS_NODE(psu_fan_dir);
+        if (onlp_file_read_string(node, fan_dir, sizeof(fan_dir), 0) != 0) {
+            return PSU_TYPE_UNKNOWN;
+        }
+
+        if (strncmp(fan_dir, "F2B", strlen("F2B")) == 0) {
+            return PSU_TYPE_DC_48V_F2B;
+        }
+
+        if (strncmp(fan_dir, "B2F", strlen("B2F")) == 0) {
+            return PSU_TYPE_DC_48V_B2F;
+        }
     }
 
-    if (strncmp(fan_dir, "F2B", strlen("F2B")) == 0) {
-        return PSU_TYPE_AC_F2B;
-    }
+    if (strncmp(model_name, "FSF019", 6) == 0) {
+        if (modelname) {
+            aim_strlcpy(modelname, model_name, 11+1); /* Copy full model name */
+        }
 
-    if (strncmp(fan_dir, "B2F", strlen("B2F")) == 0) {
-        return PSU_TYPE_AC_B2F;
+        /* Read model */
+        char *string = NULL;
+        char *prefix = (id == PSU1_ID) ? PSU1_AC_PMBUS_PREFIX : PSU2_AC_PMBUS_PREFIX;
+        int len = onlp_file_read_str(&string, "%s""psu_fan_dir", prefix);
+        if (!string || len <= 0) {
+            return PSU_TYPE_UNKNOWN;
+        }
+
+        aim_strlcpy(fan_dir, string, (len+1));
+        aim_free(string);
+
+        if (strncmp(fan_dir, "F2B", strlen("F2B")) == 0) {
+            return PSU_TYPE_AC_F2B_ACBEL;
+        }
+
+        if (strncmp(fan_dir, "B2F", strlen("B2F")) == 0) {
+            return PSU_TYPE_AC_B2F_ACBEL;
+        }
     }
 
     return PSU_TYPE_UNKNOWN;
 }
 
-int psu_ym2651y_pmbus_info_get(int id, char *node, int *value)
+int psu_pmbus_info_get(int id, char *node, int *value)
 {
     int  ret = 0;
     char path[PSU_NODE_MAX_PATH_LEN] = {0};
@@ -154,7 +199,7 @@ int psu_ym2651y_pmbus_info_get(int id, char *node, int *value)
     return ret;
 }
 
-int psu_ym2651y_pmbus_info_set(int id, char *node, int value)
+int psu_pmbus_info_set(int id, char *node, int value)
 {
     char path[PSU_NODE_MAX_PATH_LEN] = {0};
 
@@ -179,7 +224,7 @@ int psu_ym2651y_pmbus_info_set(int id, char *node, int value)
 
 #define PSU_SERIAL_NUMBER_LEN	18
 
-int psu_serial_number_get(int id, char *serial, int serial_len)
+int psu_pmbus_serial_number_get(int id, char *serial, int serial_len)
 {
 	int   size = 0;
 	int   ret  = ONLP_STATUS_OK;
@@ -199,4 +244,20 @@ int psu_serial_number_get(int id, char *serial, int serial_len)
 
 	serial[PSU_SERIAL_NUMBER_LEN] = '\0';
 	return ONLP_STATUS_OK;
+}
+
+int psu_acbel_serial_number_get(int id, char *serial, int serial_len)
+{
+    char *serial_number = NULL;
+    char *prefix = (id == PSU1_ID) ? PSU1_AC_HWMON_PREFIX : PSU2_AC_HWMON_PREFIX;
+
+    int len = onlp_file_read_str(&serial_number, "%s""psu_serial_number", prefix);
+    if (!serial_number || len <= 0) {
+        return ONLP_STATUS_E_INTERNAL;
+    }
+
+    aim_strlcpy(serial, serial_number, (len+1));
+    aim_free(serial_number);
+
+    return ONLP_STATUS_OK;
 }

--- a/packages/platforms/accton/x86-64/as7726-32x/onlp/builds/x86_64_accton_as7726_32x/module/src/platform_lib.h
+++ b/packages/platforms/accton/x86-64/as7726-32x/onlp/builds/x86_64_accton_as7726_32x/module/src/platform_lib.h
@@ -63,17 +63,22 @@ int onlp_file_read_binary(char *filename, char *buffer, int buf_size, int data_l
 int onlp_file_read_string(char *filename, char *buffer, int buf_size, int data_len);
 
 
-int psu_ym2651y_pmbus_info_get(int id, char *node, int *value);
-int psu_ym2651y_pmbus_info_set(int id, char *node, int value);
+int psu_pmbus_info_get(int id, char *node, int *value);
+int psu_pmbus_info_set(int id, char *node, int value);
 
 typedef enum psu_type {
     PSU_TYPE_UNKNOWN,
-    PSU_TYPE_AC_F2B,
-    PSU_TYPE_AC_B2F
+    PSU_TYPE_AC_F2B_3YPOWER,
+    PSU_TYPE_AC_B2F_3YPOWER,
+    PSU_TYPE_AC_F2B_ACBEL,
+    PSU_TYPE_AC_B2F_ACBEL,
+    PSU_TYPE_DC_48V_F2B,
+    PSU_TYPE_DC_48V_B2F
 } psu_type_t;
 
 psu_type_t get_psu_type(int id, char* modelname, int modelname_len);
-int psu_serial_number_get(int id, char *serial, int serial_len);
+int psu_pmbus_serial_number_get(int id, char *serial, int serial_len);
+int psu_acbel_serial_number_get(int id, char *serial, int serial_len);
 
 //#define DEBUG_MODE 1
 

--- a/packages/platforms/accton/x86-64/as7726-32x/onlp/builds/x86_64_accton_as7726_32x/module/src/psui.c
+++ b/packages/platforms/accton/x86-64/as7726-32x/onlp/builds/x86_64_accton_as7726_32x/module/src/psui.c
@@ -71,40 +71,71 @@ onlp_psui_init(void)
 }
 
 static int
-psu_ym2651y_info_get(onlp_psu_info_t* info)
+psu_ym2651_info_get(onlp_psu_info_t* info)
 {
     int val   = 0;
     int index = ONLP_OID_ID_GET(info->hdr.id);
-    
-    /* Set capability
-     */
-    info->caps = ONLP_PSU_CAPS_AC;
-    
-	if (info->status & ONLP_PSU_STATUS_FAILED) {
-	    return ONLP_STATUS_OK;
-	}
+
+    if (info->status & ONLP_PSU_STATUS_FAILED) {
+        return ONLP_STATUS_OK;
+    }
 
     /* Set the associated oid_table */
     info->hdr.coids[0] = ONLP_FAN_ID_CREATE(index + CHASSIS_FAN_COUNT);
     info->hdr.coids[1] = ONLP_THERMAL_ID_CREATE(index + CHASSIS_THERMAL_COUNT);
 
     /* Read voltage, current and power */
-    if (psu_ym2651y_pmbus_info_get(index, "psu_v_out", &val) == 0) {
+    if (psu_pmbus_info_get(index, "psu_v_out", &val) == 0) {
         info->mvout = val;
         info->caps |= ONLP_PSU_CAPS_VOUT;
     }
 
-    if (psu_ym2651y_pmbus_info_get(index, "psu_i_out", &val) == 0) {
+    if (psu_pmbus_info_get(index, "psu_i_out", &val) == 0) {
         info->miout = val;
         info->caps |= ONLP_PSU_CAPS_IOUT;
     }
 
-    if (psu_ym2651y_pmbus_info_get(index, "psu_p_out", &val) == 0) {
+    if (psu_pmbus_info_get(index, "psu_p_out", &val) == 0) {
         info->mpout = val;
         info->caps |= ONLP_PSU_CAPS_POUT;
     }
 
-    psu_serial_number_get(index, info->serial, sizeof(info->serial));
+    psu_pmbus_serial_number_get(index, info->serial, sizeof(info->serial));
+
+    return ONLP_STATUS_OK;
+}
+
+static int
+psu_acbel_info_get(onlp_psu_info_t* info)
+{
+    int val   = 0;
+    int index = ONLP_OID_ID_GET(info->hdr.id);
+
+    if (info->status & ONLP_PSU_STATUS_FAILED) {
+        return ONLP_STATUS_OK;
+    }
+
+    /* Set the associated oid_table */
+    info->hdr.coids[0] = ONLP_FAN_ID_CREATE(index + CHASSIS_FAN_COUNT);
+    info->hdr.coids[1] = ONLP_THERMAL_ID_CREATE(index + CHASSIS_THERMAL_COUNT);
+
+    /* Read voltage, current and power */
+    if (psu_pmbus_info_get(index, "psu_v_out", &val) == 0) {
+        info->mvout = val;
+        info->caps |= ONLP_PSU_CAPS_VOUT;
+    }
+
+    if (psu_pmbus_info_get(index, "psu_i_out", &val) == 0) {
+        info->miout = val;
+        info->caps |= ONLP_PSU_CAPS_IOUT;
+    }
+
+    if (psu_pmbus_info_get(index, "psu_p_out", &val) == 0) {
+        info->mpout = val;
+        info->caps |= ONLP_PSU_CAPS_POUT;
+    }
+
+    psu_acbel_serial_number_get(index, info->serial, sizeof(info->serial));
 
     return ONLP_STATUS_OK;
 }
@@ -129,7 +160,7 @@ onlp_psui_info_get(onlp_oid_t id, onlp_psu_info_t* info)
     int val   = 0;
     int ret   = ONLP_STATUS_OK;
     int index = ONLP_OID_ID_GET(id);
-    psu_type_t psu_type; 
+    psu_type_t psu_type;
 
     VALIDATE(id);
 
@@ -160,9 +191,20 @@ onlp_psui_info_get(onlp_oid_t id, onlp_psu_info_t* info)
      */
     psu_type = get_psu_type(index, info->model, sizeof(info->model));
     switch (psu_type) {
-        case PSU_TYPE_AC_F2B:
-        case PSU_TYPE_AC_B2F:
-            ret = psu_ym2651y_info_get(info);
+        case PSU_TYPE_AC_F2B_3YPOWER:
+        case PSU_TYPE_AC_B2F_3YPOWER:
+            info->caps = ONLP_PSU_CAPS_AC;
+            ret = psu_ym2651_info_get(info);
+            break;
+        case PSU_TYPE_AC_F2B_ACBEL:
+        case PSU_TYPE_AC_B2F_ACBEL:
+            info->caps = ONLP_PSU_CAPS_AC;
+            ret = psu_acbel_info_get(info);
+            break;
+        case PSU_TYPE_DC_48V_F2B:
+        case PSU_TYPE_DC_48V_B2F:
+            info->caps = ONLP_PSU_CAPS_DC48;
+            ret = psu_ym2651_info_get(info);
             break;
         case PSU_TYPE_UNKNOWN:  /* User insert a unknown PSU or unplugged.*/
             info->status |= ONLP_PSU_STATUS_UNPLUGGED;


### PR DESCRIPTION
Support ACBEL PSUs because of the part replacement.
- Models: as7716-32x, as7726-32x, as7326-56x