### PR TITLE
[Edgecore] added kernel parameter

### DIFF
--- a/packages/platforms/accton/x86-64/as4630-54pe/platform-config/r0/src/lib/x86-64-accton-as4630-54pe-r0.yml
+++ b/packages/platforms/accton/x86-64/as4630-54pe/platform-config/r0/src/lib/x86-64-accton-as4630-54pe-r0.yml
@@ -24,6 +24,7 @@ x86-64-accton-as4630-54pe-r0:
       nopat
       console=ttyS0,115200n8
       intel_iommu=off
+      pcie_aspm=off
 
   network:
     interfaces:

--- a/packages/platforms/accton/x86-64/as4630-54te/platform-config/r0/src/lib/x86-64-accton-as4630-54te-r0.yml
+++ b/packages/platforms/accton/x86-64/as4630-54te/platform-config/r0/src/lib/x86-64-accton-as4630-54te-r0.yml
@@ -23,6 +23,7 @@ x86-64-accton-as4630-54te-r0:
     args: >-
       console=ttyS0,115200n8
       intel_iommu=pt
+      pcie_aspm=off
 
   network:
     interfaces:

--- a/packages/platforms/accton/x86-64/as5712-54x/platform-config/r0/src/lib/x86-64-accton-as5712-54x-r0.yml
+++ b/packages/platforms/accton/x86-64/as5712-54x/platform-config/r0/src/lib/x86-64-accton-as5712-54x-r0.yml
@@ -23,6 +23,7 @@ x86-64-accton-as5712-54x-r0:
     args: >-
       nopat
       console=ttyS1,115200n8
+      pcie_aspm=off
 
   ##network
   ##  interfaces:

--- a/packages/platforms/accton/x86-64/as5812-54t/platform-config/r0/src/lib/x86-64-accton-as5812-54t-r0.yml
+++ b/packages/platforms/accton/x86-64/as5812-54t/platform-config/r0/src/lib/x86-64-accton-as5812-54t-r0.yml
@@ -23,6 +23,7 @@ x86-64-accton-as5812-54t-r0:
     args: >-
       nopat
       console=ttyS1,115200n8
+      pcie_aspm=off
 
   ##network
   ##  interfaces:

--- a/packages/platforms/accton/x86-64/as5812-54x/platform-config/r0/src/lib/x86-64-accton-as5812-54x-r0.yml
+++ b/packages/platforms/accton/x86-64/as5812-54x/platform-config/r0/src/lib/x86-64-accton-as5812-54x-r0.yml
@@ -23,6 +23,7 @@ x86-64-accton-as5812-54x-r0:
     args: >-
       nopat
       console=ttyS1,115200n8
+      pcie_aspm=off
 
   ##network
   ##  interfaces:

--- a/packages/platforms/accton/x86-64/as5835-54t/platform-config/r0/src/lib/x86-64-accton-as5835-54t-r0.yml
+++ b/packages/platforms/accton/x86-64/as5835-54t/platform-config/r0/src/lib/x86-64-accton-as5835-54t-r0.yml
@@ -24,6 +24,7 @@ x86-64-accton-as5835-54t-r0:
       nopat
       console=ttyS0,115200n8
       intel_iommu=off
+      pcie_aspm=off
 
   ##network
   ##  interfaces:

--- a/packages/platforms/accton/x86-64/as5835-54x/platform-config/r0/src/lib/x86-64-accton-as5835-54x-r0.yml
+++ b/packages/platforms/accton/x86-64/as5835-54x/platform-config/r0/src/lib/x86-64-accton-as5835-54x-r0.yml
@@ -24,6 +24,7 @@ x86-64-accton-as5835-54x-r0:
       nopat
       console=ttyS0,115200n8
       intel_iommu=off
+      pcie_aspm=off
 
   ##network
   ##  interfaces:

--- a/packages/platforms/accton/x86-64/as5912-54x/platform-config/r0/src/lib/x86-64-accton-as5912-54x-r0.yml
+++ b/packages/platforms/accton/x86-64/as5912-54x/platform-config/r0/src/lib/x86-64-accton-as5912-54x-r0.yml
@@ -23,6 +23,7 @@ x86-64-accton-as5912-54x-r0:
     args: >-
       nopat
       console=ttyS1,115200n8
+      pcie_aspm=off
 
   ##network
   ##  interfaces:

--- a/packages/platforms/accton/x86-64/as5912-54xk/platform-config/r0/src/lib/x86-64-accton-as5912-54xk-r0.yml
+++ b/packages/platforms/accton/x86-64/as5912-54xk/platform-config/r0/src/lib/x86-64-accton-as5912-54xk-r0.yml
@@ -23,6 +23,7 @@ x86-64-accton-as5912-54xk-r0:
     args: >-
       nopat
       console=ttyS1,115200n8
+      pcie_aspm=off
 
   ##network
   ##  interfaces:

--- a/packages/platforms/accton/x86-64/as5915-18x/platform-config/r0/src/lib/x86-64-accton-as5915-18x-r0.yml
+++ b/packages/platforms/accton/x86-64/as5915-18x/platform-config/r0/src/lib/x86-64-accton-as5915-18x-r0.yml
@@ -23,6 +23,7 @@ x86-64-accton-as5915-18x-r0:
     args: >-
       console=ttyS0,115200n8
       intel_iommu=pt
+      pcie_aspm=off
 
   ##network
   ##  interfaces:

--- a/packages/platforms/accton/x86-64/as5916-26xb/platform-config/r0/src/lib/x86-64-accton-as5916-26xb-r0.yml
+++ b/packages/platforms/accton/x86-64/as5916-26xb/platform-config/r0/src/lib/x86-64-accton-as5916-26xb-r0.yml
@@ -25,6 +25,7 @@ x86-64-accton-as5916-26xb-r0:
       console=ttyS0,115200n8
       tg3.short_preamble=1
       tg3.bcm5718s_reset=1
+      pcie_aspm=off
 
   ##network:
   ##  interfaces:

--- a/packages/platforms/accton/x86-64/as5916-54x/platform-config/r1/src/lib/x86-64-accton-as5916-54x-r1.yml
+++ b/packages/platforms/accton/x86-64/as5916-54x/platform-config/r1/src/lib/x86-64-accton-as5916-54x-r1.yml
@@ -25,6 +25,7 @@ x86-64-accton-as5916-54x-r1:
       console=ttyS0,115200n8
       tg3.short_preamble=1
       tg3.bcm5718s_reset=1
+      pcie_aspm=off
 
   ##network:
   ##  interfaces:

--- a/packages/platforms/accton/x86-64/as5916-54xk/platform-config/r1/src/lib/x86-64-accton-as5916-54xk-r1.yml
+++ b/packages/platforms/accton/x86-64/as5916-54xk/platform-config/r1/src/lib/x86-64-accton-as5916-54xk-r1.yml
@@ -25,6 +25,7 @@ x86-64-accton-as5916-54xk-r1:
       console=ttyS0,115200n8
       tg3.short_preamble=1
       tg3.bcm5718s_reset=1
+      pcie_aspm=off
 
   ##network:
   ##  interfaces:

--- a/packages/platforms/accton/x86-64/as5916-54xks/platform-config/r0/src/lib/x86-64-accton-as5916-54xks-r0.yml
+++ b/packages/platforms/accton/x86-64/as5916-54xks/platform-config/r0/src/lib/x86-64-accton-as5916-54xks-r0.yml
@@ -26,6 +26,7 @@ x86-64-accton-as5916-54xks-r0:
       tg3.short_preamble=1
       tg3.bcm5718s_reset=1
       intel_iommu=off
+      pcie_aspm=off
 
   ##network:
   ##  interfaces:

--- a/packages/platforms/accton/x86-64/as5916-54xl/platform-config/r0/src/lib/x86-64-accton-as5916-54xl-r0.yml
+++ b/packages/platforms/accton/x86-64/as5916-54xl/platform-config/r0/src/lib/x86-64-accton-as5916-54xl-r0.yml
@@ -25,6 +25,7 @@ x86-64-accton-as5916-54xl-r0:
       console=ttyS0,115200n8
       tg3.short_preamble=1
       tg3.bcm5718s_reset=1
+      pcie_aspm=off
 
   ##network:
   ##  interfaces:

--- a/packages/platforms/accton/x86-64/as5916-54xm/platform-config/r0/src/lib/x86-64-accton-as5916-54xm-r0.yml
+++ b/packages/platforms/accton/x86-64/as5916-54xm/platform-config/r0/src/lib/x86-64-accton-as5916-54xm-r0.yml
@@ -25,6 +25,7 @@ x86-64-accton-as5916-54xm-r0:
       console=ttyS0,115200n8
       tg3.short_preamble=1
       tg3.bcm5718s_reset=1
+      pcie_aspm=off
 
   ##network:
   ##  interfaces:

--- a/packages/platforms/accton/x86-64/as6712-32x/platform-config/r0/src/lib/x86-64-accton-as6712-32x-r0.yml
+++ b/packages/platforms/accton/x86-64/as6712-32x/platform-config/r0/src/lib/x86-64-accton-as6712-32x-r0.yml
@@ -23,6 +23,7 @@ x86-64-accton-as6712-32x-r0:
     args: >-
       nopat
       console=ttyS1,115200n8
+      pcie_aspm=off
 
   ##network
   ##  interfaces:

--- a/packages/platforms/accton/x86-64/as6812-32x/platform-config/r0/src/lib/x86-64-accton-as6812-32x-r0.yml
+++ b/packages/platforms/accton/x86-64/as6812-32x/platform-config/r0/src/lib/x86-64-accton-as6812-32x-r0.yml
@@ -23,6 +23,7 @@ x86-64-accton-as6812-32x-r0:
     args: >-
       nopat
       console=ttyS1,115200n8
+      pcie_aspm=off
 
   ##network
   ##  interfaces:

--- a/packages/platforms/accton/x86-64/as7312-54x/platform-config/r0/src/lib/x86-64-accton-as7312-54x-r0.yml
+++ b/packages/platforms/accton/x86-64/as7312-54x/platform-config/r0/src/lib/x86-64-accton-as7312-54x-r0.yml
@@ -25,6 +25,7 @@ x86-64-accton-as7312-54x-r0:
       console=ttyS1,115200n8
       i2c-ismt.bus_speed=100
       i2c-ismt.delay=100
+      pcie_aspm=off
 
   ##network
   ##  interfaces:

--- a/packages/platforms/accton/x86-64/as7312-54xs/platform-config/r0/src/lib/x86-64-accton-as7312-54xs-r0.yml
+++ b/packages/platforms/accton/x86-64/as7312-54xs/platform-config/r0/src/lib/x86-64-accton-as7312-54xs-r0.yml
@@ -25,6 +25,7 @@ x86-64-accton-as7312-54xs-r0:
       console=ttyS1,115200n8
       i2c-ismt.bus_speed=100
       i2c-ismt.delay=100
+      pcie_aspm=off
 
   ##network
   ##  interfaces:

--- a/packages/platforms/accton/x86-64/as7315-27xb/platform-config/r0/src/lib/x86-64-accton-as7315-27xb-r0.yml
+++ b/packages/platforms/accton/x86-64/as7315-27xb/platform-config/r0/src/lib/x86-64-accton-as7315-27xb-r0.yml
@@ -26,6 +26,7 @@ x86-64-accton-as7315-27xb-r0:
       tg3.short_preamble=1
       tg3.bcm5718s_reset=1
       intel_iommu=off
+      pcie_aspm=off
 
   ##network:
   ##  interfaces:

--- a/packages/platforms/accton/x86-64/as7315-30x/platform-config/r0/src/lib/x86-64-accton-as7315-30x-r0.yml
+++ b/packages/platforms/accton/x86-64/as7315-30x/platform-config/r0/src/lib/x86-64-accton-as7315-30x-r0.yml
@@ -23,6 +23,7 @@ x86-64-accton-as7315-30x-r0:
     args: >-
       console=ttyS0,115200n8
       intel_iommu=pt
+      pcie_aspm=off
 
   ##network
   ##  interfaces:

--- a/packages/platforms/accton/x86-64/as7316-26xb/platform-config/r0/src/lib/x86-64-accton-as7316-26xb-r0.yml
+++ b/packages/platforms/accton/x86-64/as7316-26xb/platform-config/r0/src/lib/x86-64-accton-as7316-26xb-r0.yml
@@ -25,6 +25,7 @@ x86-64-accton-as7316-26xb-r0:
       console=ttyS0,115200n8
       tg3.short_preamble=1
       tg3.bcm5718s_reset=1
+      pcie_aspm=off
 
   ##network:
   ##  interfaces:

--- a/packages/platforms/accton/x86-64/as7326-56x/platform-config/r0/src/lib/x86-64-accton-as7326-56x-r0.yml
+++ b/packages/platforms/accton/x86-64/as7326-56x/platform-config/r0/src/lib/x86-64-accton-as7326-56x-r0.yml
@@ -23,6 +23,7 @@ x86-64-accton-as7326-56x-r0:
     args: >-
       nopat
       console=ttyS0,115200n8
+      pcie_aspm=off
 
   ##network:
   ##  interfaces:

--- a/packages/platforms/accton/x86-64/as7535-28xb/platform-config/r0/src/lib/x86-64-accton-as7535-28xb-r0.yml
+++ b/packages/platforms/accton/x86-64/as7535-28xb/platform-config/r0/src/lib/x86-64-accton-as7535-28xb-r0.yml
@@ -23,6 +23,7 @@ x86-64-accton-as7535-28xb-r0:
     args: >-
       console=ttyS0,115200n8
       intel_iommu=pt
+      pcie_aspm=off
 
   ##network
   ##  interfaces:

--- a/packages/platforms/accton/x86-64/as7712-32x/platform-config/r0/src/lib/x86-64-accton-as7712-32x-r0.yml
+++ b/packages/platforms/accton/x86-64/as7712-32x/platform-config/r0/src/lib/x86-64-accton-as7712-32x-r0.yml
@@ -23,6 +23,7 @@ x86-64-accton-as7712-32x-r0:
     args: >-
       nopat
       console=ttyS1,115200n8
+      pcie_aspm=off
 
   ##network
   ##  interfaces:

--- a/packages/platforms/accton/x86-64/as7716-24sc/platform-config/r0/src/lib/x86-64-accton-as7716-24sc-r0.yml
+++ b/packages/platforms/accton/x86-64/as7716-24sc/platform-config/r0/src/lib/x86-64-accton-as7716-24sc-r0.yml
@@ -25,6 +25,7 @@ x86-64-accton-as7716-24sc-r0:
       console=ttyS0,115200n8
       tg3.short_preamble=1
       tg3.bcm5718s_reset=1
+      pcie_aspm=off
 
   ##network:
   ##  interfaces:

--- a/packages/platforms/accton/x86-64/as7716-24xc/platform-config/r0/src/lib/x86-64-accton-as7716-24xc-r0.yml
+++ b/packages/platforms/accton/x86-64/as7716-24xc/platform-config/r0/src/lib/x86-64-accton-as7716-24xc-r0.yml
@@ -25,6 +25,7 @@ x86-64-accton-as7716-24xc-r0:
       console=ttyS0,115200n8
       tg3.short_preamble=1
       tg3.bcm5718s_reset=1
+      pcie_aspm=off
 
   ##network:
   ##  interfaces:

--- a/packages/platforms/accton/x86-64/as7716-32x/platform-config/r0/src/lib/x86-64-accton-as7716-32x-r0.yml
+++ b/packages/platforms/accton/x86-64/as7716-32x/platform-config/r0/src/lib/x86-64-accton-as7716-32x-r0.yml
@@ -25,6 +25,7 @@ x86-64-accton-as7716-32x-r0:
       console=ttyS0,115200n8
       tg3.short_preamble=1
       tg3.bcm5718s_reset=1
+      pcie_aspm=off
 
   ##network:
   ##  interfaces:

--- a/packages/platforms/accton/x86-64/as7726-32x/platform-config/r0/src/lib/x86-64-accton-as7726-32x-r0.yml
+++ b/packages/platforms/accton/x86-64/as7726-32x/platform-config/r0/src/lib/x86-64-accton-as7726-32x-r0.yml
@@ -23,6 +23,7 @@ x86-64-accton-as7726-32x-r0:
     args: >-
       nopat
       console=ttyS0,115200n8
+      pcie_aspm=off
 
   ##network
   ##  interfaces:

--- a/packages/platforms/accton/x86-64/as7816-64x/platform-config/r0/src/lib/x86-64-accton-as7816-64x-r0.yml
+++ b/packages/platforms/accton/x86-64/as7816-64x/platform-config/r0/src/lib/x86-64-accton-as7816-64x-r0.yml
@@ -25,6 +25,7 @@ x86-64-accton-as7816-64x-r0:
       console=ttyS0,115200n8
       tg3.short_preamble=1
       tg3.bcm5718s_reset=1
+      pcie_aspm=off
 
   ##network:
   ##  interfaces:

--- a/packages/platforms/accton/x86-64/as7926-40xfb/platform-config/r0/src/lib/x86-64-accton-as7926-40xfb-r0.yml
+++ b/packages/platforms/accton/x86-64/as7926-40xfb/platform-config/r0/src/lib/x86-64-accton-as7926-40xfb-r0.yml
@@ -23,6 +23,7 @@ x86-64-accton-as7926-40xfb-r0:
     args: >-
       console=ttyS0,115200n8
       intel_iommu=pt
+      pcie_aspm=off
 
   ##network
   ##  interfaces:

--- a/packages/platforms/accton/x86-64/as7926-40xke/platform-config/r0/src/lib/x86-64-accton-as7926-40xke-r0.yml
+++ b/packages/platforms/accton/x86-64/as7926-40xke/platform-config/r0/src/lib/x86-64-accton-as7926-40xke-r0.yml
@@ -25,6 +25,7 @@ x86-64-accton-as7926-40xke-r0:
       console=ttyS0,115200n8
       tg3.short_preamble=1
       tg3.bcm5718s_reset=1
+      pcie_aspm=off
 
   ##network:
   ##  interfaces:

--- a/packages/platforms/accton/x86-64/as7926-80xk/platform-config/r0/src/lib/x86-64-accton-as7926-80xk-r0.yml
+++ b/packages/platforms/accton/x86-64/as7926-80xk/platform-config/r0/src/lib/x86-64-accton-as7926-80xk-r0.yml
@@ -25,6 +25,7 @@ x86-64-accton-as7926-80xk-r0:
       console=ttyS0,115200n8
       tg3.short_preamble=1
       tg3.bcm5718s_reset=1
+      pcie_aspm=off
 
   ##network:
   ##  interfaces:

--- a/packages/platforms/accton/x86-64/as7936-22xke/platform-config/r0/src/lib/x86-64-accton-as7936-22xke-r0.yml
+++ b/packages/platforms/accton/x86-64/as7936-22xke/platform-config/r0/src/lib/x86-64-accton-as7936-22xke-r0.yml
@@ -25,6 +25,7 @@ x86-64-accton-as7936-22xke-r0:
       console=ttyS0,115200n8
       tg3.short_preamble=1
       tg3.bcm5718s_reset=1
+      pcie_aspm=off
 
   ##network:
   ##  interfaces:

--- a/packages/platforms/accton/x86-64/as7946-74xkb/platform-config/r0/src/lib/x86-64-accton-as7946-74xkb-r0.yml
+++ b/packages/platforms/accton/x86-64/as7946-74xkb/platform-config/r0/src/lib/x86-64-accton-as7946-74xkb-r0.yml
@@ -23,6 +23,7 @@ x86-64-accton-as7946-74xkb-r0:
     args: >-
       console=ttyS0,115200n8
       intel_iommu=pt
+      pcie_aspm=off
 
   ##network
   ##  interfaces:

--- a/packages/platforms/accton/x86-64/as9716_32d/platform-config/r0/src/lib/x86-64-accton-as9716-32d-r0.yml
+++ b/packages/platforms/accton/x86-64/as9716_32d/platform-config/r0/src/lib/x86-64-accton-as9716-32d-r0.yml
@@ -23,6 +23,7 @@ x86-64-accton-as9716-32d-r0:
     args: >-
       nopat
       console=ttyS0,115200n8
+      pcie_aspm=off
 
   ##network:
   ##  interfaces:

--- a/packages/platforms/accton/x86-64/as9926-24d/platform-config/r0/src/lib/x86-64-accton-as9926-24d-r0.yml
+++ b/packages/platforms/accton/x86-64/as9926-24d/platform-config/r0/src/lib/x86-64-accton-as9926-24d-r0.yml
@@ -24,6 +24,7 @@ x86-64-accton-as9926-24d-r0:
       nopat
       console=ttyS0,115200n8
       intel_iommu=off
+      pcie_aspm=off
 
   ##network
   ##  interfaces:

--- a/packages/platforms/accton/x86-64/asgvolt64/platform-config/r0/src/lib/x86-64-accton-asgvolt64-r0.yml
+++ b/packages/platforms/accton/x86-64/asgvolt64/platform-config/r0/src/lib/x86-64-accton-asgvolt64-r0.yml
@@ -26,6 +26,7 @@ x86-64-accton-asgvolt64-r0:
       tg3.short_preamble=1
       tg3.bcm5718s_reset=1
       intel_iommu=off
+      pcie_aspm=off
 
   ##network:
   ##  interfaces:

--- a/packages/platforms/accton/x86-64/asxvolt16/platform-config/r0/src/lib/x86-64-accton-asxvolt16-r0.yml
+++ b/packages/platforms/accton/x86-64/asxvolt16/platform-config/r0/src/lib/x86-64-accton-asxvolt16-r0.yml
@@ -26,6 +26,7 @@ x86-64-accton-asxvolt16-r0:
       tg3.short_preamble=1
       tg3.bcm5718s_reset=1
       intel_iommu=off
+      pcie_aspm=off
 
   ##network:
   ##  interfaces:

--- a/packages/platforms/accton/x86-64/es7632bt3/platform-config/r0/src/lib/x86-64-accton-es7632bt3-r0.yml
+++ b/packages/platforms/accton/x86-64/es7632bt3/platform-config/r0/src/lib/x86-64-accton-es7632bt3-r0.yml
@@ -22,6 +22,7 @@ x86-64-accton-es7632bt3-r0:
     args: >-
       console=ttyS0,115200n8
       intel_iommu=pt
+      pcie_aspm=off
 
 
   ##network

--- a/packages/platforms/accton/x86-64/minipack/platform-config/r0/src/lib/x86-64-accton-minipack-r0.yml
+++ b/packages/platforms/accton/x86-64/minipack/platform-config/r0/src/lib/x86-64-accton-minipack-r0.yml
@@ -27,6 +27,7 @@ x86-64-accton-minipack-r0:
       rd_NO_LUKS
       intel_iommu=off
       noapic
+      pcie_aspm=off
 
   ##network
   ##  interfaces:

--- a/packages/platforms/accton/x86-64/wedge-16x/platform-config/r0/src/lib/x86-64-accton-wedge-16x-r0.yml
+++ b/packages/platforms/accton/x86-64/wedge-16x/platform-config/r0/src/lib/x86-64-accton-wedge-16x-r0.yml
@@ -26,6 +26,7 @@ x86-64-accton-wedge-16x-r0:
       rd_NO_MD
       rd_NO_LUKS
       intel_iommu=off
+      pcie_aspm=off
 
   ##network
   ##  interfaces:

--- a/packages/platforms/accton/x86-64/wedge100-32x/platform-config/r0/src/lib/x86-64-accton-wedge100-32x-r0.yml
+++ b/packages/platforms/accton/x86-64/wedge100-32x/platform-config/r0/src/lib/x86-64-accton-wedge100-32x-r0.yml
@@ -27,6 +27,7 @@ x86-64-accton-wedge100-32x-r0:
       rd_NO_LUKS
       intel_iommu=off
       noapic
+      pcie_aspm=off
 
   ##network
   ##  interfaces:

--- a/packages/platforms/accton/x86-64/wedge100/platform-config/r0/src/lib/x86-64-facebook-wedge100-r0.yml
+++ b/packages/platforms/accton/x86-64/wedge100/platform-config/r0/src/lib/x86-64-facebook-wedge100-r0.yml
@@ -26,6 +26,7 @@ x86-64-facebook-wedge100-r0:
       rd_NO_MD
       rd_NO_LUKS
       intel_iommu=off
+      pcie_aspm=off
 
   ##network
   ##  interfaces:

--- a/packages/platforms/accton/x86-64/wedge100s-32x/platform-config/r0/src/lib/x86-64-accton-wedge100s-32x-r0.yml
+++ b/packages/platforms/accton/x86-64/wedge100s-32x/platform-config/r0/src/lib/x86-64-accton-wedge100s-32x-r0.yml
@@ -21,3 +21,4 @@ x86-64-accton-wedge100s-32x-r0:
       rd_NO_LUKS
       intel_iommu=off
       noapic
+      pcie_aspm=off


### PR DESCRIPTION
1. added pcie_aspm=off. because BRCM MAC chipset DNX/XGS series does not support the ASPM function.

Signed-off-by: Alex Lai <alex_lai@edge-core.com>