### PR TITLE
[AS5835-54x] Support psu_fan_dir sysfs for YM-1401A PSU

### DIFF
--- a/packages/base/any/kernels/modules/ym2651y.c
+++ b/packages/base/any/kernels/modules/ym2651y.c
@@ -862,18 +862,25 @@ static struct ym2651y_data *ym2651y_update_device(struct device *dev)
                 dev_dbg(&client->dev, "reg %d, err %d\n", command, status);
                 goto exit;
             }
-
-            status = ym2651y_read_block(client, command, data->mfr_serial, buf+1);
-            if (data->mfr_serial[0] < ARRAY_SIZE(data->mfr_serial)-2) {
-                data->mfr_serial[data->mfr_serial[0] + 1] = '\0';
+            if(!strncmp("YM-1401A", data->mfr_model+1, strlen("YM-1401A")))
+            {
+                data->mfr_serial[0] = '\0';
+                data->fan_dir[0] = '\0';
             }
-            else {
-                data->mfr_serial[ARRAY_SIZE(data->mfr_serial)-1] = '\0';
-            }
+            else
+            {
+                status = ym2651y_read_block(client, command, data->mfr_serial, buf+1);
+                if (data->mfr_serial[0] < ARRAY_SIZE(data->mfr_serial)-2) {
+                    data->mfr_serial[data->mfr_serial[0] + 1] = '\0';
+                }
+                else {
+                    data->mfr_serial[ARRAY_SIZE(data->mfr_serial)-1] = '\0';
+                }
 
-            if (status < 0) {
-                dev_dbg(&client->dev, "reg %d, err %d\n", command, status);
-                goto exit;
+                if (status < 0) {
+                    dev_dbg(&client->dev, "reg %d, err %d\n", command, status);
+                    goto exit;
+                }
             }
         }
 

--- a/packages/platforms/accton/x86-64/as5835-54x/onlp/builds/x86_64_accton_as5835_54x/module/src/platform_lib.c
+++ b/packages/platforms/accton/x86-64/as5835-54x/onlp/builds/x86_64_accton_as5835_54x/module/src/platform_lib.c
@@ -86,7 +86,7 @@ psu_type_t get_psu_type(int id, char* modelname, int modelname_len)
     if (strncmp(mn, "YM-1401A", 8) == 0) {
         char *fd = NULL;
         
-        node = (id == PSU1_ID) ? PSU1_AC_PMBUS_NODE(psu_fan_dir) : PSU1_AC_PMBUS_NODE(psu_fan_dir);
+        node = (id == PSU1_ID) ? PSU1_AC_HWMON_NODE(psu_fan_dir) : PSU2_AC_HWMON_NODE(psu_fan_dir);
         ret = onlp_file_read_str(&fd, node);
 
         if (ret <= 0 || ret > PSU_FAN_DIR_LEN || fd == NULL) {


### PR DESCRIPTION
Signed-off-by: Jostar Yang <jostar_yang@accton.com.tw>

Because YM-1401A doesn't support psu_fan_dir from pmbus. Read from command = 0xC3 in pmbus that will always get "F2B". But YM-10401A has F2B and B2F PSU. So read PSU fan dir from psu eerpm and add psu_fan_dir sysfs. YM-1401ABR is F2B  and  YM-1401ACR is B2B.

Test log as below,
(YM-1401ABR)
cat /sys/bus/i2c/devices/12-0053/psu_fan_dir 
F2B
onlpdump log as below,
.............
{
Description: PSU 2 - Fan 1
Status: 0x00000009 [ PRESENT,F2B ]
Caps: 0x00000038 [ SET_PERCENTAGE,GET_RPM,GET_PERCENTAGE ]
RPM: 3200
Per: 14
Model: NULL
SN: NULL

( YM-1401ACR)
/sys/bus/i2c/devices/12-0053/psu_fan_dir
B2F
onlpdump log as below,
Description: PSU-1
Model: YM-1401ACR
SN: SA040W261837000030
Status: 0x00000001 [ PRESENT ]
Caps: 0x00000151 [ AC,VOUT,IOUT,POUT ]
Vin: 0
Vout: 11841
Iin: 0
Iout: 3972
Pin: 0
Pout: 44000
fan @ 6 = {
Description: PSU 1 - Fan 1
Status: 0x00000005 [ PRESENT,B2F ]
..............