### PR TITLE
Change DEBIAN_MIRROR site to fix build issue

### DIFF
--- a/builds/any/rootfs/jessie/standard/standard.yml
+++ b/builds/any/rootfs/jessie/standard/standard.yml
@@ -29,14 +29,14 @@ Multistrap:
 
   Debian:
     packages: *Packages
-    source: http://${DEBIAN_MIRROR}
+    source: http://archive.debian.org/debian/
     suite: ${ONL_DEBIAN_SUITE}
     keyring: debian-archive-keyring
     omitdebsrc: true
 
   Debian-Local:
     packages: *Packages
-    source: http://${APT_CACHE}${DEBIAN_MIRROR}
+    source: http://${APT_CACHE}archive.debian.org/debian/
     suite: ${ONL_DEBIAN_SUITE}
     keyring: debian-archive-keyring
     omitdebsrc: true

--- a/builds/any/rootfs/stretch/standard/standard.yml
+++ b/builds/any/rootfs/stretch/standard/standard.yml
@@ -29,14 +29,14 @@ Multistrap:
 
   Debian:
     packages: *Packages
-    source: http://${DEBIAN_MIRROR}
+    source: http://archive.debian.org/debian/
     suite: ${ONL_DEBIAN_SUITE}
     keyring: debian-archive-keyring
     omitdebsrc: true
 
   Debian-Local:
     packages: *Packages
-    source: http://${APT_CACHE}${DEBIAN_MIRROR}
+    source: http://${APT_CACHE}archive.debian.org/debian/
     suite: ${ONL_DEBIAN_SUITE}
     keyring: debian-archive-keyring
     omitdebsrc: true

--- a/builds/any/rootfs/wheezy/standard/standard.yml
+++ b/builds/any/rootfs/wheezy/standard/standard.yml
@@ -28,14 +28,14 @@ Multistrap:
 
   Debian:
     packages: *Packages
-    source: http://${DEBIAN_MIRROR}
+    source: http://archive.debian.org/debian/
     suite: ${ONL_DEBIAN_SUITE}
     keyring: debian-archive-keyring
     omitdebsrc: true
 
   Debian-Local:
     packages: *Packages
-    source: http://${APT_CACHE}${DEBIAN_MIRROR}
+    source: http://${APT_CACHE}archive.debian.org/debian/
     suite: ${ONL_DEBIAN_SUITE}
     keyring: debian-archive-keyring
     omitdebsrc: true


### PR DESCRIPTION
https://mirrors.edge.kernel.org/debian/dists/ not support jessie.
Workaround URL is http://archive.debian.org/debian/dists/ and test OK.