### PR TITLE
[Accton][as7535-28xb] Modify what onlpdump -x displays

### DIFF
--- a/packages/platforms/accton/x86-64/as7535-28xb/modules/builds/x86-64-accton-as7535-28xb-cpld.c
+++ b/packages/platforms/accton/x86-64/as7535-28xb/modules/builds/x86-64-accton-as7535-28xb-cpld.c
@@ -190,6 +190,7 @@ enum as7535_28xb_cpld_sysfs_attributes {
 	MODULE_PRESENT_ALL,
 	MODULE_RXLOS_ALL,
 	CPLD_VERSION,
+	MINOR_VERSION,
 	ACCESS,
 };
 
@@ -225,6 +226,10 @@ enum as7535_28xb_cpld_sysfs_attributes {
 	&sensor_dev_attr_module_rx_los_##index.dev_attr.attr
 
 static SENSOR_DEVICE_ATTR(version, S_IRUGO, show_version, NULL, CPLD_VERSION);
+
+static SENSOR_DEVICE_ATTR(minor_version, S_IRUGO, show_version, NULL, \
+							MINOR_VERSION);
+
 static SENSOR_DEVICE_ATTR(access, S_IWUSR, NULL, access, ACCESS);
 
 static SENSOR_DEVICE_ATTR(module_present_all, S_IRUGO, show_present_all, \
@@ -293,6 +298,7 @@ static struct attribute *as7535_28xb_cpld_attributes[] = {
 	DECLARE_SFP_TRANSCEIVER_ATTR(27),
 	DECLARE_SFP_TRANSCEIVER_ATTR(28),
 	&sensor_dev_attr_version.dev_attr.attr,
+	&sensor_dev_attr_minor_version.dev_attr.attr,
 	&sensor_dev_attr_access.dev_attr.attr,
 	&sensor_dev_attr_module_present_all.dev_attr.attr,
 	&sensor_dev_attr_module_rx_los_all.dev_attr.attr,
@@ -707,6 +713,13 @@ static ssize_t show_version(struct device *dev, struct device_attribute *da,
 		addr = 0x61;
 		reg = 0x1;
 		break;
+
+	case MINOR_VERSION:
+		bus = 12;
+		addr = 0x61;
+		reg = 0x2;
+		break;
+		
 	default:
 		return -ENXIO;
 	}

--- a/packages/platforms/accton/x86-64/as7535-28xb/onlp/builds/x86_64_accton_as7535_28xb/module/src/sysi.c
+++ b/packages/platforms/accton/x86-64/as7535-28xb/onlp/builds/x86_64_accton_as7535_28xb/module/src/sysi.c
@@ -34,12 +34,22 @@
 #include "x86_64_accton_as7535_28xb_int.h"
 #include "x86_64_accton_as7535_28xb_log.h"
 
-#define NUM_OF_CPLD_VER 3
+
+#define NUM_OF_CPLD_VER 8
+#define BMC_AUX_FW_VER_LEN 20
+
+#define BIOS_VER_PATH "/sys/devices/virtual/dmi/id/bios_version"
+#define BMC_VER_PREFIX "/sys/devices/pci0000:00/0000:00:1f.0/IPI0001:00/bmc/"
 
 static char* cpld_ver_path[NUM_OF_CPLD_VER] = {
+    "/sys/devices/platform/as7535_28xb_sys/cpu_cpld_version",
+    "/sys/devices/platform/as7535_28xb_sys/cpu_cpld_minor_version", 
     "/sys/bus/i2c/devices/12-0061/version",   /* Main CPLD */
-    "/sys/devices/platform/as7535_28xb_sys/fpga_version", /* FPGA */
-    "/sys/devices/platform/as7535_28xb_fan/version", /* Fan CPLD */
+    "/sys/bus/i2c/devices/12-0061/minor_version",
+    "/sys/devices/platform/as7535_28xb_fan/version",
+    "/sys/devices/platform/as7535_28xb_fan/minor_version",
+    "/sys/devices/platform/as7535_28xb_sys/fpga_version",
+    "/sys/devices/platform/as7535_28xb_sys/fpga_minor_version",
 };
 
 const char*
@@ -110,6 +120,12 @@ int
 onlp_sysi_platform_info_get(onlp_platform_info_t* pi)
 {
     int i, v[NUM_OF_CPLD_VER] = {0};
+    int len = 0;
+    onlp_onie_info_t onie;
+    char *bios_ver = NULL;
+    char *bmc_fw_ver = NULL;
+    char *tmp = NULL;
+    char bmc_aux_fw_ver[BMC_AUX_FW_VER_LEN] = {0};
 
     for (i = 0; i < AIM_ARRAYSIZE(cpld_ver_path); i++) {
         v[i] = 0;
@@ -119,8 +135,31 @@ onlp_sysi_platform_info_get(onlp_platform_info_t* pi)
         }
     }
 
-    pi->cpld_versions = aim_fstrdup("\r\nCPLD:%02x\r\nFPGA:%02x\r\nFan CPLD:%02x",
-                                     v[0], v[1], v[2]);
+    onlp_file_read_str(&bios_ver, BIOS_VER_PATH);
+    onlp_onie_decode_file(&onie, IDPROM_PATH);
+    onlp_file_read_str(&bmc_fw_ver, BMC_VER_PREFIX"firmware_revision");
+    len = onlp_file_read_str(&tmp, BMC_VER_PREFIX"aux_firmware_revision");
+
+    if(tmp && len){
+        memcpy(bmc_aux_fw_ver, tmp, len);
+        bmc_aux_fw_ver[len] = '\0';
+    }
+
+    pi->cpld_versions = aim_fstrdup("\r\n\t   CPU CPLD(0x65): %02X.%02X"
+                                    "\r\n\t   Main CPLD(0x61): %02X.%02X"
+                                    "\r\n\t   Fan CPLD(0x66): %02X.%02X"
+                                    "\r\n\t   FPGA(0x60): %02X.%02X\r\n",
+                                    v[0], v[1], v[2], v[3], 
+                                    v[4], v[5], v[6], v[7]);
+
+    pi->other_versions = aim_fstrdup("\r\n\t   BIOS: %s\r\n\t   ONIE: %s"
+                                     "\r\n\t   BMC: %s.%c%c",
+                                    bios_ver, onie.onie_version, bmc_fw_ver, 
+                                    bmc_aux_fw_ver[17], bmc_aux_fw_ver[18]);
+
+    AIM_FREE_IF_PTR(bios_ver);
+    AIM_FREE_IF_PTR(bmc_fw_ver);
+    AIM_FREE_IF_PTR(tmp);
 
     return ONLP_STATUS_OK;
 }
@@ -129,4 +168,5 @@ void
 onlp_sysi_platform_info_free(onlp_platform_info_t* pi)
 {
     aim_free(pi->cpld_versions);
+    aim_free(pi->other_versions);
 }


### PR DESCRIPTION
[Accton][as7535-28xb] Modify what onlpdump -x displays

1. Add a sysfs, minor_vsrsion, in x86-64-accton-as7535-28xb-cpld.c

2. Add a sysfs, minor_version, in x86-64-accton-as7535-28xb-fan.c

3. Add 3 sysfses, fpga_minor_version, cpu_cpld_version, and 
   cpu_cpld_minor_version, in x86-64-accton-as7535-28xb-sys.c

4. Modify what onlpdump -x displays.
    Before modification:

            CPLD Versions:
        CPLD:0b
        FPGA:5b
        Fan CPLD:0b

    After modification:

            CPLD Versions:
               CPU CPLD(0x65): E1.0A
               Main CPLD(0x61): 0B.04
               Fan CPLD(0x66): 0B.13
               FPGA(0x60): 5B.16

            Other Versions:
               BIOS: v48.0b.03.00
               ONIE: 2020.11.00.14
               BMC: 0.4.00