### PR TITLE
Enhanced the ONLP_SFP_CONTROL for 'Soft Rate_Select Select' in Optional Status/Control Bits as per SFF-8472  Specification for Management Interface for SFP+

### DIFF
--- a/packages/base/any/onlp/src/onlp/module/inc/onlp/sfp.h
+++ b/packages/base/any/onlp/src/onlp/module/inc/onlp/sfp.h
@@ -41,6 +41,7 @@ typedef enum onlp_sfp_control_e {
     ONLP_SFP_CONTROL_TX_DISABLE,
     ONLP_SFP_CONTROL_TX_DISABLE_CHANNEL,
     ONLP_SFP_CONTROL_LP_MODE,
+    ONLP_SFP_CONTROL_SOFT_RATE_SELECT,
     ONLP_SFP_CONTROL_POWER_OVERRIDE,
     ONLP_SFP_CONTROL_LAST = ONLP_SFP_CONTROL_POWER_OVERRIDE,
     ONLP_SFP_CONTROL_COUNT,
@@ -58,7 +59,8 @@ typedef enum onlp_sfp_control_flag_e {
     ONLP_SFP_CONTROL_FLAG_TX_DISABLE = (1 << 4),
     ONLP_SFP_CONTROL_FLAG_TX_DISABLE_CHANNEL = (1 << 5),
     ONLP_SFP_CONTROL_FLAG_LP_MODE = (1 << 6),
-    ONLP_SFP_CONTROL_FLAG_POWER_OVERRIDE = (1 << 7),
+    ONLP_SFP_CONTROL_FLAG_SOFT_RATE_SELECT = (1 << 7),
+    ONLP_SFP_CONTROL_FLAG_POWER_OVERRIDE = (1 << 8),
 } onlp_sfp_control_flag_t;
 /* <auto.end.enum(tag:sfp2).define> */
 
@@ -242,6 +244,7 @@ int onlp_sfp_control_flags_get(int port, uint32_t* flags);
     "TX_DISABLE", \
     "TX_DISABLE_CHANNEL", \
     "LP_MODE", \
+    "SOFT_RATE_SELECT", \
     "POWER_OVERRIDE", \
 }
 /** Enum names. */

--- a/packages/base/any/onlp/src/onlp/module/src/onlp_enums.c
+++ b/packages/base/any/onlp/src/onlp/module/src/onlp_enums.c
@@ -856,6 +856,7 @@ aim_map_si_t onlp_sfp_control_map[] =
     { "TX_DISABLE", ONLP_SFP_CONTROL_TX_DISABLE },
     { "TX_DISABLE_CHANNEL", ONLP_SFP_CONTROL_TX_DISABLE_CHANNEL },
     { "LP_MODE", ONLP_SFP_CONTROL_LP_MODE },
+    { "SOFT_RATE_SELECT", ONLP_SFP_CONTROL_SOFT_RATE_SELECT},
     { "POWER_OVERRIDE", ONLP_SFP_CONTROL_POWER_OVERRIDE },
     { NULL, 0 }
 };
@@ -869,6 +870,7 @@ aim_map_si_t onlp_sfp_control_desc_map[] =
     { "None", ONLP_SFP_CONTROL_TX_DISABLE },
     { "None", ONLP_SFP_CONTROL_TX_DISABLE_CHANNEL },
     { "None", ONLP_SFP_CONTROL_LP_MODE },
+    { "None", ONLP_SFP_CONTROL_SOFT_RATE_SELECT },
     { "None", ONLP_SFP_CONTROL_POWER_OVERRIDE },
     { NULL, 0 }
 };
@@ -922,6 +924,7 @@ aim_map_si_t onlp_sfp_control_flag_map[] =
     { "TX_DISABLE", ONLP_SFP_CONTROL_FLAG_TX_DISABLE },
     { "TX_DISABLE_CHANNEL", ONLP_SFP_CONTROL_FLAG_TX_DISABLE_CHANNEL },
     { "LP_MODE", ONLP_SFP_CONTROL_FLAG_LP_MODE },
+    { "SOFT_RATE_SELECT", ONLP_SFP_CONTROL_FLAG_SOFT_RATE_SELECT},
     { "POWER_OVERRIDE", ONLP_SFP_CONTROL_FLAG_POWER_OVERRIDE },
     { NULL, 0 }
 };
@@ -935,6 +938,7 @@ aim_map_si_t onlp_sfp_control_flag_desc_map[] =
     { "None", ONLP_SFP_CONTROL_FLAG_TX_DISABLE },
     { "None", ONLP_SFP_CONTROL_FLAG_TX_DISABLE_CHANNEL },
     { "None", ONLP_SFP_CONTROL_FLAG_LP_MODE },
+    { "None", ONLP_SFP_CONTROL_FLAG_SOFT_RATE_SELECT },
     { "None", ONLP_SFP_CONTROL_FLAG_POWER_OVERRIDE },
     { NULL, 0 }
 };
@@ -1243,4 +1247,3 @@ onlp_thermal_threshold_valid(onlp_thermal_threshold_t e)
 }
 
 /* <auto.end.enum(ALL).source> */
-

--- a/packages/base/any/onlp/src/onlp/module/src/onlp_main.c
+++ b/packages/base/any/onlp/src/onlp/module/src/onlp_main.c
@@ -113,6 +113,9 @@ show_inventory__(aim_pvs_t* pvs, int database)
             if(status & ONLP_SFP_CONTROL_FLAG_LP_MODE) {
                 *cp++ = 'L';
             }
+            if(status & ONLP_SFP_CONTROL_FLAG_SOFT_RATE_SELECT) {
+                *cp++ = 'M';
+            }
             aim_printf(pvs, "%4d  %-14s  %-6s  %-6.6s  %-5.5s  %-16.16s  %-16.16s  %16.16s\n",
                        port,
                        sff.info.module_type_name,

--- a/packages/base/any/onlp/src/onlp/module/src/sfp.c
+++ b/packages/base/any/onlp/src/onlp/module/src/sfp.c
@@ -353,7 +353,8 @@ onlp_sfp_control_flags_get(int port, uint32_t* flags)
             ONLP_SFP_CONTROL_RESET_STATE,
             ONLP_SFP_CONTROL_RX_LOS,
             ONLP_SFP_CONTROL_TX_DISABLE,
-            ONLP_SFP_CONTROL_LP_MODE
+            ONLP_SFP_CONTROL_LP_MODE,
+            ONLP_SFP_CONTROL_SOFT_RATE_SELECT
         };
 
     if(flags) {


### PR DESCRIPTION
This PR is raised to add Multi-rate soft select in sfp control set, for multi-rate supporting transeivers

This is supported as per SFF-8472 : 5.7 Rate Identifier [Address A0h, Byte 13]

Ref : SFF-8472: https://members.snia.org/document/dl/25916

**Test System :**
Transeiver used for tesing **FiniserFTLX8574D3BCV**, it supports multimode rates (1G/10G). https://www.epsglobal.com/Media-Library/EPSGlobal/Products/files/finisar/transceivers/FTLX8574D3BCV.pdf?ext=.pdf
Platform : **AS7535-28XB-O-AC-F**
The port with the above transeiver is connected to IXIA port with same transeriver
Port UP & DOWN state changes are verfied

Also please note that I have signedoff the commits and pushed

Requesting for review & commet/approve the code change
