### PR TITLE
[Edgecore][as7926_40xfb] Update drivers/API to match latest BMC firmware

### DIFF
--- a/packages/platforms/accton/x86-64/as7926-40xfb/modules/builds/x86-64-accton-as7926-40xfb-cpld.c
+++ b/packages/platforms/accton/x86-64/as7926-40xfb/modules/builds/x86-64-accton-as7926-40xfb-cpld.c
@@ -1,8 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
 /*
  * A hwmon driver for the as7926_40xfb_cpld
  *
  * Copyright (C) 2019  Edgecore Networks Corporation.
- * Jostar Yang <brandon_chuang@edge-core.com>
+ * Brandon Chuang <brandon_chuang@edge-core.com>
  *
  * Based on ad7414.c
  * Copyright 2006 Stefan Roese <sr at denx.de>, DENX Software Engineering
@@ -37,11 +38,11 @@
 #define DRVNAME "as7926_40xfb_cpld"
 
 static LIST_HEAD(cpld_client_list);
-static struct mutex	 list_lock;
+static struct mutex list_lock;
 
 struct cpld_client_node {
 	struct i2c_client *client;
-	struct list_head   list;
+	struct list_head list;
 };
 
 enum cpld_type {
@@ -51,25 +52,25 @@ enum cpld_type {
 };
 
 #define I2C_RW_RETRY_COUNT    10
-#define I2C_RW_RETRY_INTERVAL 60 /* ms */
+#define I2C_RW_RETRY_INTERVAL 60	/* ms */
 
 static ssize_t show_status(struct device *dev, struct device_attribute *da,
-			 char *buf);
+			   char *buf);
 static ssize_t show_present_all(struct device *dev, struct device_attribute *da,
-			 char *buf);
+				char *buf);
 static ssize_t set_tx_disable(struct device *dev, struct device_attribute *da,
-			const char *buf, size_t count);
+			      const char *buf, size_t count);
 static ssize_t set_control(struct device *dev, struct device_attribute *da,
-			const char *buf, size_t count);
+			   const char *buf, size_t count);
 static ssize_t access(struct device *dev, struct device_attribute *da,
-			const char *buf, size_t count);
+		      const char *buf, size_t count);
 static ssize_t show_version(struct device *dev, struct device_attribute *da,
-			char *buf);
+			    char *buf);
 
 struct as7926_40xfb_cpld_data {
 	struct device *hwmon_dev;
-	struct mutex   update_lock;
-	u8  index; /* CPLD index */
+	struct mutex update_lock;
+	u8 index;		/* CPLD index */
 };
 
 /* Addresses scanned for as7926_40xfb_cpld
@@ -239,8 +240,8 @@ enum as7926_40xfb_cpld_sysfs_attributes {
 
 static SENSOR_DEVICE_ATTR(version, S_IRUGO, show_version, NULL, CPLD_VERSION);
 static SENSOR_DEVICE_ATTR(access, S_IWUSR, NULL, access, ACCESS);
-static SENSOR_DEVICE_ATTR(module_present_all, S_IRUGO, show_present_all, \
-							NULL, MODULE_PRESENT_ALL);
+static SENSOR_DEVICE_ATTR(module_present_all, S_IRUGO, show_present_all,
+			  NULL, MODULE_PRESENT_ALL);
 
 /* transceiver attributes */
 DECLARE_QSFP28_TRANSCEIVER_SENSOR_DEVICE_ATTR(1);
@@ -388,7 +389,7 @@ static const struct attribute_group as7926_40xfb_cpld4_group = {
 	.attrs = as7926_40xfb_cpld4_attributes,
 };
 
-static const struct attribute_group* cpld_groups[] = {
+static const struct attribute_group *cpld_groups[] = {
 	&as7926_40xfb_cpld2_group,
 	&as7926_40xfb_cpld3_group,
 	&as7926_40xfb_cpld4_group,
@@ -396,18 +397,18 @@ static const struct attribute_group* cpld_groups[] = {
 
 int as7926_40xfb_cpld_read(int bus_num, unsigned short cpld_addr, u8 reg)
 {
-	struct list_head   *list_node = NULL;
+	struct list_head *list_node = NULL;
 	struct cpld_client_node *cpld_node = NULL;
 	int ret = -EPERM;
 
 	mutex_lock(&list_lock);
 
-	list_for_each(list_node, &cpld_client_list)
-	{
-		cpld_node = list_entry(list_node, struct cpld_client_node, list);
+	list_for_each(list_node, &cpld_client_list) {
+		cpld_node =
+		    list_entry(list_node, struct cpld_client_node, list);
 
 		if (cpld_node->client->addr == cpld_addr
-			&& cpld_node->client->adapter->nr == bus_num) {
+		    && cpld_node->client->adapter->nr == bus_num) {
 			ret = i2c_smbus_read_byte_data(cpld_node->client, reg);
 			break;
 		}
@@ -417,9 +418,11 @@ int as7926_40xfb_cpld_read(int bus_num, unsigned short cpld_addr, u8 reg)
 
 	return ret;
 }
+
 EXPORT_SYMBOL(as7926_40xfb_cpld_read);
 
-int as7926_40xfb_cpld_write(int bus_num, unsigned short cpld_addr, u8 reg, u8 value)
+int as7926_40xfb_cpld_write(int bus_num, unsigned short cpld_addr, u8 reg,
+			    u8 value)
 {
 	struct list_head *list_node = NULL;
 	struct cpld_client_node *cpld_node = NULL;
@@ -427,12 +430,11 @@ int as7926_40xfb_cpld_write(int bus_num, unsigned short cpld_addr, u8 reg, u8 va
 
 	mutex_lock(&list_lock);
 
-	list_for_each(list_node, &cpld_client_list)
-	{
+	list_for_each(list_node, &cpld_client_list) {
 		cpld_node = list_entry(list_node, struct cpld_client_node, list);
 
 		if (cpld_node->client->addr == cpld_addr
-			&& cpld_node->client->adapter->nr == bus_num) {
+		    && cpld_node->client->adapter->nr == bus_num) {
 			ret = i2c_smbus_write_byte_data(cpld_node->client, reg, value);
 			break;
 		}
@@ -442,10 +444,11 @@ int as7926_40xfb_cpld_write(int bus_num, unsigned short cpld_addr, u8 reg, u8 va
 
 	return ret;
 }
+
 EXPORT_SYMBOL(as7926_40xfb_cpld_write);
 
 static ssize_t show_status(struct device *dev, struct device_attribute *da,
-			 char *buf)
+			   char *buf)
 {
 	struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
 	struct i2c_client *client = to_i2c_client(dev);
@@ -458,127 +461,131 @@ static ssize_t show_status(struct device *dev, struct device_attribute *da,
 	case MODULE_PRESENT_3 ... MODULE_PRESENT_4:
 	case MODULE_PRESENT_21 ... MODULE_PRESENT_22:
 	case MODULE_PRESENT_23 ... MODULE_PRESENT_24:
-		reg  = 0x10;
+		reg = 0x10;
 		mask = 0x1 << (attr->index - MODULE_PRESENT_1);
 		break;
 	case MODULE_PRESENT_5 ... MODULE_PRESENT_6:
 	case MODULE_PRESENT_7 ... MODULE_PRESENT_8:
 	case MODULE_PRESENT_25 ... MODULE_PRESENT_26:
 	case MODULE_PRESENT_27 ... MODULE_PRESENT_28:
-		reg  = 0x11;
+		reg = 0x11;
 		mask = 0x1 << (attr->index - MODULE_PRESENT_5);
 		break;
 	case MODULE_PRESENT_9 ... MODULE_PRESENT_10:
 	case MODULE_PRESENT_29 ... MODULE_PRESENT_30:
-		reg  = 0x12;
+		reg = 0x12;
 		mask = 0x1 << (attr->index - MODULE_PRESENT_9);
 		break;
 	case MODULE_PRESENT_11 ... MODULE_PRESENT_12:
 	case MODULE_PRESENT_13 ... MODULE_PRESENT_14:
 	case MODULE_PRESENT_31 ... MODULE_PRESENT_32:
 	case MODULE_PRESENT_33 ... MODULE_PRESENT_34:
-		reg  = 0x10;
+		reg = 0x10;
 		mask = 0x1 << (attr->index - MODULE_PRESENT_11);
 		break;
 	case MODULE_PRESENT_15 ... MODULE_PRESENT_16:
 	case MODULE_PRESENT_17 ... MODULE_PRESENT_18:
 	case MODULE_PRESENT_35 ... MODULE_PRESENT_36:
 	case MODULE_PRESENT_37 ... MODULE_PRESENT_38:
-		reg  = 0x11;
+		reg = 0x11;
 		mask = 0x1 << (attr->index - MODULE_PRESENT_15);
 		break;
 	case MODULE_PRESENT_19 ... MODULE_PRESENT_20:
 	case MODULE_PRESENT_39 ... MODULE_PRESENT_40:
-		reg  = 0x12;
+		reg = 0x12;
 		mask = 0x1 << (attr->index - MODULE_PRESENT_19);
 		break;
-	case MODULE_PRESENT_41 ... MODULE_PRESENT_48: /*QSFP-DD*/
-		reg  = 0x50;
+	case MODULE_PRESENT_41 ... MODULE_PRESENT_48:	/*QSFP-DD */
+		reg = 0x50;
 		mask = 0x1 << (attr->index - MODULE_PRESENT_41);
 		break;
-	case MODULE_PRESENT_49 ... MODULE_PRESENT_53: /*QSFP-DD*/
-		reg  = 0x51;
+	case MODULE_PRESENT_49 ... MODULE_PRESENT_53:	/*QSFP-DD */
+		reg = 0x51;
 		mask = 0x1 << (attr->index - MODULE_PRESENT_49);
 		break;
 	case MODULE_RESET_1 ... MODULE_RESET_2:
 	case MODULE_RESET_3 ... MODULE_RESET_4:
 	case MODULE_RESET_21 ... MODULE_RESET_22:
 	case MODULE_RESET_23 ... MODULE_RESET_24:
-		reg  = 0x8;
+		reg = 0x8;
 		mask = 0x1 << (attr->index - MODULE_RESET_1);
 		break;
 	case MODULE_RESET_5 ... MODULE_RESET_6:
 	case MODULE_RESET_7 ... MODULE_RESET_8:
 	case MODULE_RESET_25 ... MODULE_RESET_26:
 	case MODULE_RESET_27 ... MODULE_RESET_28:
-		reg  = 0x9;
+		reg = 0x9;
 		mask = 0x1 << (attr->index - MODULE_RESET_5);
 		break;
 	case MODULE_RESET_9 ... MODULE_RESET_10:
 	case MODULE_RESET_29 ... MODULE_RESET_30:
-		reg  = 0xA;
+		reg = 0xA;
 		mask = 0x1 << (attr->index - MODULE_RESET_9);
 		break;
 	case MODULE_RESET_11 ... MODULE_RESET_12:
 	case MODULE_RESET_13 ... MODULE_RESET_14:
 	case MODULE_RESET_31 ... MODULE_RESET_32:
 	case MODULE_RESET_33 ... MODULE_RESET_34:
-		reg  = 0x8;
+		reg = 0x8;
 		mask = 0x1 << (attr->index - MODULE_RESET_11);
 		break;
 	case MODULE_RESET_15 ... MODULE_RESET_16:
 	case MODULE_RESET_17 ... MODULE_RESET_18:
 	case MODULE_RESET_35 ... MODULE_RESET_36:
 	case MODULE_RESET_37 ... MODULE_RESET_38:
-		reg  = 0x9;
+		reg = 0x9;
 		mask = 0x1 << (attr->index - MODULE_RESET_15);
 		break;
 	case MODULE_RESET_19 ... MODULE_RESET_20:
 	case MODULE_RESET_39 ... MODULE_RESET_40:
-		reg  = 0xA;
+		reg = 0xA;
 		mask = 0x1 << (attr->index - MODULE_RESET_19);
 		break;
-	case MODULE_RESET_41 ... MODULE_RESET_48: /*QSFP-DD*/
-		reg  = 0xA;
+	case MODULE_RESET_41 ... MODULE_RESET_48:	/*QSFP-DD */
+		reg = 0xA;
 		mask = 0x1 << (attr->index - MODULE_RESET_41);
 		break;
-	case MODULE_RESET_49 ... MODULE_RESET_53: /*QSFP-DD*/
-		reg  = 0xB;
+	case MODULE_RESET_49 ... MODULE_RESET_53:	/*QSFP-DD */
+		reg = 0xB;
 		mask = 0x1 << (attr->index - MODULE_RESET_49);
 		break;
 	case MODULE_PRESENT_54 ... MODULE_PRESENT_55:
-		reg  = 0x13;
+		reg = 0x13;
 		mask = 0x1 << (attr->index - MODULE_PRESENT_54);
 		break;
 	case MODULE_TXDISABLE_54 ... MODULE_TXDISABLE_55:
-		reg  = 0xB;
+		reg = 0xB;
 		mask = 0x1 << (attr->index - MODULE_TXDISABLE_54);
-		invert=0;
+		invert = 0;
 		break;
 	case MODULE_RXLOS_54 ... MODULE_RXLOS_55:
-		reg  = 0x23;
+		reg = 0x23;
 		mask = 0x1 << (attr->index - MODULE_RXLOS_54);
-		invert=0;
+		invert = 0;
 		break;
- 	default:
+	default:
 		return -ENXIO;
 	}
 
 	mutex_lock(&data->update_lock);
-	switch(data->index) {
-	/* Port 1-20, 41-42 present statuus: read from i2c bus number '12'
-		and CPLD slave address 0x62 */
-	case as7926_40xfb_cpld2: status = as7926_40xfb_cpld_read(12, 0x62, reg);
+	switch (data->index) {
+		/* Port 1-20, 41-42 present statuus: read from i2c bus number '12'
+		   and CPLD slave address 0x62 */
+	case as7926_40xfb_cpld2:
+		status = as7926_40xfb_cpld_read(12, 0x62, reg);
 		break;
-	/* Port 21-40 present statuus: read from i2c bus number '13'
-		and CPLD slave address 0x63 */
-	case as7926_40xfb_cpld3: status = as7926_40xfb_cpld_read(13, 0x63, reg);
+		/* Port 21-40 present statuus: read from i2c bus number '13'
+		   and CPLD slave address 0x63 */
+	case as7926_40xfb_cpld3:
+		status = as7926_40xfb_cpld_read(13, 0x63, reg);
 		break;
-	/* Port 41-53 plug-unplug read from i2c bus number '20'
-		and CPLD slave address 0x64 */
-	case as7926_40xfb_cpld4: status = as7926_40xfb_cpld_read(20, 0x64, reg);
+		/* Port 41-53 plug-unplug read from i2c bus number '20'
+		   and CPLD slave address 0x64 */
+	case as7926_40xfb_cpld4:
+		status = as7926_40xfb_cpld_read(20, 0x64, reg);
 		break;
-	default: status = -ENXIO;
+	default:
+		status = -ENXIO;
 		break;
 	}
 
@@ -587,18 +594,19 @@ static ssize_t show_status(struct device *dev, struct device_attribute *da,
 
 	mutex_unlock(&data->update_lock);
 
-	return sprintf(buf, "%d\n", invert? !(status & mask): !!(status & mask));
+	return sprintf(buf, "%d\n",
+		       invert ? !(status & mask) : ! !(status & mask));
 
-exit:
+ exit:
 	mutex_unlock(&data->update_lock);
 	return status;
 }
 
 static ssize_t show_present_all(struct device *dev, struct device_attribute *da,
-			 char *buf)
+				char *buf)
 {
 	int i, status;
-	u8 values[4]  = { 0 };
+	u8 values[4] = { 0 };
 	u8 regs_cpld2[] = { 0x10, 0x11, 0x12, 0x13 };
 	u8 regs_cpld3[] = { 0x10, 0x11, 0x12 };
 	u8 regs_cpld4[] = { 0x50, 0x51 };
@@ -614,35 +622,38 @@ static ssize_t show_present_all(struct device *dev, struct device_attribute *da,
 
 	for (i = 0; i < size[data->index]; i++) {
 		status = as7926_40xfb_cpld_read(bus[data->index],
-									addr[data->index], regs[data->index][i]);
+						addr[data->index],
+						regs[data->index][i]);
 		if (status < 0)
 			goto exit;
 
-		values[i] = ~(u8)status;
+		values[i] = ~(u8) status;
 	}
 
 	mutex_unlock(&data->update_lock);
 
-	switch(data->index) {
+	switch (data->index) {
 	case as7926_40xfb_cpld2:
 		return sprintf(buf, "%.2x %.2x %.2x %.2x\n",
-						values[0], values[1], values[2]&0xF, values[3] & 0x3);
+			       values[0], values[1], values[2] & 0xF,
+			       values[3] & 0x3);
 	case as7926_40xfb_cpld3:
 		return sprintf(buf, "%.2x %.2x %.2x\n",
-						values[0], values[1], (values[2] & 0xF));
+			       values[0], values[1], (values[2] & 0xF));
 	case as7926_40xfb_cpld4:
-		return sprintf(buf, "%.2x %.2x\n", values[0], (values[1] & 0x1F));
+		return sprintf(buf, "%.2x %.2x\n", values[0],
+			       (values[1] & 0x1F));
 	default:
 		return -EINVAL;
 	}
 
-exit:
+ exit:
 	mutex_unlock(&data->update_lock);
 	return status;
 }
 
 static ssize_t set_tx_disable(struct device *dev, struct device_attribute *da,
-			const char *buf, size_t count)
+			      const char *buf, size_t count)
 {
 	struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
 	struct i2c_client *client = to_i2c_client(dev);
@@ -655,7 +666,7 @@ static ssize_t set_tx_disable(struct device *dev, struct device_attribute *da,
 	if (status)
 		return status;
 
-	reg  = 0xB;
+	reg = 0xB;
 	switch (attr->index) {
 	case MODULE_TXDISABLE_54:
 		mask = 0x1;
@@ -685,13 +696,13 @@ static ssize_t set_tx_disable(struct device *dev, struct device_attribute *da,
 	mutex_unlock(&data->update_lock);
 	return count;
 
-exit:
+ exit:
 	mutex_unlock(&data->update_lock);
 	return status;
 }
 
 static ssize_t set_control(struct device *dev, struct device_attribute *da,
-			const char *buf, size_t count)
+			   const char *buf, size_t count)
 {
 	struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
 	struct i2c_client *client = to_i2c_client(dev);
@@ -709,46 +720,46 @@ static ssize_t set_control(struct device *dev, struct device_attribute *da,
 	case MODULE_RESET_3 ... MODULE_RESET_4:
 	case MODULE_RESET_21 ... MODULE_RESET_22:
 	case MODULE_RESET_23 ... MODULE_RESET_24:
-		reg  = 0x8;
+		reg = 0x8;
 		mask = 0x1 << (attr->index - MODULE_RESET_1);
 		break;
 	case MODULE_RESET_5 ... MODULE_RESET_6:
 	case MODULE_RESET_7 ... MODULE_RESET_8:
 	case MODULE_RESET_25 ... MODULE_RESET_26:
 	case MODULE_RESET_27 ... MODULE_RESET_28:
-		reg  = 0x9;
+		reg = 0x9;
 		mask = 0x1 << (attr->index - MODULE_RESET_5);
 		break;
 	case MODULE_RESET_9 ... MODULE_RESET_10:
 	case MODULE_RESET_29 ... MODULE_RESET_30:
-		reg  = 0xA;
+		reg = 0xA;
 		mask = 0x1 << (attr->index - MODULE_RESET_9);
 		break;
 	case MODULE_RESET_11 ... MODULE_RESET_12:
 	case MODULE_RESET_13 ... MODULE_RESET_14:
 	case MODULE_RESET_31 ... MODULE_RESET_32:
 	case MODULE_RESET_33 ... MODULE_RESET_34:
-		reg  = 0x8;
+		reg = 0x8;
 		mask = 0x1 << (attr->index - MODULE_RESET_11);
 		break;
 	case MODULE_RESET_15 ... MODULE_RESET_16:
 	case MODULE_RESET_17 ... MODULE_RESET_18:
 	case MODULE_RESET_35 ... MODULE_RESET_36:
 	case MODULE_RESET_37 ... MODULE_RESET_38:
-		reg  = 0x9;
+		reg = 0x9;
 		mask = 0x1 << (attr->index - MODULE_RESET_15);
 		break;
 	case MODULE_RESET_19 ... MODULE_RESET_20:
 	case MODULE_RESET_39 ... MODULE_RESET_40:
-		reg  = 0xA;
+		reg = 0xA;
 		mask = 0x1 << (attr->index - MODULE_RESET_19);
 		break;
-	case MODULE_RESET_41 ... MODULE_RESET_48: /*QSFP-DD*/
-		reg  = 0xA;
+	case MODULE_RESET_41 ... MODULE_RESET_48:	/*QSFP-DD */
+		reg = 0xA;
 		mask = 0x1 << (attr->index - MODULE_RESET_41);
 		break;
-	case MODULE_RESET_49 ... MODULE_RESET_53: /*QSFP-DD*/
-		reg  = 0xB;
+	case MODULE_RESET_49 ... MODULE_RESET_53:	/*QSFP-DD */
+		reg = 0xB;
 		mask = 0x1 << (attr->index - MODULE_RESET_49);
 		break;
 	default:
@@ -756,26 +767,27 @@ static ssize_t set_control(struct device *dev, struct device_attribute *da,
 	}
 
 	mutex_lock(&data->update_lock);
-	switch(data->index) {
-	/* Port 1-20, 41-42 present statuus: read from i2c bus number '12'
-		and CPLD slave address 0x62 */
+	switch (data->index) {
+		/* Port 1-20, 41-42 present statuus: read from i2c bus number '12'
+		   and CPLD slave address 0x62 */
 	case as7926_40xfb_cpld2:
-		bus  = 12;
+		bus = 12;
 		addr = 0x62;
 		break;
-	/* Port 21-40 present statuus: read from i2c bus number '13'
-		and CPLD slave address 0x63 */
+		/* Port 21-40 present statuus: read from i2c bus number '13'
+		   and CPLD slave address 0x63 */
 	case as7926_40xfb_cpld3:
-		bus  = 13;
+		bus = 13;
 		addr = 0x63;
 		break;
-	/* Port 41-53 plug-unplug read from i2c bus number '20'
-		and CPLD slave address 0x64 */
+		/* Port 41-53 plug-unplug read from i2c bus number '20'
+		   and CPLD slave address 0x64 */
 	case as7926_40xfb_cpld4:
-		bus  = 20;
+		bus = 20;
 		addr = 0x64;
 		break;
-	default: status = -ENXIO;
+	default:
+		status = -ENXIO;
 		goto exit;
 	}
 
@@ -797,7 +809,7 @@ static ssize_t set_control(struct device *dev, struct device_attribute *da,
 	mutex_unlock(&data->update_lock);
 	return count;
 
-exit:
+ exit:
 	mutex_unlock(&data->update_lock);
 	return status;
 }
@@ -805,11 +817,12 @@ exit:
 static void as7926_40xfb_cpld_add_client(struct i2c_client *client)
 {
 	struct cpld_client_node *node = kzalloc(sizeof(struct cpld_client_node),
-											GFP_KERNEL);
+						GFP_KERNEL);
 
 	if (!node) {
-		dev_dbg(&client->dev, "Can't allocate cpld_client_node (0x%x)\n",
-								client->addr);
+		dev_dbg(&client->dev,
+			"Can't allocate cpld_client_node (0x%x)\n",
+			client->addr);
 		return;
 	}
 
@@ -828,8 +841,7 @@ static void as7926_40xfb_cpld_remove_client(struct i2c_client *client)
 
 	mutex_lock(&list_lock);
 
-	list_for_each(list_node, &cpld_client_list)
-	{
+	list_for_each(list_node, &cpld_client_list) {
 		cpld_node = list_entry(list_node, struct cpld_client_node, list);
 
 		if (cpld_node->client == client) {
@@ -847,7 +859,7 @@ static void as7926_40xfb_cpld_remove_client(struct i2c_client *client)
 }
 
 static ssize_t access(struct device *dev, struct device_attribute *da,
-			const char *buf, size_t count)
+		      const char *buf, size_t count)
 {
 	int status;
 	u32 reg, val;
@@ -861,15 +873,19 @@ static ssize_t access(struct device *dev, struct device_attribute *da,
 		return -EINVAL;
 
 	mutex_lock(&data->update_lock);
-	switch(data->index) {
-	case as7926_40xfb_cpld2: status = as7926_40xfb_cpld_write(12,0x62, reg, val);
+	switch (data->index) {
+	case as7926_40xfb_cpld2:
+		status = as7926_40xfb_cpld_write(12, 0x62, reg, val);
 		break;
-	case as7926_40xfb_cpld3: status = as7926_40xfb_cpld_write(13,0x63, reg, val);
+	case as7926_40xfb_cpld3:
+		status = as7926_40xfb_cpld_write(13, 0x63, reg, val);
 		break;
-	case as7926_40xfb_cpld4: status = as7926_40xfb_cpld_write(20,0x64, reg, val);
+	case as7926_40xfb_cpld4:
+		status = as7926_40xfb_cpld_write(20, 0x64, reg, val);
 		break;
-	default: status = -ENXIO;
-			break;
+	default:
+		status = -ENXIO;
+		break;
 	}
 
 	if (unlikely(status < 0))
@@ -878,28 +894,32 @@ static ssize_t access(struct device *dev, struct device_attribute *da,
 	mutex_unlock(&data->update_lock);
 	return count;
 
-exit:
+ exit:
 	mutex_unlock(&data->update_lock);
 	return status;
 }
 
 static ssize_t show_version(struct device *dev, struct device_attribute *attr,
-							char *buf)
+			    char *buf)
 {
 	struct i2c_client *client = to_i2c_client(dev);
 	struct as7926_40xfb_cpld_data *data = i2c_get_clientdata(client);
 	int status = 0;
 
 	mutex_lock(&data->update_lock);
-	switch(data->index) {
-	case as7926_40xfb_cpld2: status = as7926_40xfb_cpld_read(12,0x62, 0x1);
+	switch (data->index) {
+	case as7926_40xfb_cpld2:
+		status = as7926_40xfb_cpld_read(12, 0x62, 0x1);
 		break;
-	case as7926_40xfb_cpld3: status = as7926_40xfb_cpld_read(13,0x63, 0x1);
+	case as7926_40xfb_cpld3:
+		status = as7926_40xfb_cpld_read(13, 0x63, 0x1);
 		break;
-	case as7926_40xfb_cpld4: status = as7926_40xfb_cpld_read(20,0x64, 0x1);
+	case as7926_40xfb_cpld4:
+		status = as7926_40xfb_cpld_read(20, 0x64, 0x1);
 		break;
-	default: status = -1;
-			break;
+	default:
+		status = -1;
+		break;
 	}
 
 	if (unlikely(status < 0)) {
@@ -910,20 +930,19 @@ static ssize_t show_version(struct device *dev, struct device_attribute *attr,
 	mutex_unlock(&data->update_lock);
 
 	return sprintf(buf, "%d\n", status);
-exit:
+ exit:
 	return status;
 }
 
-
 static int as7926_40xfb_cpld_probe(struct i2c_client *client,
-			const struct i2c_device_id *dev_id)
+				   const struct i2c_device_id *dev_id)
 {
 	int status;
 	struct as7926_40xfb_cpld_data *data = NULL;
 
 	if (!i2c_check_functionality(client->adapter, I2C_FUNC_SMBUS_BYTE_DATA)) {
 		dev_dbg(&client->dev, "i2c_check_functionality failed (0x%x)\n",
-								client->addr);
+			client->addr);
 		status = -EIO;
 		goto exit;
 	}
@@ -944,7 +963,9 @@ static int as7926_40xfb_cpld_probe(struct i2c_client *client,
 	if (status)
 		goto exit_free;
 
-	data->hwmon_dev = hwmon_device_register_with_info(&client->dev, DRVNAME, NULL, NULL, NULL);
+	data->hwmon_dev =
+	    hwmon_device_register_with_info(&client->dev, DRVNAME, NULL, NULL,
+					    NULL);
 	if (IS_ERR(data->hwmon_dev)) {
 		status = PTR_ERR(data->hwmon_dev);
 		goto exit_remove;
@@ -953,15 +974,15 @@ static int as7926_40xfb_cpld_probe(struct i2c_client *client,
 	as7926_40xfb_cpld_add_client(client);
 
 	dev_info(&client->dev, "%s: cpld '%s'\n",
-							dev_name(data->hwmon_dev), client->name);
+		 dev_name(data->hwmon_dev), client->name);
 
 	return 0;
 
-exit_remove:
+ exit_remove:
 	sysfs_remove_group(&client->dev.kobj, cpld_groups[data->index]);
-exit_free:
+ exit_free:
 	kfree(data);
-exit:
+ exit:
 
 	return status;
 }
@@ -979,9 +1000,9 @@ static int as7926_40xfb_cpld_remove(struct i2c_client *client)
 }
 
 static const struct i2c_device_id as7926_40xfb_cpld_id[] = {
-	{ "as7926_40xfb_cpld2", as7926_40xfb_cpld2 },
-	{ "as7926_40xfb_cpld3", as7926_40xfb_cpld3 },
-	{ "as7926_40xfb_cpld4", as7926_40xfb_cpld4 },
+	{"as7926_40xfb_cpld2", as7926_40xfb_cpld2},
+	{"as7926_40xfb_cpld3", as7926_40xfb_cpld3},
+	{"as7926_40xfb_cpld4", as7926_40xfb_cpld4},
 	{}
 };
 
@@ -990,8 +1011,8 @@ MODULE_DEVICE_TABLE(i2c, as7926_40xfb_cpld_id);
 static struct i2c_driver as7926_40xfb_cpld_driver = {
 	.class = I2C_CLASS_HWMON,
 	.driver = {
-		.name = DRVNAME,
-	},
+		   .name = DRVNAME,
+		   },
 	.probe = as7926_40xfb_cpld_probe,
 	.remove = as7926_40xfb_cpld_remove,
 	.id_table = as7926_40xfb_cpld_id,

--- a/packages/platforms/accton/x86-64/as7926-40xfb/modules/builds/x86-64-accton-as7926-40xfb-cpld.c
+++ b/packages/platforms/accton/x86-64/as7926-40xfb/modules/builds/x86-64-accton-as7926-40xfb-cpld.c
@@ -574,9 +574,9 @@ static ssize_t show_status(struct device *dev, struct device_attribute *da,
 		and CPLD slave address 0x63 */
 	case as7926_40xfb_cpld3: status = as7926_40xfb_cpld_read(13, 0x63, reg);
 		break;
-	/* Port 41-53 plug-unplug read from i2c bus number '76'
+	/* Port 41-53 plug-unplug read from i2c bus number '20'
 		and CPLD slave address 0x64 */
-	case as7926_40xfb_cpld4: status = as7926_40xfb_cpld_read(76, 0x64, reg);
+	case as7926_40xfb_cpld4: status = as7926_40xfb_cpld_read(20, 0x64, reg);
 		break;
 	default: status = -ENXIO;
 		break;
@@ -605,7 +605,7 @@ static ssize_t show_present_all(struct device *dev, struct device_attribute *da,
 	u8 *regs[] = { NULL, regs_cpld2, regs_cpld3, regs_cpld4 };
 	u8  size[] = { 0, ARRAY_SIZE(regs_cpld2),
 					ARRAY_SIZE(regs_cpld3),ARRAY_SIZE(regs_cpld3) };
-	u8 bus[] = { 0, 12, 13, 76 };
+	u8 bus[] = { 0, 12, 13, 20 };
 	u8 addr[] = { 0, 0x62, 0x63, 0x64 };
 	struct i2c_client *client = to_i2c_client(dev);
 	struct as7926_40xfb_cpld_data *data = i2c_get_clientdata(client);
@@ -769,10 +769,10 @@ static ssize_t set_control(struct device *dev, struct device_attribute *da,
 		bus  = 13;
 		addr = 0x63;
 		break;
-	/* Port 41-53 plug-unplug read from i2c bus number '76'
+	/* Port 41-53 plug-unplug read from i2c bus number '20'
 		and CPLD slave address 0x64 */
 	case as7926_40xfb_cpld4:
-		bus  = 76;
+		bus  = 20;
 		addr = 0x64;
 		break;
 	default: status = -ENXIO;
@@ -866,7 +866,7 @@ static ssize_t access(struct device *dev, struct device_attribute *da,
 		break;
 	case as7926_40xfb_cpld3: status = as7926_40xfb_cpld_write(13,0x63, reg, val);
 		break;
-	case as7926_40xfb_cpld4: status = as7926_40xfb_cpld_write(76,0x64, reg, val);
+	case as7926_40xfb_cpld4: status = as7926_40xfb_cpld_write(20,0x64, reg, val);
 		break;
 	default: status = -ENXIO;
 			break;
@@ -896,7 +896,7 @@ static ssize_t show_version(struct device *dev, struct device_attribute *attr,
 		break;
 	case as7926_40xfb_cpld3: status = as7926_40xfb_cpld_read(13,0x63, 0x1);
 		break;
-	case as7926_40xfb_cpld4: status = as7926_40xfb_cpld_read(76,0x64, 0x1);
+	case as7926_40xfb_cpld4: status = as7926_40xfb_cpld_read(20,0x64, 0x1);
 		break;
 	default: status = -1;
 			break;

--- a/packages/platforms/accton/x86-64/as7926-40xfb/modules/builds/x86-64-accton-as7926-40xfb-fan.c
+++ b/packages/platforms/accton/x86-64/as7926-40xfb/modules/builds/x86-64-accton-as7926-40xfb-fan.c
@@ -36,6 +36,7 @@
 #define ACCTON_IPMI_NETFN   0x34
 #define IPMI_FAN_READ_CMD   0x14
 #define IPMI_FAN_WRITE_CMD  0x15
+#define IPMI_FAN_READ_RPM_CMD 0x20
 #define IPMI_TIMEOUT		(5 * HZ)
 #define IPMI_ERR_RETRY_TIMES 1
 #define IPMI_FAN_REG_READ_CMD  0x20
@@ -49,6 +50,8 @@ static ssize_t show_fan(struct device *dev, struct device_attribute *attr,
 static ssize_t show_version(struct device *dev, struct device_attribute *da,
 			char *buf);
 static ssize_t show_dir(struct device *dev, struct device_attribute *da,
+			char *buf);
+static ssize_t show_threshold(struct device *dev, struct device_attribute *da,
 			char *buf);
 static int as7926_40xfb_fan_probe(struct platform_device *pdev);
 static int as7926_40xfb_fan_remove(struct platform_device *pdev);
@@ -73,13 +76,18 @@ enum fan_data_index {
 	FAN_PWM,
 	FAN_SPEED0,
 	FAN_SPEED1,
-	FAN_DATA_COUNT
+	FAN_DATA_COUNT,
+
+	FAN_TARGET_SPEED0 = 0,
+	FAN_TARGET_SPEED1,
+	FAN_SPEED_TOLERANCE,
+	FAN_SPEED_DATA_COUNT
 };
 
 struct ipmi_data {
 	struct completion read_complete;
 	struct ipmi_addr address;
-	ipmi_user_t user;
+	struct ipmi_user* user;
 	int interface;
 
 	struct kernel_ipmi_msg tx_message;
@@ -101,6 +109,7 @@ struct as7926_40xfb_fan_data {
 	/* 4 bytes for each fan, the last 2 bytes is fan dir */
 	unsigned char ipmi_resp[NUM_OF_FAN * FAN_DATA_COUNT + 2];
 	unsigned char ipmi_resp_cpld;
+	unsigned char ipmi_resp_speed[NUM_OF_FAN * FAN_SPEED_DATA_COUNT];
 	struct ipmi_data ipmi;
 	unsigned char ipmi_tx_data[3];  /* 0: FAN id, 1: 0x02, 2: PWM */
 };
@@ -120,12 +129,18 @@ static struct platform_driver as7926_40xfb_fan_driver = {
 #define FAN_PWM_ATTR_ID(index) FAN##index##_PWM
 #define FAN_RPM_ATTR_ID(index) FAN##index##_INPUT
 #define FAN_DIR_ATTR_ID(index) FAN##index##_DIR
+#define FAN_RPM_TARGET_ATTR_ID(index) FAN##index##_TARGET
+#define FAN_RPM_TOLERANCE_ATTR_ID(index) FAN##index##_TOLERANCE
 
 #define FAN_ATTR(fan_id) \
 	FAN_PRESENT_ATTR_ID(fan_id), \
 	FAN_PWM_ATTR_ID(fan_id), \
 	FAN_RPM_ATTR_ID(fan_id), \
 	FAN_DIR_ATTR_ID(fan_id)
+
+#define FAN_RPM_THRESHOLD_ATTR(fan_id) \
+	FAN_RPM_TARGET_ATTR_ID(fan_id), \
+	FAN_RPM_TOLERANCE_ATTR_ID(fan_id)
 
 enum as7926_40xfb_fan_sysfs_attrs {
 	FAN_ATTR(1),
@@ -141,6 +156,16 @@ enum as7926_40xfb_fan_sysfs_attrs {
 	NUM_OF_FAN_ATTR,
 	FAN_VERSION,
 	NUM_OF_PER_FAN_ATTR = (NUM_OF_FAN_ATTR/NUM_OF_FAN),
+	FAN_RPM_THRESHOLD_ATTR(1),
+	FAN_RPM_THRESHOLD_ATTR(2),
+	FAN_RPM_THRESHOLD_ATTR(3),
+	FAN_RPM_THRESHOLD_ATTR(4),
+	FAN_RPM_THRESHOLD_ATTR(5),
+	FAN_RPM_THRESHOLD_ATTR(6),
+	FAN_RPM_THRESHOLD_ATTR(7),
+	FAN_RPM_THRESHOLD_ATTR(8),
+	FAN_RPM_THRESHOLD_ATTR(9),
+	FAN_RPM_THRESHOLD_ATTR(10),
 };
 
 /* fan attributes */
@@ -157,12 +182,19 @@ enum as7926_40xfb_fan_sysfs_attrs {
 	static SENSOR_DEVICE_ATTR(fan##index##_input, S_IRUGO, show_fan, NULL, \
 								FAN##index##_INPUT); \
 	static SENSOR_DEVICE_ATTR(fan##index##_dir, S_IRUGO, show_dir, NULL, \
-								FAN##index##_DIR)
+								FAN##index##_DIR); \
+	static SENSOR_DEVICE_ATTR(fan##index##_target, S_IRUGO, show_threshold, \
+								NULL, FAN##index##_TARGET); \
+	static SENSOR_DEVICE_ATTR(fan##index##_tolerance, S_IRUGO, show_threshold, \
+								NULL, FAN##index##_TOLERANCE)
+
 #define DECLARE_FAN_ATTR(index) \
 	&sensor_dev_attr_fan##index##_present.dev_attr.attr, \
 	&sensor_dev_attr_fan##index##_pwm.dev_attr.attr, \
 	&sensor_dev_attr_fan##index##_input.dev_attr.attr, \
-	&sensor_dev_attr_fan##index##_dir.dev_attr.attr
+	&sensor_dev_attr_fan##index##_dir.dev_attr.attr, \
+	&sensor_dev_attr_fan##index##_target.dev_attr.attr, \
+	&sensor_dev_attr_fan##index##_tolerance.dev_attr.attr
 
 DECLARE_FAN_SENSOR_DEVICE_ATTR(1);
 DECLARE_FAN_SENSOR_DEVICE_ATTR(2);
@@ -349,6 +381,12 @@ static struct as7926_40xfb_fan_data *as7926_40xfb_fan_update_device(void)
 		status = -EIO;
 		goto exit;
 	}
+
+	data->ipmi_tx_data[0] = IPMI_FAN_READ_RPM_CMD;
+	status = ipmi_send_message(&data->ipmi, IPMI_FAN_READ_CMD,
+								data->ipmi_tx_data, 1,
+								data->ipmi_resp_speed,
+								sizeof(data->ipmi_resp_speed));
 
 	data->last_updated = jiffies;
 	data->valid = 1;
@@ -547,6 +585,68 @@ static ssize_t show_dir(struct device *dev, struct device_attribute *da,
 	else
 		return sprintf(buf, "%s\n",
 						(value & BIT(fid % NUM_OF_FAN_MODULE)) ? "B2F" : "F2B");
+
+exit:
+	mutex_unlock(&data->update_lock);
+	return error;
+}
+
+static ssize_t show_threshold(struct device *dev, struct device_attribute *da,
+			char *buf)
+{
+	struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
+	int value = 0;
+	int index = 0;
+	int error = 0;
+
+	mutex_lock(&data->update_lock);
+
+	data = as7926_40xfb_fan_update_device();
+	if (!data->valid) {
+		error = -EIO;
+		goto exit;
+	}
+
+	switch (attr->index) {
+    case FAN1_TARGET:
+    case FAN2_TARGET:
+    case FAN3_TARGET:
+    case FAN4_TARGET:
+    case FAN5_TARGET:
+        value = (int)data->ipmi_resp_speed[FAN_TARGET_SPEED0] |
+                (int)data->ipmi_resp_speed[FAN_TARGET_SPEED1] << 8;
+        break;
+    case FAN6_TARGET:
+    case FAN7_TARGET:
+    case FAN8_TARGET:
+    case FAN9_TARGET:
+    case FAN10_TARGET:
+        index = NUM_OF_FAN_MODULE * FAN_SPEED_DATA_COUNT;
+        value = (int)data->ipmi_resp_speed[index + FAN_TARGET_SPEED0] |
+                (int)data->ipmi_resp_speed[index + FAN_TARGET_SPEED1] << 8;
+        break;
+    case FAN1_TOLERANCE:
+    case FAN2_TOLERANCE:
+    case FAN3_TOLERANCE:
+    case FAN4_TOLERANCE:
+    case FAN5_TOLERANCE:
+        value = (int)data->ipmi_resp_speed[FAN_SPEED_TOLERANCE];
+        break;
+    case FAN6_TOLERANCE:
+    case FAN7_TOLERANCE:
+    case FAN8_TOLERANCE:
+    case FAN9_TOLERANCE:
+    case FAN10_TOLERANCE:
+        index = NUM_OF_FAN_MODULE * FAN_SPEED_DATA_COUNT;
+        value = (int)data->ipmi_resp_speed[index + FAN_SPEED_TOLERANCE];
+        break;
+    default:
+        error = -EINVAL;
+        goto exit;
+	}
+
+	mutex_unlock(&data->update_lock);
+	return sprintf(buf, "%d\n", value);
 
 exit:
 	mutex_unlock(&data->update_lock);

--- a/packages/platforms/accton/x86-64/as7926-40xfb/modules/builds/x86-64-accton-as7926-40xfb-leds.c
+++ b/packages/platforms/accton/x86-64/as7926-40xfb/modules/builds/x86-64-accton-as7926-40xfb-leds.c
@@ -49,7 +49,7 @@ static int as7926_40xfb_led_remove(struct platform_device *pdev);
 struct ipmi_data {
 	struct completion read_complete;
 	struct ipmi_addr address;
-	ipmi_user_t user;
+	struct ipmi_user* user;
 	int interface;
 
 	struct kernel_ipmi_msg tx_message;

--- a/packages/platforms/accton/x86-64/as7926-40xfb/modules/builds/x86-64-accton-as7926-40xfb-sys.c
+++ b/packages/platforms/accton/x86-64/as7926-40xfb/modules/builds/x86-64-accton-as7926-40xfb-sys.c
@@ -1,0 +1,388 @@
+/*
+ * Copyright (C)  Brandon Chuang <brandon_chuang@accton.com.tw>
+ *
+ * Based on:
+ *	pca954x.c from Kumar Gala <galak@kernel.crashing.org>
+ * Copyright (C) 2006
+ *
+ * Based on:
+ *	pca954x.c from Ken Harrenstien
+ * Copyright (C) 2004 Google, Inc. (Ken Harrenstien)
+ *
+ * Based on:
+ *	i2c-virtual_cb.c from Brian Kuschak <bkuschak@yahoo.com>
+ * and
+ *	pca9540.c from Jean Delvare <khali@linux-fr.org>.
+ *
+ * This file is licensed under the terms of the GNU General Public
+ * License version 2. This program is licensed "as is" without any
+ * warranty of any kind, whether express or implied.
+ */
+
+#include <linux/module.h>
+#include <linux/init.h>
+#include <linux/slab.h>
+#include <linux/device.h>
+#include <linux/version.h>
+#include <linux/stat.h>
+#include <linux/sysfs.h>
+#include <linux/hwmon-sysfs.h>
+#include <linux/ipmi.h>
+#include <linux/ipmi_smi.h>
+#include <linux/platform_device.h>
+
+#define DRVNAME "as7926_40xfb_sys"
+#define ACCTON_IPMI_NETFN       0x34
+
+#define IPMI_SYSEEPROM_READ_CMD 0x18
+#define IPMI_TIMEOUT		    (5 * HZ)
+#define IPMI_ERR_RETRY_TIMES    1
+#define IPMI_READ_MAX_LEN       128
+
+#define EEPROM_NAME				"eeprom"
+#define EEPROM_SIZE				256	/*	256 byte eeprom */
+
+static int as7926_40xfb_sys_probe(struct platform_device *pdev);
+static int as7926_40xfb_sys_remove(struct platform_device *pdev);
+static void ipmi_msg_handler(struct ipmi_recv_msg *msg, void *user_msg_data);
+
+struct ipmi_data {
+	struct completion   read_complete;
+	struct ipmi_addr	address;
+	struct ipmi_user    *user;
+	int                 interface;
+
+	struct kernel_ipmi_msg tx_message;
+	long                   tx_msgid;
+
+	void            *rx_msg_data;
+	unsigned short   rx_msg_len;
+	unsigned char    rx_result;
+	int              rx_recv_type;
+
+	struct ipmi_user_hndl ipmi_hndlrs;
+};
+
+struct as7926_40xfb_sys_data {
+    struct platform_device *pdev;
+    struct mutex     update_lock;
+    char             valid;           /* != 0 if registers are valid */
+    unsigned long    last_updated;    /* In jiffies */
+    struct ipmi_data ipmi;
+    unsigned char    ipmi_resp_eeprom[EEPROM_SIZE];
+    unsigned char    ipmi_tx_data[2];
+    struct bin_attribute eeprom;      /* eeprom data */
+};
+
+struct as7926_40xfb_sys_data *data = NULL;
+
+static struct platform_driver as7926_40xfb_sys_driver = {
+    .probe      = as7926_40xfb_sys_probe,
+    .remove     = as7926_40xfb_sys_remove,
+    .driver     = {
+        .name   = DRVNAME,
+        .owner  = THIS_MODULE,
+    },
+};
+
+/* Functions to talk to the IPMI layer */
+
+/* Initialize IPMI address, message buffers and user data */
+static int init_ipmi_data(struct ipmi_data *ipmi, int iface,
+			      struct device *dev)
+{
+	int err;
+
+	init_completion(&ipmi->read_complete);
+
+	/* Initialize IPMI address */
+	ipmi->address.addr_type = IPMI_SYSTEM_INTERFACE_ADDR_TYPE;
+	ipmi->address.channel = IPMI_BMC_CHANNEL;
+	ipmi->address.data[0] = 0;
+	ipmi->interface = iface;
+
+	/* Initialize message buffers */
+	ipmi->tx_msgid = 0;
+	ipmi->tx_message.netfn = ACCTON_IPMI_NETFN;
+
+    ipmi->ipmi_hndlrs.ipmi_recv_hndl = ipmi_msg_handler;
+
+	/* Create IPMI messaging interface user */
+	err = ipmi_create_user(ipmi->interface, &ipmi->ipmi_hndlrs,
+			       ipmi, &ipmi->user);
+	if (err < 0) {
+		dev_err(dev, "Unable to register user with IPMI "
+			"interface %d\n", ipmi->interface);
+		return -EACCES;
+	}
+
+	return 0;
+}
+
+/* Send an IPMI command */
+static int _ipmi_send_message(struct ipmi_data *ipmi, unsigned char cmd,
+                                     unsigned char *tx_data, unsigned short tx_len,
+                                     unsigned char *rx_data, unsigned short rx_len)
+{
+	int err;
+
+    ipmi->tx_message.cmd      = cmd;
+    ipmi->tx_message.data     = tx_data;
+    ipmi->tx_message.data_len = tx_len;
+    ipmi->rx_msg_data         = rx_data;
+    ipmi->rx_msg_len          = rx_len;
+
+	err = ipmi_validate_addr(&ipmi->address, sizeof(ipmi->address));
+	if (err)
+		goto addr_err;
+
+	ipmi->tx_msgid++;
+	err = ipmi_request_settime(ipmi->user, &ipmi->address, ipmi->tx_msgid,
+				   &ipmi->tx_message, ipmi, 0, 0, 0);
+	if (err)
+		goto ipmi_req_err;
+
+    err = wait_for_completion_timeout(&ipmi->read_complete, IPMI_TIMEOUT);
+	if (!err)
+		goto ipmi_timeout_err;
+
+	return 0;
+
+ipmi_timeout_err:
+    err = -ETIMEDOUT;
+    dev_err(&data->pdev->dev, "request_timeout=%x\n", err);
+    return err;
+ipmi_req_err:
+	dev_err(&data->pdev->dev, "request_settime=%x\n", err);
+	return err;
+addr_err:
+	dev_err(&data->pdev->dev, "validate_addr=%x\n", err);
+	return err;
+}
+
+/* Send an IPMI command with retry */
+static int ipmi_send_message(struct ipmi_data *ipmi, unsigned char cmd,
+                                     unsigned char *tx_data, unsigned short tx_len,
+                                     unsigned char *rx_data, unsigned short rx_len)
+{
+    int status = 0, retry = 0;
+
+    for (retry = 0; retry <= IPMI_ERR_RETRY_TIMES; retry++) {
+        status = _ipmi_send_message(ipmi, cmd, tx_data, tx_len, rx_data, rx_len);
+        if (unlikely(status != 0)) {
+            dev_err(&data->pdev->dev, "ipmi_send_message_%d err status(%d)\r\n", retry, status);
+            continue;
+        }
+
+        if (unlikely(ipmi->rx_result != 0)) {
+            dev_err(&data->pdev->dev, "ipmi_send_message_%d err rx_result(%d)\r\n", retry, ipmi->rx_result);
+            continue;
+        }
+
+        break;
+    }
+
+    return status;
+}
+
+/* Dispatch IPMI messages to callers */
+static void ipmi_msg_handler(struct ipmi_recv_msg *msg, void *user_msg_data)
+{
+	unsigned short rx_len;
+	struct ipmi_data *ipmi = user_msg_data;
+
+	if (msg->msgid != ipmi->tx_msgid) {
+		dev_err(&data->pdev->dev, "Mismatch between received msgid "
+			"(%02x) and transmitted msgid (%02x)!\n",
+			(int)msg->msgid,
+			(int)ipmi->tx_msgid);
+		ipmi_free_recv_msg(msg);
+		return;
+	}
+
+	ipmi->rx_recv_type = msg->recv_type;
+	if (msg->msg.data_len > 0)
+		ipmi->rx_result = msg->msg.data[0];
+	else
+		ipmi->rx_result = IPMI_UNKNOWN_ERR_COMPLETION_CODE;
+
+	if (msg->msg.data_len > 1) {
+		rx_len = msg->msg.data_len - 1;
+		if (ipmi->rx_msg_len < rx_len)
+			rx_len = ipmi->rx_msg_len;
+		ipmi->rx_msg_len = rx_len;
+		memcpy(ipmi->rx_msg_data, msg->msg.data + 1, ipmi->rx_msg_len);
+	} else
+		ipmi->rx_msg_len = 0;
+
+	ipmi_free_recv_msg(msg);
+	complete(&ipmi->read_complete);
+}
+
+static ssize_t sys_eeprom_read(loff_t off, char *buf, size_t count)
+{
+    int status = 0;
+    unsigned char length = 0;
+
+    if ((off + count) > EEPROM_SIZE) {
+        return -EINVAL;
+    }
+
+    length = (count >= IPMI_READ_MAX_LEN) ? IPMI_READ_MAX_LEN : count;
+    data->ipmi_tx_data[0] = (off & 0xff);
+    data->ipmi_tx_data[1] = length;
+    status = ipmi_send_message(&data->ipmi, IPMI_SYSEEPROM_READ_CMD,
+                                data->ipmi_tx_data, sizeof(data->ipmi_tx_data),
+                                data->ipmi_resp_eeprom + off, length);
+    if (unlikely(status != 0)) {
+        goto exit;
+    }
+
+    if (unlikely(data->ipmi.rx_result != 0)) {
+        status = -EIO;
+        goto exit;
+    }
+
+    status = length; /* Read length */
+    memcpy(buf, data->ipmi_resp_eeprom + off, length);
+
+exit:
+    return status;
+}
+
+static ssize_t sysfs_bin_read(struct file *filp, struct kobject *kobj,
+		struct bin_attribute *attr,
+		char *buf, loff_t off, size_t count)
+{
+	ssize_t retval = 0;
+
+	if (unlikely(!count)) {
+		return count;
+	}
+
+	/*
+	 * Read data from chip, protecting against concurrent updates
+	 * from this host
+	 */
+	mutex_lock(&data->update_lock);
+
+	while (count) {
+		ssize_t status;
+
+		status = sys_eeprom_read(off, buf, count);
+		if (status <= 0) {
+			if (retval == 0) {
+				retval = status;
+			}
+			break;
+		}
+
+		buf += status;
+		off += status;
+		count -= status;
+		retval += status;
+	}
+
+	mutex_unlock(&data->update_lock);
+	return retval;
+
+}
+
+static int sysfs_eeprom_init(struct kobject *kobj, struct bin_attribute *eeprom)
+{
+    sysfs_bin_attr_init(eeprom);
+	eeprom->attr.name = EEPROM_NAME;
+	eeprom->attr.mode = S_IRUGO;
+	eeprom->read	  = sysfs_bin_read;
+	eeprom->write	  = NULL;
+	eeprom->size	  = EEPROM_SIZE;
+
+	/* Create eeprom file */
+	return sysfs_create_bin_file(kobj, eeprom);
+}
+
+static int sysfs_eeprom_cleanup(struct kobject *kobj, struct bin_attribute *eeprom)
+{
+	sysfs_remove_bin_file(kobj, eeprom);
+	return 0;
+}
+
+static int as7926_40xfb_sys_probe(struct platform_device *pdev)
+{
+    int status = -1;
+
+    /* Register sysfs hooks */
+	status = sysfs_eeprom_init(&pdev->dev.kobj, &data->eeprom);
+	if (status) {
+		goto exit;
+	}
+
+    dev_info(&pdev->dev, "device created\n");
+
+    return 0;
+
+exit:
+    return status;
+}
+
+static int as7926_40xfb_sys_remove(struct platform_device *pdev)
+{
+    sysfs_eeprom_cleanup(&pdev->dev.kobj, &data->eeprom);
+
+    return 0;
+}
+
+static int __init as7926_40xfb_sys_init(void)
+{
+    int ret;
+
+    data = kzalloc(sizeof(struct as7926_40xfb_sys_data), GFP_KERNEL);
+    if (!data) {
+        ret = -ENOMEM;
+        goto alloc_err;
+    }
+
+	mutex_init(&data->update_lock);
+
+    ret = platform_driver_register(&as7926_40xfb_sys_driver);
+    if (ret < 0) {
+        goto dri_reg_err;
+    }
+
+    data->pdev = platform_device_register_simple(DRVNAME, -1, NULL, 0);
+    if (IS_ERR(data->pdev)) {
+        ret = PTR_ERR(data->pdev);
+        goto dev_reg_err;
+    }
+
+	/* Set up IPMI interface */
+	ret = init_ipmi_data(&data->ipmi, 0, &data->pdev->dev);
+	if (ret)
+		goto ipmi_err;
+
+    return 0;
+
+ipmi_err:
+    platform_device_unregister(data->pdev);
+dev_reg_err:
+    platform_driver_unregister(&as7926_40xfb_sys_driver);
+dri_reg_err:
+    kfree(data);
+alloc_err:
+    return ret;
+}
+
+static void __exit as7926_40xfb_sys_exit(void)
+{
+    ipmi_destroy_user(data->ipmi.user);
+    platform_device_unregister(data->pdev);
+    platform_driver_unregister(&as7926_40xfb_sys_driver);
+    kfree(data);
+}
+
+MODULE_AUTHOR("Brandon Chuang <brandon_chuang@accton.com.tw>");
+MODULE_DESCRIPTION("as7926_40xfb_sys driver");
+MODULE_LICENSE("GPL");
+
+module_init(as7926_40xfb_sys_init);
+module_exit(as7926_40xfb_sys_exit);

--- a/packages/platforms/accton/x86-64/as7926-40xfb/modules/builds/x86-64-accton-as7926-40xfb-thermal.c
+++ b/packages/platforms/accton/x86-64/as7926-40xfb/modules/builds/x86-64-accton-as7926-40xfb-thermal.c
@@ -1,5 +1,9 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
 /*
- * Copyright (C)  Brandon Chuang <brandon_chuang@accton.com.tw>
+ * A hwmon driver for the as7926_40xfb_thermal
+ *
+ * Copyright (C) 2019  Edgecore Networks Corporation.
+ * Brandon Chuang <brandon_chuang@edge-core.com>
  *
  * Based on:
  *	pca954x.c from Kumar Gala <galak@kernel.crashing.org>
@@ -42,9 +46,9 @@
 
 static void ipmi_msg_handler(struct ipmi_recv_msg *msg, void *user_msg_data);
 static ssize_t show_temp(struct device *dev, struct device_attribute *attr,
-	char *buf);
+			 char *buf);
 static ssize_t set_max(struct device *dev, struct device_attribute *da,
-			const char *buf, size_t count);
+		       const char *buf, size_t count);
 static int as7926_40xfb_thermal_probe(struct platform_device *pdev);
 static int as7926_40xfb_thermal_remove(struct platform_device *pdev);
 
@@ -58,7 +62,7 @@ enum temp_data_index {
 struct ipmi_data {
 	struct completion read_complete;
 	struct ipmi_addr address;
-	struct ipmi_user* user;
+	struct ipmi_user *user;
 	int interface;
 
 	struct kernel_ipmi_msg tx_message;
@@ -75,11 +79,11 @@ struct ipmi_data {
 struct as7926_40xfb_thermal_data {
 	struct platform_device *pdev;
 	struct mutex update_lock;
-	char valid;		   /* != 0 if registers are valid */
+	char valid;		/* != 0 if registers are valid */
 	unsigned long last_updated;	/* In jiffies */
-	char ipmi_resp[THERMAL_COUNT*TEMP_DATA_COUNT];/* 3 bytes for each thermal */
+	char ipmi_resp[THERMAL_COUNT * TEMP_DATA_COUNT];	/* 3 bytes for each thermal */
 	struct ipmi_data ipmi;
-	unsigned char ipmi_tx_data[2];  /* 0: thermal id, 1: temp */
+	unsigned char ipmi_tx_data[2];	/* 0: thermal id, 1: temp */
 	char temp_max[THERMAL_COUNT];
 };
 
@@ -89,9 +93,9 @@ static struct platform_driver as7926_40xfb_thermal_driver = {
 	.probe = as7926_40xfb_thermal_probe,
 	.remove = as7926_40xfb_thermal_remove,
 	.driver = {
-		.name = DRVNAME,
-		.owner = THIS_MODULE,
-	},
+		   .name = DRVNAME,
+		   .owner = THIS_MODULE,
+		   },
 };
 
 enum as7926_40xfb_thermal_sysfs_attrs {
@@ -159,8 +163,7 @@ static const struct attribute_group as7926_40xfb_thermal_group = {
 /* Functions to talk to the IPMI layer */
 
 /* Initialize IPMI address, message buffers and user data */
-static int init_ipmi_data(struct ipmi_data *ipmi, int iface,
-				  struct device *dev)
+static int init_ipmi_data(struct ipmi_data *ipmi, int iface, struct device *dev)
 {
 	int err;
 
@@ -180,7 +183,7 @@ static int init_ipmi_data(struct ipmi_data *ipmi, int iface,
 
 	/* Create IPMI messaging interface user */
 	err = ipmi_create_user(ipmi->interface, &ipmi->ipmi_hndlrs,
-				   ipmi, &ipmi->user);
+			       ipmi, &ipmi->user);
 	if (err < 0) {
 		dev_err(dev, "Unable to register user with IPMI "
 			"interface %d\n", ipmi->interface);
@@ -192,8 +195,8 @@ static int init_ipmi_data(struct ipmi_data *ipmi, int iface,
 
 /* Send an IPMI command */
 static int _ipmi_send_message(struct ipmi_data *ipmi, unsigned char cmd,
-								unsigned char *tx_data, unsigned short tx_len,
-								unsigned char *rx_data, unsigned short rx_len)
+			      unsigned char *tx_data, unsigned short tx_len,
+			      unsigned char *rx_data, unsigned short rx_len)
 {
 	int err;
 
@@ -219,36 +222,38 @@ static int _ipmi_send_message(struct ipmi_data *ipmi, unsigned char cmd,
 
 	return 0;
 
-ipmi_timeout_err:
+ ipmi_timeout_err:
 	err = -ETIMEDOUT;
 	dev_err(&data->pdev->dev, "request_timeout=%x\n", err);
 	return err;
-ipmi_req_err:
+ ipmi_req_err:
 	dev_err(&data->pdev->dev, "request_settime=%x\n", err);
 	return err;
-addr_err:
+ addr_err:
 	dev_err(&data->pdev->dev, "validate_addr=%x\n", err);
 	return err;
 }
 
 /* Send an IPMI command with retry */
 static int ipmi_send_message(struct ipmi_data *ipmi, unsigned char cmd,
-								unsigned char *tx_data, unsigned short tx_len,
-								unsigned char *rx_data, unsigned short rx_len)
+			     unsigned char *tx_data, unsigned short tx_len,
+			     unsigned char *rx_data, unsigned short rx_len)
 {
 	int status = 0, retry = 0;
 
 	for (retry = 0; retry <= IPMI_ERR_RETRY_TIMES; retry++) {
-		status = _ipmi_send_message(ipmi, cmd, tx_data, tx_len, rx_data, rx_len);
+		status = _ipmi_send_message(ipmi, cmd, tx_data, tx_len,rx_data, rx_len);
 		if (unlikely(status != 0)) {
-			dev_err(&data->pdev->dev, "ipmi_send_message_%d err status(%d)\r\n",
-										retry, status);
+			dev_err(&data->pdev->dev,
+				"ipmi_send_message_%d err status(%d)\r\n",
+				retry, status);
 			continue;
 		}
 
 		if (unlikely(ipmi->rx_result != 0)) {
-			dev_err(&data->pdev->dev, "ipmi_send_message_%d err result(%d)\r\n",
-										retry, ipmi->rx_result);
+			dev_err(&data->pdev->dev,
+				"ipmi_send_message_%d err result(%d)\r\n",
+				retry, ipmi->rx_result);
 			continue;
 		}
 
@@ -267,8 +272,7 @@ static void ipmi_msg_handler(struct ipmi_recv_msg *msg, void *user_msg_data)
 	if (msg->msgid != ipmi->tx_msgid) {
 		dev_err(&data->pdev->dev, "Mismatch between received msgid "
 			"(%02x) and transmitted msgid (%02x)!\n",
-			(int)msg->msgid,
-			(int)ipmi->tx_msgid);
+			(int)msg->msgid, (int)ipmi->tx_msgid);
 		ipmi_free_recv_msg(msg);
 		return;
 	}
@@ -293,16 +297,16 @@ static void ipmi_msg_handler(struct ipmi_recv_msg *msg, void *user_msg_data)
 }
 
 static ssize_t show_temp(struct device *dev, struct device_attribute *da,
-							char *buf)
+			 char *buf)
 {
 	int status = 0;
-	int index  = 0;
+	int index = 0;
 	struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
 
 	mutex_lock(&data->update_lock);
 
 	if (attr->index >= TEMP1_MAX && attr->index <= TEMP10_MAX) {
-		int max = data->temp_max[attr->index-TEMP1_MAX];
+		int max = data->temp_max[attr->index - TEMP1_MAX];
 		mutex_unlock(&data->update_lock);
 		return sprintf(buf, "%d\n", max * 1000);
 	}
@@ -310,8 +314,9 @@ static ssize_t show_temp(struct device *dev, struct device_attribute *da,
 	if (time_after(jiffies, data->last_updated + HZ * 5) || !data->valid) {
 		data->valid = 0;
 
-		status = ipmi_send_message(&data->ipmi, IPMI_THERMAL_READ_CMD, NULL, 0,
-									data->ipmi_resp, sizeof(data->ipmi_resp));
+		status = ipmi_send_message(&data->ipmi, IPMI_THERMAL_READ_CMD,
+				      NULL, 0, data->ipmi_resp,
+				      sizeof(data->ipmi_resp));
 		if (unlikely(status != 0))
 			goto exit;
 
@@ -333,18 +338,18 @@ static ssize_t show_temp(struct device *dev, struct device_attribute *da,
 
 	/* Get temperature in degree celsius */
 	index = attr->index * TEMP_DATA_COUNT + TEMP_INPUT;
-	status = ((s8)data->ipmi_resp[index]) * 1000;
+	status = ((s8) data->ipmi_resp[index]) * 1000;
 
 	mutex_unlock(&data->update_lock);
 	return sprintf(buf, "%d\n", status);
 
-exit:
+ exit:
 	mutex_unlock(&data->update_lock);
 	return status;
 }
 
 static ssize_t set_max(struct device *dev, struct device_attribute *da,
-			const char *buf, size_t count)
+		       const char *buf, size_t count)
 {
 	long temp;
 	int status;
@@ -358,7 +363,7 @@ static ssize_t set_max(struct device *dev, struct device_attribute *da,
 		return -EINVAL;
 
 	mutex_lock(&data->update_lock);
-	data->temp_max[attr->index-TEMP1_MAX] = temp;
+	data->temp_max[attr->index - TEMP1_MAX] = temp;
 	status = count;
 	mutex_unlock(&data->update_lock);
 
@@ -378,7 +383,7 @@ static int as7926_40xfb_thermal_probe(struct platform_device *pdev)
 
 	return 0;
 
-exit:
+ exit:
 	return status;
 }
 
@@ -419,18 +424,18 @@ static int __init as7926_40xfb_thermal_init(void)
 		goto ipmi_err;
 
 	for (i = 0; i < ARRAY_SIZE(data->temp_max); i++) {
-		data->temp_max[i] = 70; /* default high threshold */
+		data->temp_max[i] = 70;	/* default high threshold */
 	}
 
 	return 0;
 
-ipmi_err:
+ ipmi_err:
 	platform_device_unregister(data->pdev);
-dev_reg_err:
+ dev_reg_err:
 	platform_driver_unregister(&as7926_40xfb_thermal_driver);
-dri_reg_err:
+ dri_reg_err:
 	kfree(data);
-alloc_err:
+ alloc_err:
 	return ret;
 }
 

--- a/packages/platforms/accton/x86-64/as7926-40xfb/onlp/builds/x86_64_accton_as7926_40xfb/module/src/fani.c
+++ b/packages/platforms/accton/x86-64/as7926-40xfb/onlp/builds/x86_64_accton_as7926_40xfb/module/src/fani.c
@@ -36,7 +36,8 @@ enum fan_id {
     FAN_1_ON_PSU_2,
 };
 
-#define MAX_FAN_SPEED 18000
+#define MAX_FAN_FRONT_SPEED 18225
+#define MAX_FAN_REAR_SPEED  13950
 #define MAX_PSU_FAN_SPEED 25500
 
 #define CHASSIS_FAN_INFO(fid)        \
@@ -97,6 +98,7 @@ _onlp_fani_info_get_fan(int fid, onlp_fan_info_t* info)
     char *fandir = NULL;
     int   len = 0;
     int   value;
+    int   target_speed = MAX_FAN_FRONT_SPEED;
 
     /* get fan present status
      */
@@ -142,6 +144,7 @@ _onlp_fani_info_get_fan(int fid, onlp_fan_info_t* info)
      */
     if (info->rpm > value) {
         info->rpm = value;
+        target_speed = MAX_FAN_REAR_SPEED;
     }
 
     /* get fan fault status (turn on when any one fails)
@@ -152,7 +155,7 @@ _onlp_fani_info_get_fan(int fid, onlp_fan_info_t* info)
 
     /* get speed percentage from rpm
      */
-    info->percentage = (info->rpm * 100)/MAX_FAN_SPEED;
+    info->percentage = (info->rpm * 100)/target_speed;
 
     return ONLP_STATUS_OK;
 }
@@ -191,7 +194,7 @@ _onlp_fani_info_get_fan_on_psu(int pid, onlp_fan_info_t* info)
     /* get speed percentage from rpm
      */
     info->rpm = val;
-    info->percentage = (info->rpm * 100)/MAX_FAN_SPEED;
+    info->percentage = (info->rpm * 100)/MAX_PSU_FAN_SPEED;
 
     return ONLP_STATUS_OK;
 }

--- a/packages/platforms/accton/x86-64/as7926-40xfb/onlp/builds/x86_64_accton_as7926_40xfb/module/src/platform_lib.h
+++ b/packages/platforms/accton/x86-64/as7926-40xfb/onlp/builds/x86_64_accton_as7926_40xfb/module/src/platform_lib.h
@@ -30,7 +30,7 @@
 #include "x86_64_accton_as7926_40xfb_log.h"
 
 #define CHASSIS_FAN_COUNT     5
-#define CHASSIS_THERMAL_COUNT 12
+#define CHASSIS_THERMAL_COUNT 11
 #define CHASSIS_LED_COUNT     4
 #define CHASSIS_PSU_COUNT     2
 
@@ -39,7 +39,7 @@
 
 #define PSU_SYSFS_PATH "/sys/devices/platform/as7926_40xfb_psu/"
 #define FAN_BOARD_PATH "/sys/devices/platform/as7926_40xfb_fan/"
-#define IDPROM_PATH "/sys/class/i2c-adapter/i2c-0/0-0057/eeprom"
+#define IDPROM_PATH "/sys/devices/platform/as7926_40xfb_sys/eeprom"
 
 enum onlp_led_id
 {

--- a/packages/platforms/accton/x86-64/as7926-40xfb/onlp/builds/x86_64_accton_as7926_40xfb/module/src/sysi.c
+++ b/packages/platforms/accton/x86-64/as7926-40xfb/onlp/builds/x86_64_accton_as7926_40xfb/module/src/sysi.c
@@ -42,7 +42,7 @@
 static char* cpld_path[NUM_OF_CPLD] = {
     "/sys/bus/i2c/devices/12-0062/version",
     "/sys/bus/i2c/devices/13-0063/version",
-    "/sys/bus/i2c/devices/76-0064/version"
+    "/sys/bus/i2c/devices/20-0064/version"
 };
 
 const char*
@@ -111,7 +111,7 @@ onlp_sysi_platform_info_get(onlp_platform_info_t* pi)
         }
     }
 
-    pi->cpld_versions = aim_fstrdup("%d.%d.%d.%d.%d", v[0], v[1], v[2], v[3], v[4]);
+    pi->cpld_versions = aim_fstrdup("%d.%d.%d", v[0], v[1], v[2]);
     return ONLP_STATUS_OK;
 }
 

--- a/packages/platforms/accton/x86-64/as7926-40xfb/onlp/builds/x86_64_accton_as7926_40xfb/module/src/thermali.c
+++ b/packages/platforms/accton/x86-64/as7926-40xfb/onlp/builds/x86_64_accton_as7926_40xfb/module/src/thermali.c
@@ -37,6 +37,7 @@
 static char* ipmi_devfiles__[] = { /* must map with onlp_thermal_id */
     NULL,
     NULL, /* CPU_CORE files */
+    "/sys/devices/platform/as7926_40xfb_thermal/temp1_input",
     "/sys/devices/platform/as7926_40xfb_thermal/temp2_input",
     "/sys/devices/platform/as7926_40xfb_thermal/temp3_input",
     "/sys/devices/platform/as7926_40xfb_thermal/temp4_input",
@@ -46,8 +47,6 @@ static char* ipmi_devfiles__[] = { /* must map with onlp_thermal_id */
     "/sys/devices/platform/as7926_40xfb_thermal/temp8_input",
     "/sys/devices/platform/as7926_40xfb_thermal/temp9_input",
     "/sys/devices/platform/as7926_40xfb_thermal/temp10_input",
-    "/sys/devices/platform/as7926_40xfb_thermal/temp11_input",
-    "/sys/devices/platform/as7926_40xfb_thermal/temp12_input",
     "/sys/devices/platform/as7926_40xfb_psu/psu1_temp1_input",
     "/sys/devices/platform/as7926_40xfb_psu/psu2_temp1_input",
 };
@@ -68,10 +67,6 @@ static char* cpu_coretemp_files[] = {
 static onlp_thermal_info_t linfo[] = {
     { }, /* Not used */
     { { ONLP_THERMAL_ID_CREATE(THERMAL_CPU_CORE), "CPU Core", 0, {0} },
-            ONLP_THERMAL_STATUS_PRESENT,
-            ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
-        },
-    { { ONLP_THERMAL_ID_CREATE(THERMAL_1_ON_ASIC), "Main Board ASIC", 0, {0} },
             ONLP_THERMAL_STATUS_PRESENT,
             ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
         },

--- a/packages/platforms/accton/x86-64/as7926-40xfb/platform-config/r0/src/python/x86_64_accton_as7926_40xfb_r0/__init__.py
+++ b/packages/platforms/accton/x86-64/as7926-40xfb/platform-config/r0/src/python/x86_64_accton_as7926_40xfb_r0/__init__.py
@@ -1,6 +1,69 @@
+import commands
+from itertools import chain
 from onl.platform.base import *
 from onl.platform.accton import *
 from time import sleep
+
+init_ipmi_dev = [
+    'echo "remove,kcs,i/o,0xca2" > /sys/module/ipmi_si/parameters/hotmod',
+    'echo "add,kcs,i/o,0xca2" > /sys/module/ipmi_si/parameters/hotmod']
+
+ATTEMPTS = 5
+INTERVAL = 3
+
+def init_ipmi_dev_intf():
+    attempts = ATTEMPTS
+    interval = INTERVAL
+
+    while attempts:
+        if os.path.exists('/dev/ipmi0') or os.path.exists('/dev/ipmidev/0'):
+            return (True, (ATTEMPTS - attempts) * interval)
+
+        for i in range(0, len(init_ipmi_dev)):
+            commands.getstatusoutput(init_ipmi_dev[i])
+
+        attempts -= 1
+        sleep(interval)
+
+    return (False, ATTEMPTS * interval)
+
+def init_ipmi_oem_cmd():
+    attempts = ATTEMPTS
+    interval = INTERVAL
+
+    while attempts:
+        status, output = commands.getstatusoutput('ipmitool raw 0x34 0x95')
+        if status:
+            attempts -= 1
+            sleep(interval)
+            continue
+
+        return (True, (ATTEMPTS - attempts) * interval)
+
+    return (False, ATTEMPTS * interval)
+
+def init_ipmi():
+    attempts = ATTEMPTS
+    interval = 60
+
+    while attempts:
+        attempts -= 1
+
+        (status, elapsed_dev) = init_ipmi_dev_intf()
+        if status is not True:
+            sleep(interval - elapsed_dev)
+            continue
+
+        (status, elapsed_oem) = init_ipmi_oem_cmd()
+        if status is not True:
+            sleep(interval - elapsed_dev - elapsed_oem)
+            continue
+
+        print('IPMI dev interface is ready.')
+        return True
+
+    print('Failed to initialize IPMI dev interface')
+    return False
 
 class OnlPlatform_x86_64_accton_as7926_40xfb_r0(OnlPlatformAccton,
                                               OnlPlatformPortConfig_48x1_4x10):
@@ -9,8 +72,11 @@ class OnlPlatform_x86_64_accton_as7926_40xfb_r0(OnlPlatformAccton,
     SYS_OBJECT_ID=".7926.40"
 
     def baseconfig(self):
+        if init_ipmi() is not True:
+            return False
+
         self.insmod('optoe')
-        for m in [ 'cpld', 'fan', 'psu', 'leds', 'thermal' ]:
+        for m in [ 'cpld', 'fan', 'psu', 'leds', 'thermal', 'sys' ]:
             self.insmod("x86-64-accton-as7926-40xfb-%s.ko" % m)
 
         ########### initialize I2C bus 0 ###########
@@ -20,7 +86,7 @@ class OnlPlatform_x86_64_accton_as7926_40xfb_r0(OnlPlatformAccton,
 
                 # initiate  multiplexer (PCA9548) of bottom board
                 ('pca9548', 0x76, 1), # i2c 9-16
-                ('pca9548', 0x72, 2), # i2c 17-24
+                ('pca9548', 0x70, 1), # i2c 17-24
                 ('pca9548', 0x73, 9), # i2c 25-32
 
                 # initiate multiplexer for QSFP ports
@@ -31,25 +97,31 @@ class OnlPlatform_x86_64_accton_as7926_40xfb_r0(OnlPlatformAccton,
                 ('pca9548', 0x74, 29), # i2c 65-72
 
                 # initiate multiplexer for FAB ports
-                ('pca9548', 0x70, 1),  # i2c 73-80
-                ('pca9548', 0x74, 73), # i2c 81-88
-                ('pca9548', 0x74, 74), # i2c 89-96
+                ('pca9548', 0x74, 17), # i2c 73-80
+                ('pca9548', 0x74, 18), # i2c 81-88
 
                 #initiate CPLD
                 ('as7926_40xfb_cpld2', 0x62, 12),
                 ('as7926_40xfb_cpld3', 0x63, 13),
-                ('as7926_40xfb_cpld4', 0x64, 76),
-
-                ('24c02', 0x57, 0),
+                ('as7926_40xfb_cpld4', 0x64, 20)
                 ])
+
+        for port in chain(range(1, 11), range(21, 31)):
+            subprocess.call('echo 0 > /sys/bus/i2c/devices/12-0062/module_reset_%d' % port, shell=True)
+
+        for port in chain(range(11, 21), range(31, 41)):
+            subprocess.call('echo 0 > /sys/bus/i2c/devices/13-0063/module_reset_%d' % port, shell=True)
+
+        for port in range(41, 54):
+            subprocess.call('echo 0 > /sys/bus/i2c/devices/20-0064/module_reset_%d' % port, shell=True)
 
         # initialize QSFP port(0-39), FAB port(40-52)
         port_i2c_bus = [33, 34, 37, 38, 41, 42, 45, 46, 49, 50,
                         53, 54, 57, 58, 61, 62, 65, 66, 69, 70,
                         35, 36, 39, 40, 43, 44, 47, 48, 51, 52,
                         55, 56, 59, 60, 63, 64, 67, 68, 71, 72,
-                        93, 84, 83, 82, 81, 86, 85, 88, 87, 90,
-                        89, 92, 91]
+                        85, 76, 75, 74, 73, 78, 77, 80, 79, 82,
+                        81, 84, 83]
 
         for port in range(0, 53):
             self.new_i2c_device('optoe1', 0x50, port_i2c_bus[port])


### PR DESCRIPTION
- Remove i2c mux 0x72 which is used by BMC
- Use GNU indent to format peripheral drivers
- Add BMC detection in __init__.py
- Add ONLP_SFP_CONTROL_RESET in sfp.py

Signed-off-by: Brandon Chuang <brandon_chuang@edge-core.com>