### PR TITLE
[Accton][as7946-30xb] Add onlp_data_path_reset() to support chip reset

### DIFF
--- a/packages/platforms/accton/x86-64/as7946-30xb/onlp/builds/x86_64_accton_as7946_30xb/module/src/fani.c
+++ b/packages/platforms/accton/x86-64/as7946-30xb/onlp/builds/x86_64_accton_as7946_30xb/module/src/fani.c
@@ -62,15 +62,6 @@ enum fan_id {
         { 0 },\
     }
 
-#define AIM_FREE_IF_PTR(p) \
-    do \
-    { \
-        if (p) { \
-            aim_free(p); \
-            p = NULL; \
-        } \
-    } while (0)
-
 /* Static fan information */
 onlp_fan_info_t finfo[] = {
     { }, /* Not used */

--- a/packages/platforms/accton/x86-64/as7946-30xb/onlp/builds/x86_64_accton_as7946_30xb/module/src/platform_lib.c
+++ b/packages/platforms/accton/x86-64/as7946-30xb/onlp/builds/x86_64_accton_as7946_30xb/module/src/platform_lib.c
@@ -1,0 +1,65 @@
+/************************************************************
+ * <bsn.cl fy=2014 v=onl>
+ *
+ *           Copyright 2014 Big Switch Networks, Inc.
+ *
+ * Licensed under the Eclipse Public License, Version 1.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *        http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ *
+ * </bsn.cl>
+ ************************************************************
+ *
+ * Platform Library
+ *
+ ***********************************************************/
+#include <unistd.h>
+#include <onlp/onlp.h>
+#include <onlplib/file.h>
+#include "platform_lib.h"
+
+#define WARM_RESET_FORMAT "/sys/devices/platform/as7946_30xb_sys/reset_%s"
+
+/**
+ * @brief warm reset for mac
+ * @param unit_id The warm reset device unit id, should be 0
+ * @param reset_dev The warm reset device id, should be 1 ~ (WARM_RESET_MAX-1)
+ * @param ret return value.
+ */
+int onlp_data_path_reset(uint8_t unit_id, uint8_t reset_dev)
+{
+    int len = 0;
+    int ret = ONLP_STATUS_OK;
+    char *magic_num = NULL;
+    char *device_id[] = { NULL, "mac" };
+
+    if (unit_id != 0 || reset_dev >= WARM_RESET_MAX)
+        return ONLP_STATUS_E_PARAM;
+
+    if (reset_dev == 0)
+        return ONLP_STATUS_E_UNSUPPORTED;
+
+    /* Reset device */
+    len = onlp_file_read_str(&magic_num, WARM_RESET_FORMAT, device_id[reset_dev]);
+    if (magic_num && len) {
+        ret = onlp_file_write_str(magic_num, WARM_RESET_FORMAT, device_id[reset_dev]);
+        if (ret < 0) {
+            AIM_LOG_ERROR("Reset device-%d:(%s) failed.", reset_dev, device_id[reset_dev]);
+        }
+    }
+    else {
+        ret = ONLP_STATUS_E_INTERNAL;
+    }
+
+    AIM_FREE_IF_PTR(magic_num);
+    return ret;
+}

--- a/packages/platforms/accton/x86-64/as7946-30xb/onlp/builds/x86_64_accton_as7946_30xb/module/src/platform_lib.h
+++ b/packages/platforms/accton/x86-64/as7946-30xb/onlp/builds/x86_64_accton_as7946_30xb/module/src/platform_lib.h
@@ -42,6 +42,15 @@
 #define FAN_BOARD_PATH "/sys/devices/platform/as7946_30xb_fan/"
 #define IDPROM_PATH    "/sys/devices/platform/as7946_30xb_sys/eeprom"
 
+#define AIM_FREE_IF_PTR(p) \
+    do \
+    { \
+        if (p) { \
+            aim_free(p); \
+            p = NULL; \
+        } \
+    } while (0)
+
 enum onlp_led_id {
     LED_LOC = 1,
     LED_DIAG,
@@ -68,6 +77,11 @@ enum onlp_thermal_id {
     THERMAL_1_ON_PSU2,
     THERMAL_2_ON_PSU2,
     THERMAL_3_ON_PSU2,
+};
+
+enum reset_dev_type {
+    WARM_RESET_MAC = 1,
+    WARM_RESET_MAX
 };
 
 #endif  /* __PLATFORM_LIB_H__ */

--- a/packages/platforms/accton/x86-64/as7946-30xb/onlp/builds/x86_64_accton_as7946_30xb/module/src/psui.c
+++ b/packages/platforms/accton/x86-64/as7946-30xb/onlp/builds/x86_64_accton_as7946_30xb/module/src/psui.c
@@ -37,15 +37,6 @@
         }                                       \
     } while(0)
 
-#define AIM_FREE_IF_PTR(p) \
-    do \
-    { \
-        if (p) { \
-            aim_free(p); \
-            p = NULL; \
-        } \
-    } while (0)
-
 int
 onlp_psui_init(void)
 {


### PR DESCRIPTION
* Implements warm reset for MAC.
* @param unit_id: The warm reset device unit ID, should be 0.
* @param reset_dev: The warm reset device ID, should be 1 to (WARM_RESET_MAX-1).
* @param ret: Return value.