### PR TITLE
[Accton][as7535-28xb] Add onlp_data_path_reset() to support chip reset

### DIFF
--- a/packages/platforms/accton/x86-64/as7535-28xb/onlp/builds/x86_64_accton_as7535_28xb/module/src/platform_lib.h
+++ b/packages/platforms/accton/x86-64/as7535-28xb/onlp/builds/x86_64_accton_as7535_28xb/module/src/platform_lib.h
@@ -65,6 +65,13 @@ enum onlp_thermal_id {
     THERMAL_COUNT
 };
 
+enum reset_dev_type {
+    WARM_RESET_MAC = 1,
+    WARM_RESET_PHY, /* Not supported */
+    WARM_RESET_MUX,
+    WARM_RESET_MAX
+};
+
 enum onlp_led_id {
     LED_LOC = 1,
     LED_DIAG,


### PR DESCRIPTION
* Implements warm reset for MAC, MUX.
* @param unit_id: The warm reset device unit ID, should be 0.
* @param reset_dev: The warm reset device ID, should be 1 to (WARM_RESET_MAX-1).
* @param ret: Return value.