### PR TITLE
[accton/as7315-27xb] Support AC PSU on ONL

### DIFF
--- a/packages/base/any/kernels/modules/ym2651y.c
+++ b/packages/base/any/kernels/modules/ym2651y.c
@@ -307,19 +307,22 @@ static ssize_t show_linear(struct device *dev, struct device_attribute *da,
     switch (attr->index) {
     case PSU_V_IN:
         if ((strncmp(ptr, "DPS-850A", strlen("DPS-850A")) == 0)||
-            (strncmp(ptr, "YM-2851J", strlen("YM-2851J")) == 0)) {
+            (strncmp(ptr, "YM-2851J", strlen("YM-2851J")) == 0)||
+            (strncmp(ptr, "SPAACTN-03", strlen("SPAACTN-03")) == 0)) {
             value = data->v_in;
         }
         break;
     case PSU_I_IN:
         if ((strncmp(ptr, "DPS-850A", strlen("DPS-850A")) == 0)||
-            (strncmp(ptr, "YM-2851J", strlen("YM-2851J")) == 0)) {
+            (strncmp(ptr, "YM-2851J", strlen("YM-2851J")) == 0)||
+            (strncmp(ptr, "SPAACTN-03", strlen("SPAACTN-03")) == 0)) {
             value = data->i_in;
         }
         break;
     case PSU_P_IN:
         if ((strncmp(ptr, "DPS-850A", strlen("DPS-850A")) == 0)||
-            (strncmp(ptr, "YM-2851J", strlen("YM-2851J")) == 0)) {
+            (strncmp(ptr, "YM-2851J", strlen("YM-2851J")) == 0)||
+            (strncmp(ptr, "SPAACTN-03", strlen("SPAACTN-03")) == 0)) {
             value = data->p_in;
         }
         break;
@@ -761,7 +764,12 @@ static struct ym2651y_data *ym2651y_update_device(struct device *dev)
             command = 0xC3;
             status = ym2651y_read_block(client, command, data->fan_dir,
                                          ARRAY_SIZE(data->fan_dir)-1);
-            data->fan_dir[ARRAY_SIZE(data->fan_dir)-1] = '\0';
+            if (data->fan_dir[0] < ARRAY_SIZE(data->fan_dir)-2) {
+                data->fan_dir[data->fan_dir[0]+1] = '\0';
+            }
+            else {
+                data->fan_dir[ARRAY_SIZE(data->fan_dir)-1] = '\0';
+            }
 
             if (status < 0) {
                 dev_dbg(&client->dev, "reg %d, err %d\n", command, status);
@@ -772,7 +780,12 @@ static struct ym2651y_data *ym2651y_update_device(struct device *dev)
             command = 0x99;
             status = ym2651y_read_block(client, command, data->mfr_id,
                                             ARRAY_SIZE(data->mfr_id)-1);
-            data->mfr_id[ARRAY_SIZE(data->mfr_id)-1] = '\0';
+            if (data->mfr_id[0] < ARRAY_SIZE(data->mfr_id)-2) {
+                data->mfr_id[data->mfr_id[0]+1] = '\0';
+            }
+            else {
+                data->mfr_id[ARRAY_SIZE(data->mfr_id)-1] = '\0';
+            }
 
             if (status < 0) {
                 dev_dbg(&client->dev, "reg %d, err %d\n", command, status);
@@ -821,7 +834,12 @@ static struct ym2651y_data *ym2651y_update_device(struct device *dev)
             command = 0x9b;
             status = ym2651y_read_block(client, command, data->mfr_revsion,
                                             ARRAY_SIZE(data->mfr_revsion)-1);
-            data->mfr_revsion[ARRAY_SIZE(data->mfr_revsion)-1] = '\0';
+            if (data->mfr_revsion[0] < ARRAY_SIZE(data->mfr_revsion)-2) {
+                data->mfr_revsion[data->mfr_revsion[0] + 1] = '\0';
+            }
+            else{
+                data->mfr_revsion[ARRAY_SIZE(data->mfr_revsion)-1] = '\0';
+            }
 
             if (status < 0) {
                 dev_dbg(&client->dev, "reg %d, err %d\n", command, status);
@@ -840,7 +858,12 @@ static struct ym2651y_data *ym2651y_update_device(struct device *dev)
             }
 
             status = ym2651y_read_block(client, command, data->mfr_serial, buf+1);
-            data->mfr_serial[buf+1] = '\0';
+            if (data->mfr_serial[0] < ARRAY_SIZE(data->mfr_serial)-2) {
+                data->mfr_serial[data->mfr_serial[0] + 1] = '\0';
+            }
+            else {
+                data->mfr_serial[ARRAY_SIZE(data->mfr_serial)-1] = '\0';
+            }
 
             if (status < 0) {
                 dev_dbg(&client->dev, "reg %d, err %d\n", command, status);

--- a/packages/platforms/accton/x86-64/as7315-27xb/modules/builds/x86-64-accton-as7315-27xb-psu.c
+++ b/packages/platforms/accton/x86-64/as7315-27xb/modules/builds/x86-64-accton-as7315-27xb-psu.c
@@ -70,17 +70,18 @@ enum as7315_27xb_psu_sysfs_attributes {
 };
 
 enum psu_type {
-    PSU_YM_1401_A,      /* AC110V - B2F */
-    PSU_YM_2401_JCR,    /* AC110V - F2B */
-    PSU_YM_2401_JDR,    /* AC110V - B2F */
-    PSU_YM_2401_TCR,    /* AC110V - B2F */
-    PSU_CPR_4011_4M11,  /* AC110V - F2B */
-    PSU_CPR_4011_4M21,  /* AC110V - B2F */
-    PSU_CPR_6011_2M11,  /* AC110V - F2B */
-    PSU_CPR_6011_2M21,  /* AC110V - B2F */
-    PSU_UM400D_01G,     /* DC48V  - F2B */
-    PSU_UM400D01_01G,   /* DC48V  - B2F */
-    PSU_BEL_TOT12,     /* DC48V  - N/A */
+    PSU_YM_1401_A,          /* AC110V - B2F */
+    PSU_YM_2401_JCR,        /* AC110V - F2B */
+    PSU_YM_2401_JDR,        /* AC110V - B2F */
+    PSU_YM_2401_TCR,        /* AC110V - B2F */
+    PSU_CPR_4011_4M11,      /* AC110V - F2B */
+    PSU_CPR_4011_4M21,      /* AC110V - B2F */
+    PSU_CPR_6011_2M11,      /* AC110V - F2B */
+    PSU_CPR_6011_2M21,      /* AC110V - B2F */
+    PSU_UM400D_01G,         /* DC48V  - F2B */
+    PSU_UM400D01_01G,       /* DC48V  - B2F */
+    PSU_BEL_TOT12,          /* DC48V  - N/A */
+    PSU_BEL_SPAACTN_03BG,   /* AC110V - N/A */
     PSU_TYPE_MAX
 };
 
@@ -93,17 +94,18 @@ struct model_info {
 };
 
 struct model_info models[] = {
-    {PSU_BEL_TOT12,     0x0A, "CRXT-T0T12",0x18, 8},
-    {PSU_YM_1401_A,     0x20, "YM-1401ACR",0x35,MAX_OUTPUT_LENGTH},
-    {PSU_YM_2401_JCR,   0x20, "YM-2401JCR",0x35,MAX_OUTPUT_LENGTH},
-    {PSU_YM_2401_JDR,   0x20, "YM-2401JDR",0x35,MAX_OUTPUT_LENGTH},
-    {PSU_YM_2401_TCR,   0x20, "YM-2401TCR",0x35,MAX_OUTPUT_LENGTH},
-    {PSU_CPR_4011_4M11, 0x26, "CPR-4011-4M11",0x47,MAX_OUTPUT_LENGTH},
-    {PSU_CPR_4011_4M21, 0x26, "CPR-4011-4M21",0x47,MAX_OUTPUT_LENGTH},
-    {PSU_CPR_6011_2M11, 0x26, "CPR-6011-2M11",0x46,MAX_OUTPUT_LENGTH},
-    {PSU_CPR_6011_2M21, 0x26, "CPR-6011-2M21",0x46,MAX_OUTPUT_LENGTH},
-    {PSU_UM400D_01G,    0x50, "um400d01G",0x50,MAX_OUTPUT_LENGTH},
-    {PSU_UM400D01_01G,  0x50, "um400d01-01G",0x50,MAX_OUTPUT_LENGTH},
+    {PSU_BEL_TOT12,         0x0A, "CRXT-T0T12",0x18, 8},
+    {PSU_BEL_SPAACTN_03BG,  0x0A, "SPAACTN-03BG",0x18, 8},
+    {PSU_YM_1401_A,         0x20, "YM-1401ACR",0x35,MAX_OUTPUT_LENGTH},
+    {PSU_YM_2401_JCR,       0x20, "YM-2401JCR",0x35,MAX_OUTPUT_LENGTH},
+    {PSU_YM_2401_JDR,       0x20, "YM-2401JDR",0x35,MAX_OUTPUT_LENGTH},
+    {PSU_YM_2401_TCR,       0x20, "YM-2401TCR",0x35,MAX_OUTPUT_LENGTH},
+    {PSU_CPR_4011_4M11,     0x26, "CPR-4011-4M11",0x47,MAX_OUTPUT_LENGTH},
+    {PSU_CPR_4011_4M21,     0x26, "CPR-4011-4M21",0x47,MAX_OUTPUT_LENGTH},
+    {PSU_CPR_6011_2M11,     0x26, "CPR-6011-2M11",0x46,MAX_OUTPUT_LENGTH},
+    {PSU_CPR_6011_2M21,     0x26, "CPR-6011-2M21",0x46,MAX_OUTPUT_LENGTH},
+    {PSU_UM400D_01G,        0x50, "um400d01G",0x50,MAX_OUTPUT_LENGTH},
+    {PSU_UM400D01_01G,      0x50, "um400d01-01G",0x50,MAX_OUTPUT_LENGTH},
 };
 
 static ssize_t show_index(struct device *dev, struct device_attribute *da, char *buf);

--- a/packages/platforms/accton/x86-64/as7315-27xb/onlp/builds/x86_64_accton_as7315_27xb/module/src/psui.c
+++ b/packages/platforms/accton/x86-64/as7315-27xb/onlp/builds/x86_64_accton_as7315_27xb/module/src/psui.c
@@ -171,6 +171,27 @@ onlp_psui_info_get(onlp_oid_t id, onlp_psu_info_t* info)
         aim_free(string);
     }
 
+    /* Read voltage, current and power for AC */
+    if(info->caps & ONLP_PSU_CAPS_AC) {
+        val = 0;
+        if (onlp_file_read_int(&val, PSU_SYSFS_PATH"psu_v_in", bus, offset) == 0 && val) {
+            info->mvin = val;
+            info->caps |= ONLP_PSU_CAPS_VIN;
+        }
+
+        val = 0;
+        if (onlp_file_read_int(&val, PSU_SYSFS_PATH"psu_i_in", bus, offset) == 0 && val) {
+            info->miin = val;
+            info->caps |= ONLP_PSU_CAPS_IIN;
+        }
+
+        val = 0;
+        if (onlp_file_read_int(&val, PSU_SYSFS_PATH"psu_p_in", bus, offset) == 0 && val) {
+            info->mpin = val;
+            info->caps |= ONLP_PSU_CAPS_PIN;
+        }
+    }
+
     /* Set the associated oid_table */
     val = 0;
     if (onlp_file_read_int(&val, PSU_SYSFS_PATH"psu_temp1_input", bus, offset) == 0 && val) {

--- a/packages/platforms/accton/x86-64/as7315-27xb/onlp/builds/x86_64_accton_as7315_27xb/module/src/psui.c
+++ b/packages/platforms/accton/x86-64/as7315-27xb/onlp/builds/x86_64_accton_as7315_27xb/module/src/psui.c
@@ -143,15 +143,33 @@ onlp_psui_info_get(onlp_oid_t id, onlp_psu_info_t* info)
 
     /* Read voltage, current and power */
     val = 0;
+    if (onlp_file_read_int(&val, PSU_SYSFS_PATH"psu_v_in", bus, offset) == 0 && val) {
+        info->mvin = val;
+        info->caps |= ONLP_PSU_CAPS_VIN;
+    }
+
+    val = 0;
     if (onlp_file_read_int(&val, PSU_SYSFS_PATH"psu_v_out", bus, offset) == 0 && val) {
         info->mvout = val;
         info->caps |= ONLP_PSU_CAPS_VOUT;
     }
 
     val = 0;
+    if (onlp_file_read_int(&val, PSU_SYSFS_PATH"psu_i_in", bus, offset) == 0 && val) {
+        info->miin = val;
+        info->caps |= ONLP_PSU_CAPS_IIN;
+    }
+
+    val = 0;
     if (onlp_file_read_int(&val, PSU_SYSFS_PATH"psu_i_out", bus, offset) == 0 && val) {
         info->miout = val;
         info->caps |= ONLP_PSU_CAPS_IOUT;
+    }
+
+    val = 0;
+    if (onlp_file_read_int(&val, PSU_SYSFS_PATH"psu_p_in", bus, offset) == 0 && val) {
+        info->mpin = val;
+        info->caps |= ONLP_PSU_CAPS_PIN;
     }
 
     val = 0;
@@ -169,27 +187,6 @@ onlp_psui_info_get(onlp_oid_t id, onlp_psu_info_t* info)
     }
     if (string) {
         aim_free(string);
-    }
-
-    /* Read voltage, current and power for AC */
-    if(info->caps & ONLP_PSU_CAPS_AC) {
-        val = 0;
-        if (onlp_file_read_int(&val, PSU_SYSFS_PATH"psu_v_in", bus, offset) == 0 && val) {
-            info->mvin = val;
-            info->caps |= ONLP_PSU_CAPS_VIN;
-        }
-
-        val = 0;
-        if (onlp_file_read_int(&val, PSU_SYSFS_PATH"psu_i_in", bus, offset) == 0 && val) {
-            info->miin = val;
-            info->caps |= ONLP_PSU_CAPS_IIN;
-        }
-
-        val = 0;
-        if (onlp_file_read_int(&val, PSU_SYSFS_PATH"psu_p_in", bus, offset) == 0 && val) {
-            info->mpin = val;
-            info->caps |= ONLP_PSU_CAPS_PIN;
-        }
     }
 
     /* Set the associated oid_table */


### PR DESCRIPTION
To support as7315-27xb AC PSU,
1. Add new PSU model information to ym2651y.c for V_IN, I_IN and P_IN.
2. Add some conditions for ym2651y.c.
3. Add new PSU model information to x86-64-accton-as7315-27xb-psu.c.
4. Modify psui.c to support onlpd showing AC PSU state.

Signed-off-by: Jake Lin <jake_lin@edge-core.com>