### PR TITLE
[Edgecore][as9817-64d][as9817-64o] Fixed spi_busy_reg's pcie addr issue

### DIFF
--- a/packages/platforms/accton/x86-64/as9817-64/src/modules/x86-64-accton-as9817-64-fan.c
+++ b/packages/platforms/accton/x86-64/as9817-64/src/modules/x86-64-accton-as9817-64-fan.c
@@ -32,6 +32,7 @@
 #include <linux/ipmi.h>
 #include <linux/ipmi_smi.h>
 #include <linux/platform_device.h>
+#include <linux/string_helpers.h>
 
 #define DRVNAME "as9817_64_fan"
 #define ACCTON_IPMI_NETFN 0x34
@@ -312,23 +313,41 @@ static int ipmi_send_message(struct ipmi_data *ipmi, unsigned char cmd,
 {
     int status = 0, retry = 0;
 
+    char *cmdline = kstrdup_quotable_cmdline(current, GFP_KERNEL);
+
+    int i = 0;
+    char raw_cmd[20] = "";
+    sprintf(raw_cmd, "0x%02x", cmd);
+    if(tx_len) {
+        for(i = 0; i < tx_len; i++)
+            sprintf(raw_cmd + strlen(raw_cmd), " 0x%02x", tx_data[i]);
+    }
+
     for (retry = 0; retry <= IPMI_ERR_RETRY_TIMES; retry++) {
-        status = _ipmi_send_message(ipmi,cmd, tx_data, tx_len, rx_data, rx_len);
+        status = _ipmi_send_message(ipmi,cmd, tx_data, tx_len, rx_data, 
+                                    rx_len);
         if (unlikely(status != 0)) {
-            dev_err(&data->pdev->dev, "ipmi_send_message_%d err status(%d)\r\n",
-                                        retry, status);
+            dev_err(&data->pdev->dev, 
+                    "ipmi_send_message_%d err status(%d)[%s] raw_cmd=[%s] tx_msgid=(%02x)\r\n",
+                    retry, status, cmdline ? cmdline : "", raw_cmd, 
+                    (int)ipmi->tx_msgid);
             continue;
         }
 
         if (unlikely(ipmi->rx_result != 0)) {
-            dev_err(&data->pdev->dev, "ipmi_send_message_%d err result(%d)\r\n",
-                                        retry, ipmi->rx_result);
+            dev_err(&data->pdev->dev, 
+                    "ipmi_send_message_%d err result(%d)[%s] raw_cmd=[%s] tx_msgid=(%02x)\r\n",
+                    retry, ipmi->rx_result, cmdline ? cmdline : "", raw_cmd, 
+                    (int)ipmi->tx_msgid);
             continue;
         }
 
         break;
     }
 
+    if (cmdline) 
+        kfree(cmdline);
+    
     return status;
 }
 

--- a/packages/platforms/accton/x86-64/as9817-64/src/modules/x86-64-accton-as9817-64-i2c-ocores.c
+++ b/packages/platforms/accton/x86-64/as9817-64/src/modules/x86-64-accton-as9817-64-i2c-ocores.c
@@ -110,9 +110,8 @@ do {                                                \
     spin_unlock(lock);                              \
 } while (0)
 
-#define SPI_BUSY_ADDR                       (0xb3320000 + 0x30)
-#define IOREMAP_SIZE                        (0x04)
-static void __iomem    *spi_busy_reg=NULL;
+void __iomem    *spi_busy_reg=NULL;
+EXPORT_SYMBOL(spi_busy_reg);
 int wait_spi(u32 mask, unsigned long timeout) {
     u32 data;
     u32 ri = 0;
@@ -941,24 +940,11 @@ static int __init ocores_i2c_as9817_64_init(void)
 
     spin_lock_init(&cpld_access_lock);
 
-    /*
-     * The register address of SPI Busy is 0x33.
-     * It can not only read one byte. It needs to read four bytes from 0x30.
-     * The value is obtained by '(ioread32(spi_busy_reg) >> 24) & 0xFF'.
-     */
-    spi_busy_reg = ioremap(SPI_BUSY_ADDR, IOREMAP_SIZE);
-    if (!spi_busy_reg) {
-        pr_err("could not remap spi_busy_reg memory\n");
-        return -ENOMEM;
-    }
-
     return 0;
 }
 static void __exit ocores_i2c_as9817_64_exit(void)
 {
     platform_driver_unregister(&ocores_i2c_driver);
-
-    iounmap(spi_busy_reg);
 }
 
 module_init(ocores_i2c_as9817_64_init);

--- a/packages/platforms/accton/x86-64/as9817-64/src/modules/x86-64-accton-as9817-64-leds.c
+++ b/packages/platforms/accton/x86-64/as9817-64/src/modules/x86-64-accton-as9817-64-leds.c
@@ -30,6 +30,7 @@
 #include <linux/ipmi.h>
 #include <linux/ipmi_smi.h>
 #include <linux/platform_device.h>
+#include <linux/string_helpers.h>
 
 #define DRVNAME "as9817_64_led"
 #define ACCTON_IPMI_NETFN 0x34
@@ -238,22 +239,39 @@ static int ipmi_send_message(struct ipmi_data *ipmi, unsigned char cmd,
 {
     int status = 0, retry = 0;
 
+    char *cmdline = kstrdup_quotable_cmdline(current, GFP_KERNEL);
+
+    int i = 0;
+    char raw_cmd[20] = "";
+    sprintf(raw_cmd, "0x%02x", cmd);
+    if(tx_len){
+        for(i = 0; i < tx_len; i++)
+            sprintf(raw_cmd + strlen(raw_cmd), " 0x%02x", tx_data[i]);
+    }
+
     for (retry = 0; retry <= IPMI_ERR_RETRY_TIMES; retry++) {
         status = _ipmi_send_message(ipmi, cmd, tx_data, tx_len, rx_data, rx_len);
         if (unlikely(status != 0)) {
-            dev_err(&data->pdev->dev, "ipmi_send_message_%d err status(%d)\r\n",
-                                        retry, status);
+            dev_err(&data->pdev->dev, 
+                    "ipmi_send_message_%d err status(%d)[%s] raw_cmd=[%s] tx_msgid=(%02x)\r\n",
+                    retry, status, cmdline ? cmdline : "", raw_cmd, 
+                    (int)ipmi->tx_msgid);
             continue;
         }
 
         if (unlikely(ipmi->rx_result != 0)) {
-            dev_err(&data->pdev->dev, "ipmi_send_message_%d err result(%d)\r\n",
-                                        retry, ipmi->rx_result);
+            dev_err(&data->pdev->dev, 
+                    "ipmi_send_message_%d err result(%d)[%s] raw_cmd=[%s] tx_msgid=(%02x)\r\n",
+                    retry, ipmi->rx_result, cmdline ? cmdline : "", raw_cmd, 
+                    (int)ipmi->tx_msgid);
             continue;
         }
 
         break;
     }
+
+    if (cmdline) 
+        kfree(cmdline);
 
     return status;
 }

--- a/packages/platforms/accton/x86-64/as9817-64/src/modules/x86-64-accton-as9817-64-sys.c
+++ b/packages/platforms/accton/x86-64/as9817-64/src/modules/x86-64-accton-as9817-64-sys.c
@@ -30,6 +30,7 @@
 #include <linux/ipmi.h>
 #include <linux/ipmi_smi.h>
 #include <linux/platform_device.h>
+#include <linux/string_helpers.h>
 
 #define DRVNAME "as9817_64_sys"
 #define ACCTON_IPMI_NETFN 0x34
@@ -83,8 +84,8 @@ static struct platform_driver as9817_64_sys_driver = {
     .remove = as9817_64_sys_remove,
     .driver = {
         .name = DRVNAME,
-        .owner = THIS_MODULE
-    }
+        .owner = THIS_MODULE,
+    },
 };
 
 enum as9817_64_sys_sysfs_attrs {
@@ -186,24 +187,40 @@ static int ipmi_send_message(struct ipmi_data *ipmi, unsigned char cmd,
 {
     int status = 0, retry = 0;
 
+    char *cmdline = kstrdup_quotable_cmdline(current, GFP_KERNEL);
+
+    int i = 0;
+    char raw_cmd[20] = "";
+    sprintf(raw_cmd, "0x%02x", cmd);
+    if(tx_len) {
+        for(i = 0; i < tx_len; i++)
+            sprintf(raw_cmd + strlen(raw_cmd), " 0x%02x", tx_data[i]);
+    }
+
     for (retry = 0; retry <= IPMI_ERR_RETRY_TIMES; retry++) {
-        status = _ipmi_send_message(ipmi,cmd, tx_data, tx_len, rx_data, rx_len);
+        status = _ipmi_send_message(ipmi,cmd, tx_data, tx_len, rx_data, 
+                 rx_len);
         if (unlikely(status != 0)) {
             dev_err(&data->pdev->dev,
-                    "ipmi_send_message_%d err status(%d)\r\n",
-                    retry, status);
+                    "ipmi_send_message_%d err status(%d)[%s] raw_cmd=[%s] tx_msgid=(%02x)\r\n",
+                    retry, status, cmdline ? cmdline : "", raw_cmd, 
+                    (int)ipmi->tx_msgid);
             continue;
         }
 
         if (unlikely(ipmi->rx_result != 0)) {
             dev_err(&data->pdev->dev,
-                    "ipmi_send_message_%d err rx_result(%d)\r\n",
-                    retry, ipmi->rx_result);
+                    "ipmi_send_message_%d err rx_result(%d)[%s] raw_cmd=[%s] tx_msgid=(%02x)\r\n",
+                    retry, ipmi->rx_result, cmdline ? cmdline : "", raw_cmd, 
+                    (int)ipmi->tx_msgid);
             continue;
         }
 
         break;
     }
+
+    if (cmdline) 
+        kfree(cmdline);
 
     return status;
 }


### PR DESCRIPTION
1. the pcie addr of spi_busy_reg becomes the current bar0 addr plus spi_busy_reg offset, instead of a fixed addr.