### PR TITLE
[installer] Use the Grub version comes from ONL OS

### DIFF
--- a/builds/any/installer/grub/builds/Makefile
+++ b/builds/any/installer/grub/builds/Makefile
@@ -14,6 +14,12 @@ DEBIAN_VERSION_ID := $(shell echo $(VERSION_ID))
 include $(ONL)/make/versions/version-onl.mk
 INSTALLER_NAME=$(FNAME_PRODUCT_VERSION)_ONL-OS$(DEBIAN_VERSION_ID)_$(FNAME_BUILD_ID)_$(UARCH)_$(BOOTMODE)_INSTALLER
 
+ifeq ($(ARCH),amd64)
+MKINSTALLER_OPTS_ARCH	= \
+  --add-dir $(ONL)/builds/$(ARCH)/rootfs/builds/$(ONL_DEBIAN_SUITE)/rootfs-$(ARCH).d/usr/lib/grub/i386-pc \
+  --add-dir $(ONL)/builds/$(ARCH)/rootfs/builds/$(ONL_DEBIAN_SUITE)/rootfs-$(ARCH).d/usr/lib/grub/x86_64-efi
+endif
+
 MKINSTALLER_OPTS	= \
   --onl-version "$(VERSION_STRING)" \
   --arch $(ARCH) \
@@ -25,6 +31,7 @@ MKINSTALLER_OPTS	= \
   --postinstall-script $(ONL)/builds/any/installer/sample-postinstall.sh \
   --plugin $(ONL)/builds/any/installer/sample-preinstall.py \
   --plugin $(ONL)/builds/any/installer/sample-postinstall.py \
+  $(MKINSTALLER_OPTS_ARCH) \
   # THIS LINE INTENTIONALLY LEFT BLANK
 
 WORK_DIR := $(ONL_DEBIAN_SUITE)

--- a/builds/any/rootfs/buster/common/amd64-base-packages.yml
+++ b/builds/any/rootfs/buster/common/amd64-base-packages.yml
@@ -7,6 +7,7 @@
 - parted
 - smartmontools
 - grub2
+- grub-efi-amd64-bin
 - onl-upgrade
 - onl-kernel-4.9-lts-x86-64-all-modules
 - onl-kernel-4.14-lts-x86-64-all-modules

--- a/builds/any/rootfs/jessie/common/amd64-base-packages.yml
+++ b/builds/any/rootfs/jessie/common/amd64-base-packages.yml
@@ -7,6 +7,7 @@
 - parted
 - smartmontools
 - grub2
+- grub-efi-amd64-bin
 - onl-upgrade
 - hw-management
 - sx-kernel

--- a/builds/any/rootfs/stretch/common/amd64-base-packages.yml
+++ b/builds/any/rootfs/stretch/common/amd64-base-packages.yml
@@ -7,6 +7,7 @@
 - parted
 - smartmontools
 - grub2
+- grub-efi-amd64-bin
 - onl-upgrade
 - hw-management
 - onl-kernel-4.9-lts-x86-64-all-modules

--- a/packages/base/all/vendor-config-onl/src/python/onl/install/BaseInstall.py
+++ b/packages/base/all/vendor-config-onl/src/python/onl/install/BaseInstall.py
@@ -683,7 +683,7 @@ class GrubInstaller(SubprocessMixin, Base):
 
         kernels = []
         for f in set(os.listdir(self.im.installerConf.installer_dir) + self.zf.namelist()):
-            if 'kernel' in f:
+            if f.startswith('kernel'):
                 kernels.append(f)
 
         initrd = None
@@ -705,6 +705,20 @@ class GrubInstaller(SubprocessMixin, Base):
                 self.installerCopy(b, dst, optional=True)
             [_cp(e) for e in kernels]
             _cp(initrd, "%s.cpio.gz" % self.im.installerConf.installer_platform)
+
+            d = None
+            if self.isUEFI:
+                d = 'x86_64-efi/'
+            else:
+                d = 'i386-pc/'
+            dirs = os.path.join(ctx.dir, 'onl-loader', 'grub', d)
+            if not os.path.isdir(dirs):
+                os.makedirs(dirs)
+            for f in self.zf.namelist():
+                if f.startswith(d) and f != d:
+                    dst = os.path.join(dirs, os.path.basename(f))
+                    if not os.path.exists(dst):
+                        self.installerCopy(f, dst)
 
         return 0
 


### PR DESCRIPTION
The Grub in ONiE OS is always out of date.  Reinstalling ONiE and ONL for upgrading Grub is quite complex and takes a lot of time.

In ONL runtime, it can upgrade the Grub directly by performing grub-install command with appropriate arguments.

This patch changes the ONL installer to include libraries come from ONL root filesystem for grub-install.  A fresh installed ONL will have the Grub version from ONL OS immediately.