### PR TITLE
[Edgecore][AS5835-54X] Fixed the issue that failed to detect PSU module on PSU SLOT-2 without PSU SLOT-1

### DIFF
--- a/packages/platforms/accton/x86-64/as5835-54x/onlp/builds/x86_64_accton_as5835_54x/module/src/platform_lib.c
+++ b/packages/platforms/accton/x86-64/as5835-54x/onlp/builds/x86_64_accton_as5835_54x/module/src/platform_lib.c
@@ -86,7 +86,7 @@ psu_type_t get_psu_type(int id, char* modelname, int modelname_len)
     if (strncmp(mn, "YM-1401A", 8) == 0) {
         char *fd = NULL;
         
-        node = (id == PSU1_ID) ? PSU1_AC_PMBUS_NODE(psu_fan_dir) : PSU1_AC_PMBUS_NODE(psu_fan_dir);
+        node = (id == PSU1_ID) ? PSU1_AC_PMBUS_NODE(psu_fan_dir) : PSU2_AC_PMBUS_NODE(psu_fan_dir);
         ret = onlp_file_read_str(&fd, node);
 
         if (ret <= 0 || ret > PSU_FAN_DIR_LEN || fd == NULL) {


### PR DESCRIPTION

1. Fixed the wrong fan dir node of psu2.