### PR TITLE
Update Makefile to default to Debian 9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ endif
 .PHONY: docker
 
 ifndef VERSION
-VERSION := 8
+VERSION := 9
 endif
 
 docker_check:


### PR DESCRIPTION
Debian 9 (and soon 10) will be the default build version.