### PR TITLE
Fix for duplicate case introduced by #862 as4630-54p3 sfpi.c

### DIFF
--- a/packages/platforms/accton/x86-64/as4630-54pe/onlp/builds/x86_64_accton_as4630_54pe/module/src/sfpi.c
+++ b/packages/platforms/accton/x86-64/as4630-54pe/onlp/builds/x86_64_accton_as4630_54pe/module/src/sfpi.c
@@ -233,8 +233,6 @@ onlp_sfpi_control_set(int port, onlp_sfp_control_t control, int value)
     {
         case ONLP_SFP_CONTROL_TX_DISABLE:
         {
-            case ONLP_SFP_CONTROL_TX_DISABLE:
-            {
                 if(port>=48 && port<=51) {
                     if (onlp_file_write_int(value, MODULE_TXDISABLE_FORMAT, bus, addr, (port+1)) < 0) {
                         AIM_LOG_ERROR("Unable to set tx_disable status to port(%d)\r\n", port);
@@ -243,7 +241,6 @@ onlp_sfpi_control_set(int port, onlp_sfp_control_t control, int value)
                      return  ONLP_STATUS_OK;
                  }
                  return ONLP_STATUS_E_UNSUPPORTED;               
-            }               
         }
         case ONLP_SFP_CONTROL_RESET:
         {


### PR DESCRIPTION
When Merging #862 there was a duplicate case statement in sfpi.c line 236 : 

`         case ONLP_SFP_CONTROL_TX_DISABLE:`

This PR removes the extra lines and fixes build issues.