### PR TITLE
[Edgecore][AS7326-56X] Enhance fan controller to execute fan-watchdog

### DIFF
--- a/packages/platforms/accton/x86-64/as7326-56x/onlp/builds/x86_64_accton_as7326_56x/module/src/fani.c
+++ b/packages/platforms/accton/x86-64/as7326-56x/onlp/builds/x86_64_accton_as7326_56x/module/src/fani.c
@@ -23,6 +23,7 @@
  * Fan Platform Implementation Defaults.
  *
  ***********************************************************/
+#include <onlplib/i2c.h>
 #include <onlp/platformi/fani.h>
 #include "platform_lib.h"
 
@@ -233,6 +234,39 @@ _onlp_fani_info_get_fan_on_psu(int pid, onlp_fan_info_t* info)
 int
 onlp_fani_init(void)
 {
+    int wdt_timer = 0;
+    char wdt_status_path[64] = {0};
+    char wdt_timer_path[64] = {0};
+    char wdt_max_pwm_path[64] = {0};
+    /* set wdt timer 240s */
+    wdt_timer = 0xf0;
+
+    sprintf(wdt_status_path, "%s""fan_wdt_status", FAN_BOARD_PATH);
+    sprintf(wdt_timer_path, "%s""fan_wdt_timer", FAN_BOARD_PATH);
+    sprintf(wdt_max_pwm_path, "%s""fan_wdt_max_pwm", FAN_BOARD_PATH);
+
+    /* Set max fan pwm to full speed */
+    if (onlp_file_write_integer(wdt_max_pwm_path, FAN_BOARD_CPLD_WDT_MAX_PWM) < 0) {
+        AIM_LOG_ERROR("Unable to write data to file (%s)\r\n", wdt_max_pwm_path);
+        return ONLP_STATUS_E_INTERNAL;
+    }
+    /* Disable WDT */
+    if (onlp_file_write_integer(wdt_status_path, FAN_BOARD_CPLD_WDT_DISABLE) < 0) {
+        AIM_LOG_ERROR("Unable to write data to file (%s)\r\n", wdt_status_path);
+        return ONLP_STATUS_E_INTERNAL;
+    }
+    /* Enable WDT */
+    if (onlp_file_write_integer(wdt_status_path, FAN_BOARD_CPLD_WDT_ENABLE) < 0) {
+        AIM_LOG_ERROR("Unable to write data to file (%s)\r\n", wdt_status_path);
+        return ONLP_STATUS_E_INTERNAL;
+    }
+    /* Timer need to be set after enable.
+       if set timer is eralier than enable wdt. Speed will become to wdt speed after 6sec.*/
+    if (onlp_file_write_integer(wdt_timer_path, wdt_timer) < 0) {
+        AIM_LOG_ERROR("Unable to write data to file (%s)\r\n", wdt_timer_path);
+        return ONLP_STATUS_E_INTERNAL;
+    }
+
     return ONLP_STATUS_OK;
 }
 

--- a/packages/platforms/accton/x86-64/as7326-56x/onlp/builds/x86_64_accton_as7326_56x/module/src/platform_lib.h
+++ b/packages/platforms/accton/x86-64/as7326-56x/onlp/builds/x86_64_accton_as7326_56x/module/src/platform_lib.h
@@ -54,6 +54,13 @@
 
 #define FAN_BOARD_PATH	"/sys/bus/i2c/devices/11-0066/"
 #define FAN_NODE(node)	FAN_BOARD_PATH#node
+#define FAN_BOARD_CPLD_BUS              11
+#define FAN_BOARD_CPLD_REG              0x66
+#define FAN_BOARD_CPLD_OFFSET_WDT_ENDIS 0x33
+#define FAN_BOARD_CPLD_OFFSET_WDT_TIMER 0x31
+#define FAN_BOARD_CPLD_WDT_ENABLE       0x1
+#define FAN_BOARD_CPLD_WDT_DISABLE      0x0
+#define FAN_BOARD_CPLD_WDT_MAX_PWM      0xF
 
 #define IDPROM_PATH_1 "/sys/bus/i2c/devices/0-0056/eeprom"
 #define IDPROM_PATH_2 "/sys/bus/i2c/devices/0-0057/eeprom"

--- a/packages/platforms/accton/x86-64/as7326-56x/onlp/builds/x86_64_accton_as7326_56x/module/src/sysi.c
+++ b/packages/platforms/accton/x86-64/as7326-56x/onlp/builds/x86_64_accton_as7326_56x/module/src/sysi.c
@@ -35,6 +35,7 @@
 #include "platform_lib.h"
 #include "x86_64_accton_as7326_56x_int.h"
 #include "x86_64_accton_as7326_56x_log.h"
+#include <onlplib/i2c.h>
 
 #define NUM_OF_FAN_ON_MAIN_BROAD      6
 
@@ -189,6 +190,61 @@ onlp_sysi_platform_manage_fans(void)
     int cur_duty_cycle, new_duty_cycle, temp=0;
     onlp_thermal_info_t thermal_3, thermal_5;
     char  buf[10] = {0};
+    int wdt_status = 0;
+    int wdt_timer = 0;
+    char wdt_status_path[64] = {0};
+    char wdt_timer_path[64] = {0};
+    /* set wdt timer 240s */
+    wdt_timer = 0xf0;
+    static int failed_cnt = 0;
+    static int failed_first_log = 0;
+
+    sprintf(wdt_status_path, "%s""fan_wdt_status", FAN_BOARD_PATH);
+    sprintf(wdt_timer_path, "%s""fan_wdt_timer", FAN_BOARD_PATH);
+    /*  Check WDT state, if WDT disable, Enable WDT and kick */
+    if (onlp_file_read_int(&wdt_status, wdt_status_path) < 0) {
+        failed_cnt++;
+    }
+    else
+    {
+        if (wdt_status == FAN_BOARD_CPLD_WDT_DISABLE)
+        {
+            AIM_SYSLOG_WARN("Fan-WDT Disable", "Fan-WDT Disable","Alarm for Fan-WDT Disable is detected");
+            /* Enable WDT */
+            if (onlp_file_write_integer(wdt_status_path, FAN_BOARD_CPLD_WDT_ENABLE) < 0) {
+                failed_cnt++;
+            }
+            else
+            {
+                /* kicks */
+                if (onlp_file_write_integer(wdt_timer_path, wdt_timer) < 0) {
+                    failed_cnt++;
+                }
+            }
+        }
+        else
+        {
+            /* kicks */
+            if (onlp_file_write_integer(wdt_timer_path, wdt_timer) < 0) {
+                failed_cnt++;
+            }
+        }
+    }
+    /* To ensure generate log message for first failed */
+    if((failed_first_log == 0) && (failed_cnt > 0))
+    {
+        failed_first_log = 1;
+        AIM_LOG_ERROR("Unable to read status from file (%s) or (%s)\r\n", wdt_status_path, wdt_timer_path);
+    }
+    /* Print the error log if the total falied counts equal or over 360 counts.
+       It can decrese number of log message.
+       polling every 10 sec. Polling 360 counts for one hour if it is failed to access fan cpld watchdog.
+    */
+    if(failed_cnt >= 360)
+    {
+        failed_cnt = 0;
+        AIM_LOG_ERROR("Unable to read status from file (%s) or (%s)\r\n", wdt_status_path, wdt_timer_path);
+    }
 
     /* Get current temperature
      */


### PR DESCRIPTION
1. We enable fan-watchdog to enhance fan controller.
2. Set the fan max PWM to 100%