### PR TITLE
Update AS7816-64X thermal policy

### DIFF
--- a/packages/platforms/accton/x86-64/as7816-64x/onlp/builds/x86_64_accton_as7816_64x/module/src/sysi.c
+++ b/packages/platforms/accton/x86-64/as7816-64x/onlp/builds/x86_64_accton_as7816_64x/module/src/sysi.c
@@ -308,7 +308,7 @@ sysi_fanctrl_overall_thermal_sensor_policy(onlp_fan_info_t fi[CHASSIS_FAN_COUNT]
         high = up_th[fanlevel].val[i-THERMAL_1_ON_MAIN_BROAD];
         low = down_th[fanlevel].val[i-THERMAL_1_ON_MAIN_BROAD];
         // perform level up if anyone is higher than high_th.
-        if(ti[i-1].mcelsius > high) {
+        if(ti[i-1].mcelsius >= high) {
             can_level_up = true;
             break;
         }

--- a/packages/platforms/accton/x86-64/as7816-64x/onlp/builds/x86_64_accton_as7816_64x/module/src/sysi.c
+++ b/packages/platforms/accton/x86-64/as7816-64x/onlp/builds/x86_64_accton_as7816_64x/module/src/sysi.c
@@ -140,7 +140,22 @@ onlp_sysi_platform_manage_init(void)
 }
 
 #define FAN_DUTY_MAX  (100)
-#define FAN_DUTY_MIN  (52)
+#define FAN_DUTY_MIN  (40)
+
+enum fan_level {
+    FAN_LEVEL5 = 0,
+    FAN_LEVEL7,
+    FAN_LEVEL9,
+    FAN_LEVELB,
+    FAN_LEVELD,
+    FAN_LEVELF,
+    NUM_FAN_LEVEL,
+    FAN_LEVEL_INVALID = NUM_FAN_LEVEL
+};
+
+static const int fanduty_by_level[] = {
+    FAN_DUTY_MIN, 52, 64, 76, 88, FAN_DUTY_MAX
+};
 
 static int
 sysi_fanctrl_fan_fault_policy(onlp_fan_info_t fi[CHASSIS_FAN_COUNT],
@@ -184,70 +199,126 @@ sysi_fanctrl_fan_absent_policy(onlp_fan_info_t fi[CHASSIS_FAN_COUNT],
     return ONLP_STATUS_OK;
 }
 
+static unsigned int get_fan_level_by_duty(int fanduty)
+{
+    switch(fanduty) {
+        case FAN_DUTY_MIN: return FAN_LEVEL5;
+        case 52: return FAN_LEVEL7;
+        case 64: return FAN_LEVEL9;
+        case 76: return FAN_LEVELB;
+        case 88: return FAN_LEVELD;
+        case FAN_DUTY_MAX: return FAN_LEVELF;
+        default: return FAN_LEVEL_INVALID;
+    }
+}
+
 static int
 sysi_fanctrl_fan_unknown_speed_policy(onlp_fan_info_t fi[CHASSIS_FAN_COUNT],
                                       onlp_thermal_info_t ti[CHASSIS_THERMAL_COUNT],
                                       int *adjusted)
 {
-	int i, match = 0;
     int fanduty;
-	int legal_duties[] = {FAN_DUTY_MIN, 64, 76, 88, FAN_DUTY_MAX};
+    unsigned int fanlevel;
 
 	*adjusted = 0;
 
     if (onlp_file_read_int(&fanduty, FAN_NODE(fan_duty_cycle_percentage)) < 0) {
         *adjusted = 1;
-        return onlp_fani_percentage_set(ONLP_FAN_ID_CREATE(1), FAN_DUTY_MIN);
-    }    
-
-    /* Bring fan speed to min if current speed is not expected
-     */
-    for (i = 0; i < AIM_ARRAYSIZE(legal_duties); i++) {
-		if (fanduty != legal_duties[i]) {
-			continue;
-		}
-
-		match = 1;
-		break;
+        return onlp_fani_percentage_set(ONLP_FAN_ID_CREATE(1), FAN_DUTY_MAX);
     }
 
-	if (!match) {
+    fanlevel = get_fan_level_by_duty(fanduty);
+
+    if (fanlevel == FAN_LEVEL_INVALID) {
         *adjusted = 1;
-        return onlp_fani_percentage_set(ONLP_FAN_ID_CREATE(1), FAN_DUTY_MIN);
+        return onlp_fani_percentage_set(ONLP_FAN_ID_CREATE(1), FAN_DUTY_MAX);
 	}
 
     return ONLP_STATUS_OK;
 }
+
+#define THERMAL_COUNT (THERMAL_6_ON_MAIN_BROAD - THERMAL_1_ON_MAIN_BROAD + 1)
+typedef struct _threshold{
+    int val[THERMAL_COUNT];
+    unsigned int next_level;
+} threshold_t;
+
+#define NA_L 0
+#define NA_H 999999
+threshold_t up_th_f2b[NUM_FAN_LEVEL] = {
+    {{57000,60000,40000,39000,36000,38000}, FAN_LEVEL7}, //LEVEL5
+    {{62000,64000,46000,45000,43000,44000}, FAN_LEVELB}, //LEVEL7
+    {{ NA_L, NA_L, NA_L, NA_L, NA_L, NA_L}, FAN_LEVELF}, //LEVEL9, NA, force to change level.
+    {{ NA_H, NA_H,51000,49000,48000,49000}, FAN_LEVELD}, //LEVELB
+    {{67000,70000,55000,54000,53000,54000}, FAN_LEVELF}, //LEVELD
+    {{ NA_H, NA_H, NA_H, NA_H, NA_H, NA_H}, FAN_LEVELF}  //LEVELF, Won't go any higher.
+};
+
+threshold_t down_th_f2b[NUM_FAN_LEVEL] = {
+    {{ NA_L, NA_L, NA_L, NA_L, NA_L, NA_L}, FAN_LEVEL5}, //LEVEL5, Won't go any lower.
+    {{55000,58000,38000,37000,34000,36000}, FAN_LEVEL5}, //LEVEL7
+    {{ NA_H, NA_H, NA_H, NA_H, NA_H, NA_H}, FAN_LEVELF}, //LEVEL9, NA, force to change level.
+    {{60000,62000,43000,42000,40000,41000}, FAN_LEVEL7}, //LEVELB
+    {{65000,68000,49000,47000,46000,47000}, FAN_LEVELB}, //LEVELD
+    {{ NA_H, NA_H,53000,52000,51000,52000}, FAN_LEVELD}  //LEVELF
+};
+
+threshold_t up_th_b2f[NUM_FAN_LEVEL] = {
+    {{52000,41000,34000,27000,26000,26000}, FAN_LEVEL7}, //LEVEL5
+    {{ NA_H, NA_H,38000,32000,31000,31000}, FAN_LEVEL9}, //LEVEL7
+    {{57000,48000,42000,37000,37000,36000}, FAN_LEVELB}, //LEVEL9,
+    {{61000,52000,46000,42000,42000,42000}, FAN_LEVELD}, //LEVELB
+    {{66000,57000,51000,47000,47000,47000}, FAN_LEVELF}, //LEVELD
+    {{ NA_H, NA_H, NA_H, NA_H, NA_H, NA_H}, FAN_LEVELF}  //LEVELF, Won't go any higher.
+};
+
+threshold_t down_th_b2f[NUM_FAN_LEVEL] = {
+    {{ NA_L, NA_L, NA_L, NA_L, NA_L, NA_L}, FAN_LEVEL5}, //LEVEL5, Won't go any lower.
+    {{50000,39000,32000,25000,24000,24000}, FAN_LEVEL5}, //LEVEL7
+    {{55000,45000,36000,30000,29000,29000}, FAN_LEVEL7}, //LEVEL9, NA, force to change level.
+    {{ NA_H, NA_H,40000,35000,34000,34000}, FAN_LEVEL9}, //LEVELB
+    {{59000,50000,44000,40000,40000,40000}, FAN_LEVELB}, //LEVELD
+    {{63000,55000,48000,45000,45000,45000}, FAN_LEVELD}  //LEVELF
+};
 
 static int
 sysi_fanctrl_overall_thermal_sensor_policy(onlp_fan_info_t fi[CHASSIS_FAN_COUNT],
                                            onlp_thermal_info_t ti[CHASSIS_THERMAL_COUNT],
                                            int *adjusted)
 {
-    int i, num_of_sensor = 0, temp_avg = 0;
+    int i, fanduty, fanlevel, next_up_level, next_down_level;
+    bool can_level_up = false; //prioritze up more than down
+    bool can_level_down = true;
+    int high, low;
+    threshold_t* up_th = (fi[0].status & ONLP_FAN_STATUS_F2B)? up_th_f2b : up_th_b2f;
+    threshold_t* down_th = (fi[0].status & ONLP_FAN_STATUS_F2B)? down_th_f2b : down_th_b2f;
 
-    for (i = (THERMAL_1_ON_MAIN_BROAD); i <= (THERMAL_6_ON_MAIN_BROAD); i++) {
-        num_of_sensor++;
-        temp_avg += ti[i-1].mcelsius;
-    }
+    *adjusted = 1;
 
-    temp_avg /= num_of_sensor;
-	*adjusted = 1;
+    // decide fanlevel by fanduty
+    if(onlp_file_read_int(&fanduty, FAN_NODE(fan_duty_cycle_percentage)) < 0)
+        fanduty = FAN_DUTY_MAX;
+    fanlevel = get_fan_level_by_duty(fanduty);
+    fanlevel = (fanlevel==FAN_LEVEL_INVALID)? FAN_LEVELF : fanlevel; //maximum while invalid.
 
-    if (temp_avg > 57000) {
-        return onlp_fani_percentage_set(ONLP_FAN_ID_CREATE(1), FAN_DUTY_MAX);
+    // decide target level by thermal sensor input.
+    next_up_level = up_th[fanlevel].next_level;
+    next_down_level = down_th[fanlevel].next_level;
+    for (i=THERMAL_1_ON_MAIN_BROAD ; i<=THERMAL_6_ON_MAIN_BROAD; i++){
+        high = up_th[fanlevel].val[i-THERMAL_1_ON_MAIN_BROAD];
+        low = down_th[fanlevel].val[i-THERMAL_1_ON_MAIN_BROAD];
+        // perform level up if anyone is higher than high_th.
+        if(ti[i-1].mcelsius > high) {
+            can_level_up = true;
+            break;
+        }
+        // cancel level down if anyone is higher than low_th.
+        if(ti[i-1].mcelsius > low)
+            can_level_down = false;
     }
-    else if (temp_avg > 52000) {
-        return onlp_fani_percentage_set(ONLP_FAN_ID_CREATE(1), 88);
-    }
-    else if (temp_avg > 46000) {
-        return onlp_fani_percentage_set(ONLP_FAN_ID_CREATE(1), 76);
-    }
-    else if (temp_avg > 43000) {
-        return onlp_fani_percentage_set(ONLP_FAN_ID_CREATE(1), 64);
-    }
-
-    return onlp_fani_percentage_set(ONLP_FAN_ID_CREATE(1), FAN_DUTY_MIN);
+    fanlevel = (can_level_up)? next_up_level : ((can_level_down)? next_down_level : fanlevel);
+    return onlp_fani_percentage_set(ONLP_FAN_ID_CREATE(1),
+                                    fanduty_by_level[fanlevel]);
 }
 
 typedef int (*fan_control_policy)(onlp_fan_info_t fi[CHASSIS_FAN_COUNT],

--- a/packages/platforms/accton/x86-64/as7816-64x/onlp/builds/x86_64_accton_as7816_64x/module/src/sysi.c
+++ b/packages/platforms/accton/x86-64/as7816-64x/onlp/builds/x86_64_accton_as7816_64x/module/src/sysi.c
@@ -248,7 +248,7 @@ typedef struct _threshold{
 threshold_t up_th_f2b[NUM_FAN_LEVEL] = {
     {{57000,60000,40000,39000,36000,38000}, FAN_LEVEL7}, //LEVEL5
     {{62000,64000,46000,45000,43000,44000}, FAN_LEVELB}, //LEVEL7
-    {{ NA_L, NA_L, NA_L, NA_L, NA_L, NA_L}, FAN_LEVELF}, //LEVEL9, NA, force to change level.
+    {{ NA_L, NA_L, NA_L, NA_L, NA_L, NA_L}, FAN_LEVELB}, //LEVEL9, NA, force to change level.
     {{ NA_H, NA_H,51000,49000,48000,49000}, FAN_LEVELD}, //LEVELB
     {{67000,70000,55000,54000,53000,54000}, FAN_LEVELF}, //LEVELD
     {{ NA_H, NA_H, NA_H, NA_H, NA_H, NA_H}, FAN_LEVELF}  //LEVELF, Won't go any higher.
@@ -257,7 +257,7 @@ threshold_t up_th_f2b[NUM_FAN_LEVEL] = {
 threshold_t down_th_f2b[NUM_FAN_LEVEL] = {
     {{ NA_L, NA_L, NA_L, NA_L, NA_L, NA_L}, FAN_LEVEL5}, //LEVEL5, Won't go any lower.
     {{55000,58000,38000,37000,34000,36000}, FAN_LEVEL5}, //LEVEL7
-    {{ NA_H, NA_H, NA_H, NA_H, NA_H, NA_H}, FAN_LEVELF}, //LEVEL9, NA, force to change level.
+    {{ NA_H, NA_H, NA_H, NA_H, NA_H, NA_H}, FAN_LEVEL7}, //LEVEL9, NA, force to change level.
     {{60000,62000,43000,42000,40000,41000}, FAN_LEVEL7}, //LEVELB
     {{65000,68000,49000,47000,46000,47000}, FAN_LEVELB}, //LEVELD
     {{ NA_H, NA_H,53000,52000,51000,52000}, FAN_LEVELD}  //LEVELF


### PR DESCRIPTION
Update AS7816-64X thermal policy according to the new spec from HW guys.
Verified with onlps, test log: [thermal_plan_test_on_DUT.log](https://github.com/opencomputeproject/OpenNetworkLinux/files/7568690/thermal_plan_test_on_DUT.log)

Signed-off-by: Sean Wu sean_wu@edge-core.c
