### PR TITLE
Update submodules to point to opennetlinux github

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,21 +1,21 @@
 [submodule "packages/base/any/initrds/buildroot/builds/buildroot-mirror"]
 	path = packages/base/any/initrds/buildroot/builds/buildroot-mirror
-	url = http://github.com/opennetworklinux/buildroot-mirror
+	url = http://github.com/opennetlinux/buildroot-mirror
 [submodule "packages/base/any/kernels/legacy/linux-3.9.6"]
 	path = packages/base/any/kernels/legacy/linux-3.9.6
-	url = http://github.com/opennetworklinux/linux-3.9.6
+	url = http://github.com/opennetlinux/linux-3.9.6
 [submodule "sm/infra"]
 	path = sm/infra
-	url = http://github.com/floodlight/infra
+	url = http://github.com/opennetlinux/infra
 [submodule "sm/bigcode"]
 	path = sm/bigcode
-	url = http://github.com/floodlight/bigcode
+	url = http://github.com/opennetlinux/bigcode
 [submodule "packages/base/any/kernels/legacy/linux-3.8.13"]
 	path = packages/base/any/kernels/legacy/linux-3.8.13
-	url = http://github.com/opennetworklinux/linux-3.8.13
+	url = http://github.com/opennetlinux/linux-3.8.13
 [submodule "packages/platforms-closed"]
 	path = packages/platforms-closed
-	url = git@github.com:opennetworklinux/platforms-closed
+	url = git@github.com:opennetlinux/platforms-closed
 [submodule "sm/build-artifacts"]
 	path = sm/build-artifacts
-        url = http://github.com/opennetworklinux/build-artifacts
+        url = http://github.com/opennetlinux/build-artifacts


### PR DESCRIPTION
By request all submodules are being moved off of the opennetworklinux/floodlight repositories.
Signed-off-by: Steven Noble <snoble@sonn.com>