### PR TITLE
[Edgecore][as7816-64x] Correct the value of input current

### DIFF
--- a/packages/platforms/accton/x86-64/as7816-64x/onlp/builds/x86_64_accton_as7816_64x/module/src/psui.c
+++ b/packages/platforms/accton/x86-64/as7816-64x/onlp/builds/x86_64_accton_as7816_64x/module/src/psui.c
@@ -148,6 +148,7 @@ psu_dps850_info_get(onlp_psu_info_t* info)
     }
 
     if (psu_dps850_pmbus_info_get(index, "psu_i_in", &val) == 0) {
+        info->miin = val;
         info->caps |= ONLP_PSU_CAPS_IIN;
     }
 


### PR DESCRIPTION
The "miin" is not assigned after reading from PSU.
Set the value to fix zero input current.

    psu @ 1 = {
        Description: PSU-2
        Model:  DPS-850A
        SN:     JKFD92L000T
        Status: 0x00000001 [ PRESENT ]
        Caps:   0x000001f9 [ AC,VIN,VOUT,IIN,IOUT,PIN,POUT ]
        Vin:    117876
        Vout:   12046
        Iin:    873
        Iout:   7859
        Pin:    103500
        Pout:   94625

Signed-off-by: brandonchuang <brandon_chuang@edge-core.com>