### PR TITLE
accton-as4610: LED handling fixes

### DIFF
--- a/packages/platforms/accton/armxx/arm-accton-as4610/arm_accton_as4610/module/src/ledi.c
+++ b/packages/platforms/accton/armxx/arm-accton-as4610/arm_accton_as4610/module/src/ledi.c
@@ -342,8 +342,8 @@ onlp_ledi_oid_to_internal_id(onlp_oid_t id)
 int
 onlp_ledi_info_get(onlp_oid_t id, onlp_led_info_t* info)
 {
-    int  fd, len, nbytes=1;
-    char data[2]      = {0};
+    int  fd, len, nbytes=2;
+    char data[3]      = {0};
     char fullpath[53] = {0};
     int lid = onlp_ledi_oid_to_internal_id(id);
 
@@ -373,6 +373,9 @@ onlp_ledi_info_get(onlp_oid_t id, onlp_led_info_t* info)
             return ONLP_STATUS_E_INTERNAL;
         }
 
+        /* data will be a single digit and a newline, or two digits. atoi ignores
+         * the newline and will return the correct value either way
+         */
         info->mode = conver_led_light_mode_to_onl(lid, atoi(data));
 
         /* Set the on/off status */
@@ -414,8 +417,8 @@ onlp_ledi_set(onlp_oid_t id, int on_or_off)
 int
 onlp_ledi_mode_set(onlp_oid_t id, onlp_led_mode_t mode)
 {
-    int  fd, len, driver_mode, nbytes=1;
-    char data[2]            = {0};	
+    int  fd, len, driver_mode, nbytes;
+    char data[3]            = {0};	
     char fullpath[PATH_MAX] = {0};		
     int lid = onlp_ledi_oid_to_internal_id(id);
     
@@ -428,7 +431,7 @@ onlp_ledi_mode_set(onlp_oid_t id, onlp_led_mode_t mode)
     sprintf(fullpath, "%s%s/%s", led_prefix_path, onlp_led_node_subname[lid], led_filename);		
 
     driver_mode = conver_onlp_led_light_mode_to_driver(lid, mode);
-    snprintf(data, sizeof(data), "%d", driver_mode);
+    nbytes = snprintf(data, sizeof(data), "%d", driver_mode);
 	
     /* Create output file descriptor */
     fd = open(fullpath, O_WRONLY | O_CREAT, 0644);

--- a/packages/platforms/accton/armxx/arm-accton-as4610/arm_accton_as4610/module/src/ledi.c
+++ b/packages/platforms/accton/armxx/arm-accton-as4610/arm_accton_as4610/module/src/ledi.c
@@ -25,6 +25,7 @@
  ***********************************************************/
 #include <onlp/platformi/ledi.h>
 #include <sys/mman.h>
+#include <limits.h>
 #include <stdio.h>
 #include <string.h>
 #include <fcntl.h>
@@ -250,7 +251,7 @@ int onlp_ledi_char_set(onlp_oid_t id, char c)
 {
     int  fd, len, nbytes=1;
     char data[2]      = {0};
-    char fullpath[50] = {0};		
+    char fullpath[PATH_MAX] = {0};		
     int lid = ONLP_OID_ID_GET(id);
 
     VALIDATE(id);
@@ -284,7 +285,7 @@ int onlp_ledi_char_get(onlp_oid_t id, char* c)
 {
     int  fd, len; 
     char data = 0;
-    char fullpath[50] = {0};
+    char fullpath[PATH_MAX] = {0};
     int lid = ONLP_OID_ID_GET(id);
 
     VALIDATE(id);
@@ -343,7 +344,7 @@ onlp_ledi_info_get(onlp_oid_t id, onlp_led_info_t* info)
 {
     int  fd, len, nbytes=1;
     char data[2]      = {0};
-    char fullpath[50] = {0};
+    char fullpath[53] = {0};
     int lid = onlp_ledi_oid_to_internal_id(id);
 
     VALIDATE(id);
@@ -355,7 +356,7 @@ onlp_ledi_info_get(onlp_oid_t id, onlp_led_info_t* info)
         return onlp_ledi_char_get(id, &info->character);
     }
     else {
-        sprintf(fullpath, "%s%s/%s", led_prefix_path, onlp_led_node_subname[lid], led_filename);
+        snprintf(fullpath, sizeof(fullpath), "%s%s/%s", led_prefix_path, onlp_led_node_subname[lid], led_filename);
 
         /* Set current mode */
         if ((fd = open(fullpath, O_RDONLY)) == -1) {
@@ -414,8 +415,8 @@ int
 onlp_ledi_mode_set(onlp_oid_t id, onlp_led_mode_t mode)
 {
     int  fd, len, driver_mode, nbytes=1;
-    char data[2]      = {0};	
-    char fullpath[50] = {0};		
+    char data[2]            = {0};	
+    char fullpath[PATH_MAX] = {0};		
     int lid = onlp_ledi_oid_to_internal_id(id);
     
     VALIDATE(id);
@@ -427,7 +428,7 @@ onlp_ledi_mode_set(onlp_oid_t id, onlp_led_mode_t mode)
     sprintf(fullpath, "%s%s/%s", led_prefix_path, onlp_led_node_subname[lid], led_filename);		
 
     driver_mode = conver_onlp_led_light_mode_to_driver(lid, mode);
-    sprintf(data, "%d", driver_mode);
+    snprintf(data, sizeof(data), "%d", driver_mode);
 	
     /* Create output file descriptor */
     fd = open(fullpath, O_WRONLY | O_CREAT, 0644);


### PR DESCRIPTION
Fix two issues found in the LED platform code:

* LED values > 9 were not properly handled, causing LED states improperly reported.
* PATH name buffer used for storing sysfs paths was insufficiently sized, causing buffer overruns which may trigger stack protection.

For details see the individual commit messages.