### PR TITLE
[accton/wedge100bf-65x] Fix some onlpi errors at onlpd.log

### DIFF
--- a/packages/platforms/accton/x86-64/wedge100bf-65x/onlp/builds/x86_64_accton_wedge100bf_65x/module/src/fani.c
+++ b/packages/platforms/accton/x86-64/wedge100bf-65x/onlp/builds/x86_64_accton_wedge100bf_65x/module/src/fani.c
@@ -89,7 +89,7 @@ onlp_fan_info_t finfo[] = {
 int
 onlp_fani_init(void)
 {
-    return ONLP_STATUS_OK;
+    return bmc_tty_init();
 }
 
 int

--- a/packages/platforms/accton/x86-64/wedge100bf-65x/onlp/builds/x86_64_accton_wedge100bf_65x/module/src/ledi.c
+++ b/packages/platforms/accton/x86-64/wedge100bf-65x/onlp/builds/x86_64_accton_wedge100bf_65x/module/src/ledi.c
@@ -105,7 +105,7 @@ static onlp_led_info_t linfo[] =
 int
 onlp_ledi_init(void)
 {
-    return ONLP_STATUS_OK;
+    return bmc_tty_init();
 }
 
 static int

--- a/packages/platforms/accton/x86-64/wedge100bf-65x/onlp/builds/x86_64_accton_wedge100bf_65x/module/src/platform_lib.c
+++ b/packages/platforms/accton/x86-64/wedge100bf-65x/onlp/builds/x86_64_accton_wedge100bf_65x/module/src/platform_lib.c
@@ -32,8 +32,8 @@
 #define TTY_DEVICE                      "/dev/ttyACM0"
 #define TTY_PROMPT                      "@bmc:"
 #define TTY_I2C_TIMEOUT                 55000
-#define TTY_BMC_LOGIN_TIMEOUT            1000000
-#define TTY_RETRY                       10
+#define TTY_BMC_LOGIN_TIMEOUT           1000000
+#define TTY_RETRY                       20
 #define MAXIMUM_TTY_BUFFER_LENGTH       1024
 #define MAXIMUM_TTY_STRING_LENGTH       (MAXIMUM_TTY_BUFFER_LENGTH - 1)
 
@@ -89,6 +89,16 @@ static int tty_exec_buf(unsigned long udelay, const char *str)
     memset(tty_buf, 0, MAXIMUM_TTY_BUFFER_LENGTH);
     read(tty_fd, tty_buf, MAXIMUM_TTY_BUFFER_LENGTH);
     return (strstr(tty_buf, str) != NULL) ? 0 : -1;
+}
+
+/* Clear Rx buffer by reading it out */
+static int tty_clear_rxbuf(void) {
+    if (tty_fd < 0)
+        return ONLP_STATUS_E_GENERIC;
+
+    read(tty_fd, tty_buf, MAXIMUM_TTY_BUFFER_LENGTH);
+    memset(tty_buf, 0, MAXIMUM_TTY_BUFFER_LENGTH);
+    return ONLP_STATUS_OK;
 }
 
 static int tty_login(void)
@@ -275,31 +285,33 @@ int
 bmc_command_read_int(int* value, char *cmd, int base)
 {
     int len;
-    int i;
+    int i, ret;
     char *prev_str = NULL;
-    char *current_str= NULL;
-    if (bmc_send_command(cmd) < 0) {
-        return ONLP_STATUS_E_INTERNAL;
-    }
+    char *current_str = NULL;
+    ret = -1;
     len = (int)strlen(cmd);
-    prev_str = strstr(tty_buf, cmd);
-    if (prev_str == NULL) {
-        return -1;
-    }
+
     for (i = 1; i <= TTY_RETRY; i++) {
-        current_str = strstr(prev_str + len, cmd);
-        if(current_str == NULL) {
-            if( !chk_numeric_char(prev_str + len, base) ){
-                return -1;
-            }
-            *value = strtoul(prev_str + len, NULL, base);
-            break;
-        }else {
-            prev_str = current_str;
+        tty_clear_rxbuf();
+        if (bmc_send_command(cmd) < 0) {
+            return ONLP_STATUS_E_INTERNAL;
+        }
+        prev_str = strstr(tty_buf ,cmd);
+        if (prev_str == NULL) {
             continue;
         }
+        while((current_str = strstr(prev_str + len, cmd)) != NULL){
+            prev_str = current_str;
+        }
+        if( !chk_numeric_char(prev_str + len, base) ) {
+            continue;
+        }
+        *value = strtoul(prev_str + len, NULL, base);
+        ret = 0;
+        goto exit;
     }
-    return 0;
+exit:
+    return ret;
 }
 
 
@@ -312,12 +324,16 @@ bmc_file_read_int(int* value, char *file, int base)
 }
 
 int
-bmc_i2c_readb(uint8_t bus, uint8_t devaddr, uint8_t addr)
+bmc_i2c_readb(uint8_t bus, uint8_t devaddr, int16_t addr)
 {
     int ret = 0, value;
     char cmd[64] = {0};
-
-    snprintf(cmd, sizeof(cmd), "i2cget -f -y %d 0x%x 0x%02x\r\n", bus, devaddr, addr);
+    if (addr < 0) {
+        snprintf(cmd, sizeof(cmd), "i2cget -f -y %d 0x%x\r\n", bus, devaddr);
+    } else {
+        snprintf(cmd, sizeof(cmd), "i2cget -f -y %d 0x%x 0x%02x\r\n", bus,
+                 devaddr, (uint8_t)addr);
+    }
     ret = bmc_command_read_int(&value, cmd, 16);
     return (ret < 0) ? ret : value;
 }

--- a/packages/platforms/accton/x86-64/wedge100bf-65x/onlp/builds/x86_64_accton_wedge100bf_65x/module/src/platform_lib.h
+++ b/packages/platforms/accton/x86-64/wedge100bf-65x/onlp/builds/x86_64_accton_wedge100bf_65x/module/src/platform_lib.h
@@ -60,7 +60,7 @@ enum onlp_thermal_id
 int bmc_send_command(char *cmd);
 int bmc_file_read_str(char *file, char *result, int slen);
 int bmc_file_read_int(int* value, char *file, int base);
-int bmc_i2c_readb(uint8_t bus, uint8_t devaddr, uint8_t addr);
+int bmc_i2c_readb(uint8_t bus, uint8_t devaddr, int16_t addr);
 int bmc_i2c_writeb(uint8_t bus, uint8_t devaddr, uint8_t addr, uint8_t value);
 int bmc_i2c_write_quick_mode(uint8_t bus, uint8_t devaddr, uint8_t value);
 int bmc_i2c_readw(uint8_t bus, uint8_t devaddr, uint8_t addr);

--- a/packages/platforms/accton/x86-64/wedge100bf-65x/onlp/builds/x86_64_accton_wedge100bf_65x/module/src/sfpi.c
+++ b/packages/platforms/accton/x86-64/wedge100bf-65x/onlp/builds/x86_64_accton_wedge100bf_65x/module/src/sfpi.c
@@ -54,7 +54,7 @@ int
 onlp_sfpi_init(void)
 {
     /* Called at initialization time */    
-    return ONLP_STATUS_OK;
+    return bmc_tty_init();
 }
 
 int

--- a/packages/platforms/accton/x86-64/wedge100bf-65x/onlp/builds/x86_64_accton_wedge100bf_65x/module/src/thermali.c
+++ b/packages/platforms/accton/x86-64/wedge100bf-65x/onlp/builds/x86_64_accton_wedge100bf_65x/module/src/thermali.c
@@ -93,7 +93,7 @@ static onlp_thermal_info_t linfo[] = {
 int
 onlp_thermali_init(void)
 {
-    return ONLP_STATUS_OK;
+    return bmc_tty_init();
 }
 
 /*


### PR DESCRIPTION
To prevent error result from BMC message broken,
1. Remain wait time (55000us) and retry more times (20 times)
   These are experimental results.
   If wait time is over 80000us, it will cause onlpd for increasing
   CPU usage.
   Verified by overnight busy run and no error at /var/log/onlpd.log.
2. Clear tty rx buffer before transaction.
3. PSUs should locate at 0x5a and 0x59, instead of 0x59 and 0x5a.
4. Print PSU's model_name and serial if it's present but not powered.
5. Set i2c mux to PSUs are both opened. It makes no conflict for
   their addresses diff.
6. For individual onlp API can be called after its own init() is run.

Signed-off-by: Jake Lin <jake_lin@edge-core.com>