### PR TITLE
[Edgecore][AS7535-28XB] Support R01 version DUT with 6 thermals and R02 version DUT with 8 thermals

### DIFF
--- a/packages/platforms/accton/x86-64/as7535-28xb/modules/builds/x86-64-accton-as7535-28xb-thermal.c
+++ b/packages/platforms/accton/x86-64/as7535-28xb/modules/builds/x86-64-accton-as7535-28xb-thermal.c
@@ -35,6 +35,7 @@
 #define DRVNAME "as7535_28xb_thermal"
 #define ACCTON_IPMI_NETFN 0x34
 #define IPMI_THERMAL_READ_CMD 0x12
+#define IPMI_FPGA_READ_CMD 0x22
 
 #define IPMI_TIMEOUT (5 * HZ)
 #define IPMI_ERR_RETRY_TIMES 1
@@ -46,6 +47,9 @@ static ssize_t set_max(struct device *dev, struct device_attribute *da,
 			const char *buf, size_t count);
 static int as7535_28xb_thermal_probe(struct platform_device *pdev);
 static int as7535_28xb_thermal_remove(struct platform_device *pdev);
+
+static int get_pcb_id(void);
+static int g_pcb_id = 0;
 
 enum temp_data_index {
 	TEMP_ADDR,
@@ -95,17 +99,21 @@ static struct platform_driver as7535_28xb_thermal_driver = {
 
 enum as7535_28xb_thermal_sysfs_attrs {
 	TEMP1_INPUT, // 0x4B
-	TEMP2_INPUT, // 0x4C tmp43 local
-	TEMP3_INPUT, // 0x4C tmp43 remote
+	TEMP2_INPUT, // TMP431_0x4C_U50
+	TEMP3_INPUT, // TMP431_0x4C_MAC
 	TEMP4_INPUT, // 0x4D lm75
 	TEMP5_INPUT, // 0x4E lm75
 	TEMP6_INPUT, // 0x4F lm75
+	TEMP7_INPUT, // TMP431_0x4C_U93
+	TEMP8_INPUT, // TMP431_0x4C_C10
 	TEMP1_MAX,
 	TEMP2_MAX,
 	TEMP3_MAX,
 	TEMP4_MAX,
 	TEMP5_MAX,
-	TEMP6_MAX
+	TEMP6_MAX,
+	TEMP7_MAX,
+	TEMP8_MAX
 };
 
 // Read only temp_input
@@ -125,6 +133,8 @@ DECLARE_THERMAL_SENSOR_DEVICE_ATTR_R(3);
 DECLARE_THERMAL_SENSOR_DEVICE_ATTR_R(4);
 DECLARE_THERMAL_SENSOR_DEVICE_ATTR_R(5);
 DECLARE_THERMAL_SENSOR_DEVICE_ATTR_R(6);
+DECLARE_THERMAL_SENSOR_DEVICE_ATTR_R(7);
+DECLARE_THERMAL_SENSOR_DEVICE_ATTR_R(8);
 
 static struct attribute *as7535_28xb_thermal_attributes[] = {
 	DECLARE_THERMAL_ATTR(1),
@@ -133,6 +143,8 @@ static struct attribute *as7535_28xb_thermal_attributes[] = {
 	DECLARE_THERMAL_ATTR(4),
 	DECLARE_THERMAL_ATTR(5),
 	DECLARE_THERMAL_ATTR(6),
+	DECLARE_THERMAL_ATTR(7),
+	DECLARE_THERMAL_ATTR(8),
 	NULL
 };
 
@@ -276,19 +288,52 @@ static void ipmi_msg_handler(struct ipmi_recv_msg *msg, void *user_msg_data)
 	complete(&ipmi->read_complete);
 }
 
+static int get_pcb_id(void)
+{
+	int status = 0;
+	int pcb_id = 0;
+	/* Get PCB ID */
+	data->ipmi_tx_data[0] = 0x60;
+	data->ipmi_tx_data[1] = 0x0;
+	status = ipmi_send_message(&data->ipmi, IPMI_FPGA_READ_CMD, data->ipmi_tx_data, 2,
+								data->ipmi_resp, sizeof(data->ipmi_resp));
+	if (unlikely(status != 0))
+		goto exit;
+
+	if (unlikely(data->ipmi.rx_result != 0)) {
+		status = -EIO;
+		goto exit;
+	}
+	/* (bit 3, bit 2) 00: No C10+IDT, 01: CY10+IDT, 10: no CY10+microchip, 11: CY10+microchip
+		Support 8 thermals for CY10+IDT */
+	pcb_id = (((s8)data->ipmi_resp[0]) >> 2) & 0xff;
+	return pcb_id;
+
+exit:
+	return status;
+}
+
 static ssize_t show_temp(struct device *dev, struct device_attribute *da,
 							char *buf)
 {
 	int status = 0;
 	int index  = 0;
 	struct sensor_device_attribute *attr = to_sensor_dev_attr(da);
-
 	mutex_lock(&data->update_lock);
-
-	if (attr->index >= TEMP1_MAX && attr->index <= TEMP6_MAX) {
+	if (attr->index >= TEMP1_MAX && attr->index <= TEMP8_MAX) {
 		int max = data->temp_max[attr->index - TEMP1_MAX];
 		mutex_unlock(&data->update_lock);
 		return sprintf(buf, "%d\n", max * 1000);
+	}
+	/* Set 0 to Temp 7 and 8 if pcb id is not 01: CY10+IDT */
+	if (g_pcb_id != 1)
+	{
+		if ((attr->index == TEMP7_INPUT) || (attr->index == TEMP8_INPUT))
+		{
+			status = 0;
+			mutex_unlock(&data->update_lock);
+			return sprintf(buf, "%d\n", status);
+		}
 	}
 
 	if (time_after(jiffies, data->last_updated + HZ * 5) || !data->valid) {
@@ -297,7 +342,9 @@ static ssize_t show_temp(struct device *dev, struct device_attribute *da,
 		status = ipmi_send_message(&data->ipmi, IPMI_THERMAL_READ_CMD, NULL, 0,
 									data->ipmi_resp, sizeof(data->ipmi_resp));
 		if (unlikely(status != 0))
+		{
 			goto exit;
+		}
 
 		if (unlikely(data->ipmi.rx_result != 0)) {
 			status = -EIO;
@@ -307,14 +354,12 @@ static ssize_t show_temp(struct device *dev, struct device_attribute *da,
 		data->last_updated = jiffies;
 		data->valid = 1;
 	}
-
 	/* Get temp fault status */
 	index = attr->index * TEMP_DATA_COUNT + TEMP_FAULT;
 	if (unlikely(data->ipmi_resp[index] == 0)) {
 		status = -EIO;
 		goto exit;
 	}
-
 	/* Get temperature in degree celsius */
 	index = attr->index * TEMP_DATA_COUNT + TEMP_INPUT;
 	status = ((s8)data->ipmi_resp[index]) * 1000;
@@ -401,6 +446,8 @@ static int __init as7535_28xb_thermal_init(void)
 	for (i = 0; i < ARRAY_SIZE(data->temp_max); i++) {
 		data->temp_max[i] = 70; /* default high threshold */
 	}
+
+	g_pcb_id = get_pcb_id();
 
 	return 0;
 

--- a/packages/platforms/accton/x86-64/as7535-28xb/onlp/builds/x86_64_accton_as7535_28xb/module/src/platform_lib.c
+++ b/packages/platforms/accton/x86-64/as7535-28xb/onlp/builds/x86_64_accton_as7535_28xb/module/src/platform_lib.c
@@ -58,3 +58,25 @@ enum onlp_fan_dir onlp_get_fan_dir(int fid)
     AIM_FREE_IF_PTR(str);
     return dir;
 }
+
+int get_pcb_id()
+{
+    FILE *pf;
+    char command[32];
+    char data[8];
+    int pcb_id = 0;
+
+    sprintf(command, "ipmitool raw 0x34 0x22 0x60 0");
+    pf = popen(command,"r");
+    fgets(data, 8 , pf);
+
+    if (pclose(pf) != 0)
+    {
+        fprintf(stderr," Error: Failed to close command stream \n");
+        return ONLP_STATUS_E_INTERNAL;
+    }
+    /* get the pcb id to check the thermal number */
+    pcb_id = (atoi(data) >> 2) & 0xff;
+
+    return pcb_id;
+}

--- a/packages/platforms/accton/x86-64/as7535-28xb/onlp/builds/x86_64_accton_as7535_28xb/module/src/platform_lib.h
+++ b/packages/platforms/accton/x86-64/as7535-28xb/onlp/builds/x86_64_accton_as7535_28xb/module/src/platform_lib.h
@@ -30,6 +30,7 @@
 
 #define CHASSIS_FAN_COUNT      6
 #define CHASSIS_THERMAL_COUNT  7
+#define CHASSIS_THERMAL_COUNT_R02  9
 #define CHASSIS_LED_COUNT      6
 #define CHASSIS_PSU_COUNT      2
 #define NUM_OF_THERMAL_PER_PSU 3
@@ -42,6 +43,8 @@
 #define SYS_LED_PATH   "/sys/devices/platform/as7535_28xb_led/"
 #define IDPROM_PATH "/sys/devices/platform/as7535_28xb_sys/eeprom"
 
+int get_pcb_id();
+
 enum onlp_thermal_id {
     THERMAL_RESERVED = 0,
     THERMAL_CPU_CORE,
@@ -51,6 +54,8 @@ enum onlp_thermal_id {
     THERMAL_4_ON_MAIN_BROAD,
     THERMAL_5_ON_MAIN_BROAD,
     THERMAL_6_ON_MAIN_BROAD,
+    THERMAL_7_ON_MAIN_BROAD,
+    THERMAL_8_ON_MAIN_BROAD,
     THERMAL_1_ON_PSU1,
     THERMAL_2_ON_PSU1,
     THERMAL_3_ON_PSU1,

--- a/packages/platforms/accton/x86-64/as7535-28xb/onlp/builds/x86_64_accton_as7535_28xb/module/src/psui.c
+++ b/packages/platforms/accton/x86-64/as7535-28xb/onlp/builds/x86_64_accton_as7535_28xb/module/src/psui.c
@@ -63,6 +63,8 @@ onlp_psui_info_get(onlp_oid_t id, onlp_psu_info_t* info)
     int ret   = ONLP_STATUS_OK;
     int pid = ONLP_OID_ID_GET(id);
     VALIDATE(id);
+    int pcb_id = 0;
+    int thermal_count = 0;
 
     memset(info, 0, sizeof(onlp_psu_info_t));
     *info = pinfo[pid]; /* Set the onlp_oid_hdr_t */
@@ -102,12 +104,15 @@ onlp_psui_info_get(onlp_oid_t id, onlp_psu_info_t* info)
     info->caps = ONLP_PSU_CAPS_AC;
 
     /* Set the associated oid_table */
-    info->hdr.coids[0] = ONLP_THERMAL_ID_CREATE(CHASSIS_THERMAL_COUNT +
-                                       (pid-1)*NUM_OF_THERMAL_PER_PSU + 1);
-    info->hdr.coids[1] = ONLP_THERMAL_ID_CREATE(CHASSIS_THERMAL_COUNT +
-                                       (pid-1)*NUM_OF_THERMAL_PER_PSU + 2);
-    info->hdr.coids[2] = ONLP_THERMAL_ID_CREATE(CHASSIS_THERMAL_COUNT +
-                                       (pid-1)*NUM_OF_THERMAL_PER_PSU + 3);
+    pcb_id = get_pcb_id();
+    if (pcb_id == 1)
+        thermal_count = CHASSIS_THERMAL_COUNT_R02;
+    else
+        thermal_count = CHASSIS_THERMAL_COUNT;
+
+    info->hdr.coids[0] = ONLP_THERMAL_ID_CREATE(thermal_count + (pid-1)*NUM_OF_THERMAL_PER_PSU + 1);
+    info->hdr.coids[1] = ONLP_THERMAL_ID_CREATE(thermal_count + (pid-1)*NUM_OF_THERMAL_PER_PSU + 2);
+    info->hdr.coids[2] = ONLP_THERMAL_ID_CREATE(thermal_count + (pid-1)*NUM_OF_THERMAL_PER_PSU + 3);
     info->hdr.coids[3] = ONLP_FAN_ID_CREATE(pid + CHASSIS_FAN_COUNT);
 
     /* Read voltage, current and power */

--- a/packages/platforms/accton/x86-64/as7535-28xb/onlp/builds/x86_64_accton_as7535_28xb/module/src/sysi.c
+++ b/packages/platforms/accton/x86-64/as7535-28xb/onlp/builds/x86_64_accton_as7535_28xb/module/src/sysi.c
@@ -70,10 +70,22 @@ onlp_sysi_oids_get(onlp_oid_t* table, int max)
     int i;
     onlp_oid_t* e = table;
     memset(table, 0, max*sizeof(onlp_oid_t));
+    int pcb_id = 0;
 
-    /* 8 Thermal sensors on the chassis */
-    for (i = 1; i <= CHASSIS_THERMAL_COUNT; i++) {
-        *e++ = ONLP_THERMAL_ID_CREATE(i);
+    pcb_id = get_pcb_id();
+    if (pcb_id == 1)
+    {
+        /* 9 Thermal sensors on the chassis */
+        for (i = 1; i <= CHASSIS_THERMAL_COUNT_R02; i++) {
+            *e++ = ONLP_THERMAL_ID_CREATE(i);
+        }
+    }
+    else
+    {
+        /* 7 Thermal sensors on the chassis */
+        for (i = 1; i <= CHASSIS_THERMAL_COUNT; i++) {
+            *e++ = ONLP_THERMAL_ID_CREATE(i);
+        }
     }
 
     /* 5 LEDs on the chassis */

--- a/packages/platforms/accton/x86-64/as7535-28xb/onlp/builds/x86_64_accton_as7535_28xb/module/src/thermali.c
+++ b/packages/platforms/accton/x86-64/as7535-28xb/onlp/builds/x86_64_accton_as7535_28xb/module/src/thermali.c
@@ -51,6 +51,26 @@ static char* devfiles__[] = { /* must map with onlp_thermal_id */
     "/sys/devices/platform/as7535_28xb_psu/psu2_temp3_input",
 };
 
+static char* devfiles_r02__[] = { /* must map with onlp_thermal_id */
+    NULL,
+    NULL,                  /* CPU_CORE files */
+    "/sys/devices/platform/as7535_28xb_thermal/temp1_input",
+    "/sys/devices/platform/as7535_28xb_thermal/temp2_input",
+    "/sys/devices/platform/as7535_28xb_thermal/temp3_input",
+    "/sys/devices/platform/as7535_28xb_thermal/temp4_input",
+    "/sys/devices/platform/as7535_28xb_thermal/temp5_input",
+    "/sys/devices/platform/as7535_28xb_thermal/temp6_input",
+    "/sys/devices/platform/as7535_28xb_thermal/temp7_input",
+    "/sys/devices/platform/as7535_28xb_thermal/temp8_input",
+    "/sys/devices/platform/as7535_28xb_psu/psu1_temp1_input",
+    "/sys/devices/platform/as7535_28xb_psu/psu1_temp2_input",
+    "/sys/devices/platform/as7535_28xb_psu/psu1_temp3_input",
+    "/sys/devices/platform/as7535_28xb_psu/psu2_temp1_input",
+    "/sys/devices/platform/as7535_28xb_psu/psu2_temp2_input",
+    "/sys/devices/platform/as7535_28xb_psu/psu2_temp3_input",
+};
+
+
 static char* cpu_coretemp_files[] = {
     "/sys/devices/platform/coretemp.0*temp2_input",
     "/sys/devices/platform/coretemp.0*temp3_input",
@@ -74,11 +94,11 @@ static onlp_thermal_info_t tinfo[] = {
         ONLP_THERMAL_STATUS_PRESENT,
         ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
     },
-    {   { ONLP_THERMAL_ID_CREATE(THERMAL_2_ON_MAIN_BROAD), "LM75-4C-1", 0, {0} },
+    {   { ONLP_THERMAL_ID_CREATE(THERMAL_2_ON_MAIN_BROAD), "TMP431_0x4C_U50", 0, {0} },
         ONLP_THERMAL_STATUS_PRESENT,
         ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
     },
-    {   { ONLP_THERMAL_ID_CREATE(THERMAL_3_ON_MAIN_BROAD), "LM75-4C-2", 0, {0} },
+    {   { ONLP_THERMAL_ID_CREATE(THERMAL_3_ON_MAIN_BROAD), "TMP431_0x4C_MAC", 0, {0} },
         ONLP_THERMAL_STATUS_PRESENT,
         ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
     },
@@ -91,6 +111,71 @@ static onlp_thermal_info_t tinfo[] = {
         ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
     },
     {   { ONLP_THERMAL_ID_CREATE(THERMAL_6_ON_MAIN_BROAD), "LM75-4F", 0, {0} },
+        ONLP_THERMAL_STATUS_PRESENT,
+        ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
+    },
+    {   { ONLP_THERMAL_ID_CREATE(THERMAL_1_ON_PSU1), "PSU-1 Thermal Sensor 1", ONLP_PSU_ID_CREATE(PSU1_ID), {0} },
+        ONLP_THERMAL_STATUS_PRESENT,
+        ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
+    },
+    {   { ONLP_THERMAL_ID_CREATE(THERMAL_2_ON_PSU1), "PSU-1 Thermal Sensor 2", ONLP_PSU_ID_CREATE(PSU1_ID), {0} },
+        ONLP_THERMAL_STATUS_PRESENT,
+        ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
+    },
+    {   { ONLP_THERMAL_ID_CREATE(THERMAL_3_ON_PSU1), "PSU-1 Thermal Sensor 3", ONLP_PSU_ID_CREATE(PSU1_ID), {0} },
+        ONLP_THERMAL_STATUS_PRESENT,
+        ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
+    },
+    {   { ONLP_THERMAL_ID_CREATE(THERMAL_1_ON_PSU2), "PSU-2 Thermal Sensor 1", ONLP_PSU_ID_CREATE(PSU2_ID), {0} },
+        ONLP_THERMAL_STATUS_PRESENT,
+        ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
+    },
+    {   { ONLP_THERMAL_ID_CREATE(THERMAL_2_ON_PSU2), "PSU-2 Thermal Sensor 2", ONLP_PSU_ID_CREATE(PSU2_ID), {0} },
+        ONLP_THERMAL_STATUS_PRESENT,
+        ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
+    },
+    {   { ONLP_THERMAL_ID_CREATE(THERMAL_3_ON_PSU2), "PSU-2 Thermal Sensor 3", ONLP_PSU_ID_CREATE(PSU2_ID), {0} },
+        ONLP_THERMAL_STATUS_PRESENT,
+        ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
+    }
+};
+
+/* Static values for R02*/
+static onlp_thermal_info_t tinfo_r02[] = {
+    { }, /* Not used */
+    {   { ONLP_THERMAL_ID_CREATE(THERMAL_CPU_CORE), "CPU Core", 0, {0} },
+        ONLP_THERMAL_STATUS_PRESENT,
+        ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
+    },
+    {   { ONLP_THERMAL_ID_CREATE(THERMAL_1_ON_MAIN_BROAD), "LM75-4B", 0, {0} },
+        ONLP_THERMAL_STATUS_PRESENT,
+        ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
+    },
+    {   { ONLP_THERMAL_ID_CREATE(THERMAL_2_ON_MAIN_BROAD), "TMP431_0x4C_U50", 0, {0} },
+        ONLP_THERMAL_STATUS_PRESENT,
+        ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
+    },
+    {   { ONLP_THERMAL_ID_CREATE(THERMAL_3_ON_MAIN_BROAD), "TMP431_0x4C_MAC", 0, {0} },
+        ONLP_THERMAL_STATUS_PRESENT,
+        ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
+    },
+    {   { ONLP_THERMAL_ID_CREATE(THERMAL_4_ON_MAIN_BROAD), "LM75-4D", 0, {0} },
+        ONLP_THERMAL_STATUS_PRESENT,
+        ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
+    },
+    {   { ONLP_THERMAL_ID_CREATE(THERMAL_5_ON_MAIN_BROAD), "LM75-4E", 0, {0} },
+        ONLP_THERMAL_STATUS_PRESENT,
+        ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
+    },
+    {   { ONLP_THERMAL_ID_CREATE(THERMAL_6_ON_MAIN_BROAD), "LM75-4F", 0, {0} },
+        ONLP_THERMAL_STATUS_PRESENT,
+        ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
+    },
+    {   { ONLP_THERMAL_ID_CREATE(THERMAL_7_ON_MAIN_BROAD), "TMP431_0x4C_U93", 0, {0} },
+        ONLP_THERMAL_STATUS_PRESENT,
+        ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
+    },
+    {   { ONLP_THERMAL_ID_CREATE(THERMAL_8_ON_MAIN_BROAD), "TMP431_0x4C_C10", 0, {0} },
         ONLP_THERMAL_STATUS_PRESENT,
         ONLP_THERMAL_CAPS_ALL, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
     },
@@ -144,15 +229,22 @@ onlp_thermali_info_get(onlp_oid_t id, onlp_thermal_info_t* info)
 {
     int tid;
     VALIDATE(id);
+    int pcb_id = 0;
 
     tid = ONLP_OID_ID_GET(id);
 
-    /* Set the onlp_oid_hdr_t and capabilities */
-    *info = tinfo[tid];
+    pcb_id = get_pcb_id();
+    if (pcb_id == 1)
+        *info = tinfo_r02[tid];
+    else
+        *info = tinfo[tid];
 
     if (tid == THERMAL_CPU_CORE) {
         return onlp_file_read_int_max(&info->mcelsius, cpu_coretemp_files);
     }
+
+    if (pcb_id == 1)
+        return onlp_file_read_int(&info->mcelsius, devfiles_r02__[tid]);
 
     return onlp_file_read_int(&info->mcelsius, devfiles__[tid]);
 }


### PR DESCRIPTION
[Edgecore][AS7535-28XB] Support R01 version DUT with 6 thermals and R02 version DUT with 8 thermals

1.  It support R01 version  DUT with 6 thermals and R02 version  DUT with 8 thermals
2. Modify thermal name
3. Add the new thermals sysfs
4. Add the function to get pcb id