### PR TITLE
Accton AS4610: let the CPLD driver handle sub devices

### DIFF
--- a/packages/platforms/accton/armxx/arm-accton-as4610/modules/accton_as4610_cpld.c
+++ b/packages/platforms/accton/armxx/arm-accton-as4610/modules/accton_as4610_cpld.c
@@ -33,6 +33,7 @@
 #include <linux/stat.h>
 #include <linux/hwmon-sysfs.h>
 #include <linux/delay.h>
+#include <linux/platform_device.h>
 
 #define I2C_RW_RETRY_COUNT				10
 #define I2C_RW_RETRY_INTERVAL			60 /* ms */
@@ -64,6 +65,7 @@ enum as4610_product_id_e {
 struct as4610_54_cpld_data {
     enum cpld_type   type;
     struct device   *hwmon_dev;
+    struct platform_device *fan_pdev;
     struct mutex     update_lock;
 };
 
@@ -443,6 +445,8 @@ static ssize_t show_version(struct device *dev, struct device_attribute *attr, c
     return sprintf(buf, "%d", val);
 }
 
+int as4610_product_id(void);
+
 /* I2C init/probing/exit functions */
 static int as4610_54_cpld_probe(struct i2c_client *client,
 			 const struct i2c_device_id *id)
@@ -472,8 +476,28 @@ static int as4610_54_cpld_probe(struct i2c_client *client,
     }
 
     as4610_54_cpld_add_client(client);
+
+    switch (as4610_product_id()) {
+    case PID_AS4610_30P:
+    case PID_AS4610_54P:
+    case PID_AS4610_54T_B:
+	    data->fan_pdev = platform_device_register_simple("as4610_fan", -1, NULL, 0);
+	    if (IS_ERR(data->fan_pdev)) {
+		    ret = PTR_ERR(data->fan_pdev);
+		    goto exit_unregister;
+	    }
+	    break;
+    default:
+	    /* no fan */
+	    break;
+    }
+
     return 0;
 
+exit_unregister:
+    as4610_54_cpld_remove_client(client);
+    /* Remove sysfs hooks */
+    sysfs_remove_group(&client->dev.kobj, &as4610_54_cpld_group);
 exit_free:
     kfree(data);
 exit:
@@ -483,6 +507,9 @@ exit:
 static int as4610_54_cpld_remove(struct i2c_client *client)
 {
     struct as4610_54_cpld_data *data = i2c_get_clientdata(client);
+
+    if (data->fan_pdev)
+	    platform_device_unregister(data->fan_pdev);
 
     as4610_54_cpld_remove_client(client);
 

--- a/packages/platforms/accton/armxx/arm-accton-as4610/modules/accton_as4610_fan.c
+++ b/packages/platforms/accton/armxx/arm-accton-as4610/modules/accton_as4610_fan.c
@@ -299,15 +299,16 @@ static int as4610_fan_remove(struct platform_device *pdev)
 	return 0;
 }
 
-static const struct i2c_device_id as4610_fan_id[] = {
+static const struct platform_device_id as4610_fan_id[] = {
 	{ "as4610_fan", 0 },
 	{}
 };
-MODULE_DEVICE_TABLE(i2c, as4610_fan_id);
+MODULE_DEVICE_TABLE(platform, as4610_fan_id);
 
 static struct platform_driver as4610_fan_driver = {
 	.probe		= as4610_fan_probe,
 	.remove		= as4610_fan_remove,
+	.id_table	= as4610_fan_id,
 	.driver		= {
 		.name	= DRVNAME,
 		.owner	= THIS_MODULE,


### PR DESCRIPTION
Properly let the CPLD driver manage the LED and CPLD platform devices instead of registering them always in their respective modules.

This avoids registering devices on platforms without the CPLD present, introduces proper ordering of registering the platform devices only after the CPLD driver has finished initializing, and simplifies the drivers significantly.

To make this properly work, also fix the module device table for the FAN driver, and add one for the LED driver.