### PR TITLE
[Edgecore][as7326-56x] Fix the last port issus

### DIFF
--- a/packages/platforms/accton/x86-64/as7326-56x/platform-config/r0/src/python/x86_64_accton_as7326_56x_r0/__init__.py
+++ b/packages/platforms/accton/x86-64/as7326-56x/platform-config/r0/src/python/x86_64_accton_as7326_56x_r0/__init__.py
@@ -134,7 +134,7 @@ class OnlPlatform_x86_64_accton_as7326_56x_r0(OnlPlatformAccton,
             bus = sfp_map[port-1]
             self.new_i2c_device('optoe1', 0x50, bus)
 
-        for port in range(1, len(sfp_map)):
+        for port in range(1, len(sfp_map)+1):
             bus = sfp_map[port-1]
             subprocess.call('echo port%d > /sys/bus/i2c/devices/%d-0050/port_name' % (port, bus), shell=True)
 


### PR DESCRIPTION
The port occur failed because the last port_name is no set. Modify the init.py to fix the issus

Signed-off-by: Willy Liu <willy_liu@edge-core.com>