### PR TITLE
[Edgecore][AS5912-54X] Support Delta AC 650W PSU

### DIFF
--- a/packages/base/any/kernels/modules/ym2651y.c
+++ b/packages/base/any/kernels/modules/ym2651y.c
@@ -307,6 +307,7 @@ static ssize_t show_linear(struct device *dev, struct device_attribute *da,
     switch (attr->index) {
     case PSU_V_IN:
         if ((strncmp(ptr, "DPS-850A", strlen("DPS-850A")) == 0)||
+            (strncmp(ptr, "DPS-650AB-11 C", strlen("DPS-650AB-11 C")) == 0)||
             (strncmp(ptr, "YM-2851J", strlen("YM-2851J")) == 0)||
             (strncmp(ptr, "SPAACTN-04", strlen("SPAACTN-04")) == 0)||
             (strncmp(ptr, "SPAACTN-03", strlen("SPAACTN-03")) == 0)) {
@@ -315,6 +316,7 @@ static ssize_t show_linear(struct device *dev, struct device_attribute *da,
         break;
     case PSU_I_IN:
         if ((strncmp(ptr, "DPS-850A", strlen("DPS-850A")) == 0)||
+            (strncmp(ptr, "DPS-650AB-11 C", strlen("DPS-650AB-11 C")) == 0)||
             (strncmp(ptr, "YM-2851J", strlen("YM-2851J")) == 0)||
             (strncmp(ptr, "SPAACTN-04", strlen("SPAACTN-04")) == 0)||
             (strncmp(ptr, "SPAACTN-03", strlen("SPAACTN-03")) == 0)) {
@@ -323,6 +325,7 @@ static ssize_t show_linear(struct device *dev, struct device_attribute *da,
         break;
     case PSU_P_IN:
         if ((strncmp(ptr, "DPS-850A", strlen("DPS-850A")) == 0)||
+            (strncmp(ptr, "DPS-650AB-11 C", strlen("DPS-650AB-11 C")) == 0)||
             (strncmp(ptr, "YM-2851J", strlen("YM-2851J")) == 0)||
             (strncmp(ptr, "SPAACTN-04", strlen("SPAACTN-04")) == 0)||
             (strncmp(ptr, "SPAACTN-03", strlen("SPAACTN-03")) == 0)) {
@@ -430,7 +433,8 @@ static ssize_t show_ascii(struct device *dev, struct device_attribute *da,
         ptr = data->fan_dir + 1;  /* Skip the first byte since it is the length of string. */
         /* FAN direction for PTT1600's PSU, depends on 
         4th and 3rd bit of return value of 0xC3 command */
-        if (strncmp((data->mfr_model + 1),"PTT1600", strlen("PTT1600")) == 0) {
+        if ((strncmp((data->mfr_model + 1),"PTT1600", strlen("PTT1600")) == 0) ||
+            (strncmp((data->mfr_model + 1),"DPS-650AB-11 C", strlen("DPS-650AB-11 C")) == 0)){
             /* Check if 4th bit is '1' and 3rd bit is '0' for "F2B (AFO)" FAN direction */
             if((((data->fan_dir[0] >> 3) & 1) == 0) && (((data->fan_dir[0] >> 4) & 1) == 1)) {
                 strcpy(ptr,"AFO");

--- a/packages/platforms/accton/x86-64/as5912-54x/modules/builds/x86-64-accton-as5912-54x-psu.c
+++ b/packages/platforms/accton/x86-64/as5912-54x/modules/builds/x86-64-accton-as5912-54x-psu.c
@@ -36,6 +36,7 @@
 
 static ssize_t show_status(struct device *dev, struct device_attribute *da, char *buf);
 static ssize_t show_model_name(struct device *dev, struct device_attribute *da, char *buf);
+static ssize_t show_product_name(struct device *dev, struct device_attribute *da, char *buf);
 static int as5912_54x_psu_read_block(struct i2c_client *client, u8 command, u8 *data,int data_len);
 extern int as5912_54x_cpld_read(unsigned short cpld_addr, u8 reg);
 
@@ -53,6 +54,7 @@ struct as5912_54x_psu_data {
     u8  index;           /* PSU index */
     u8  status;          /* Status(present/power_good) register read from CPLD */
     char model_name[9]; /* Model name, read from eeprom */
+    char product_name[11]; /* Product name, read from eeprom */
 };
 
 static struct as5912_54x_psu_data *as5912_54x_psu_update_device(struct device *dev);             
@@ -60,6 +62,7 @@ static struct as5912_54x_psu_data *as5912_54x_psu_update_device(struct device *d
 enum as5912_54x_psu_sysfs_attributes {
     PSU_PRESENT,
     PSU_MODEL_NAME,
+    PSU_PRODUCT_NAME,
     PSU_POWER_GOOD
 };
 
@@ -67,11 +70,13 @@ enum as5912_54x_psu_sysfs_attributes {
  */
 static SENSOR_DEVICE_ATTR(psu_present,    S_IRUGO, show_status,    NULL, PSU_PRESENT);
 static SENSOR_DEVICE_ATTR(psu_model_name, S_IRUGO, show_model_name,NULL, PSU_MODEL_NAME);
+static SENSOR_DEVICE_ATTR(psu_product_name, S_IRUGO, show_product_name,NULL, PSU_PRODUCT_NAME);
 static SENSOR_DEVICE_ATTR(psu_power_good, S_IRUGO, show_status,    NULL, PSU_POWER_GOOD);
 
 static struct attribute *as5912_54x_psu_attributes[] = {
     &sensor_dev_attr_psu_present.dev_attr.attr,
     &sensor_dev_attr_psu_model_name.dev_attr.attr,
+    &sensor_dev_attr_psu_product_name.dev_attr.attr,
     &sensor_dev_attr_psu_power_good.dev_attr.attr,
     NULL
 };
@@ -117,7 +122,26 @@ static ssize_t show_model_name(struct device *dev, struct device_attribute *da,
 	}
 
     mutex_unlock(&data->update_lock);
-    return sprintf(buf, "%s\n", data->model_name);
+
+    return sprintf(buf, "%s", data->model_name);
+}
+
+static ssize_t show_product_name(struct device *dev, struct device_attribute *da,
+             char *buf)
+{
+    struct i2c_client *client = to_i2c_client(dev);
+    struct as5912_54x_psu_data *data = i2c_get_clientdata(client);
+    mutex_lock(&data->update_lock);
+
+    data = as5912_54x_psu_update_device(dev);
+    if (!data->valid) {
+        mutex_unlock(&data->update_lock);
+        return 0;
+    }
+
+    mutex_unlock(&data->update_lock);
+
+    return sprintf(buf, "%s", data->product_name);
 }
 
 static const struct attribute_group as5912_54x_psu_group = {
@@ -266,15 +290,25 @@ static struct as5912_54x_psu_data *as5912_54x_psu_update_device(struct device *d
         power_good = data->status & BIT(3 - data->index);
 		
         if (power_good) {
+            /* get model name */
             status = as5912_54x_psu_read_block(client, 0x20, data->model_name, 
                                                ARRAY_SIZE(data->model_name)-1);
-
             if (status < 0) {
                 data->model_name[0] = '\0';
                 dev_dbg(&client->dev, "unable to read model name from (0x%x)\n", client->addr);
             }
             else {
                 data->model_name[ARRAY_SIZE(data->model_name)-1] = '\0';
+            }
+            /* get product name */
+            status = as5912_54x_psu_read_block(client, 0x15, data->product_name,
+                                               ARRAY_SIZE(data->product_name)-1);
+            if (status < 0) {
+                data->product_name[0] = '\0';
+                dev_dbg(&client->dev, "unable to read product name from (0x%x)\n", client->addr);
+            }
+            else {
+                data->product_name[ARRAY_SIZE(data->product_name)-1] = '\0';
             }
         }
         

--- a/packages/platforms/accton/x86-64/as5912-54x/onlp/builds/x86_64_accton_as5912_54x/module/src/psui.c
+++ b/packages/platforms/accton/x86-64/as5912-54x/onlp/builds/x86_64_accton_as5912_54x/module/src/psui.c
@@ -89,15 +89,31 @@ psu_ym2651y_info_get(onlp_psu_info_t* info)
         info->caps |= ONLP_PSU_CAPS_VOUT;
     }
 
+    if (psu_ym2651y_pmbus_info_get(index, "psu_v_in", &val) == 0) {
+        info->mvin = val;
+        info->caps |= ONLP_PSU_CAPS_VIN;
+    }
+
     if (psu_ym2651y_pmbus_info_get(index, "psu_i_out", &val) == 0) {
         info->miout = val;
         info->caps |= ONLP_PSU_CAPS_IOUT;
+    }
+
+    if (psu_ym2651y_pmbus_info_get(index, "psu_i_in", &val) == 0) {
+        info->miin = val;
+        info->caps |= ONLP_PSU_CAPS_IIN;
     }
 
     if (psu_ym2651y_pmbus_info_get(index, "psu_p_out", &val) == 0) {
         info->mpout = val;
         info->caps |= ONLP_PSU_CAPS_POUT;
     }
+
+    if (psu_ym2651y_pmbus_info_get(index, "psu_p_in", &val) == 0) {
+        info->mpin = val;
+        info->caps |= ONLP_PSU_CAPS_PIN;
+    }
+
     psu_serial_number_get(index, info->serial, sizeof(info->serial));
 
     return ONLP_STATUS_OK;
@@ -155,11 +171,10 @@ onlp_psui_info_get(onlp_oid_t id, onlp_psu_info_t* info)
     /* Get PSU type
      */
     psu_type = get_psu_type(index, info->model, sizeof(info->model));
-
     switch (psu_type) {
         case PSU_TYPE_AC_F2B:
         case PSU_TYPE_AC_B2F:
-           info->caps = ONLP_PSU_CAPS_AC;
+            info->caps = ONLP_PSU_CAPS_AC;
             ret = psu_ym2651y_info_get(info);
             break;
         case PSU_TYPE_DC_48V_F2B:


### PR DESCRIPTION
1. Add node of psu product name.
2. Access this node to get the completed PSU product name
3. Add Delta AC 650W PSU
4. remove the redundant space of output

Signed-off-by: Willy Liu <willy_liu@edge-core.com>