### PR TITLE
[Accton][as7726-32x] Add set/get QSFP tx-disable functionality

### DIFF
--- a/packages/platforms/accton/x86-64/as7726-32x/onlp/builds/x86_64_accton_as7726_32x/module/src/sfpi.c
+++ b/packages/platforms/accton/x86-64/as7726-32x/onlp/builds/x86_64_accton_as7726_32x/module/src/sfpi.c
@@ -39,6 +39,10 @@
 #define MODULE_PRESENT_ALL_ATTR	        "/sys/bus/i2c/devices/%d-00%d/module_present_all"
 #define MODULE_RXLOS_ALL_ATTR_CPLD	    "/sys/bus/i2c/devices/11-0060/module_rx_los_all"
 #define MODULE_RXLOS_ALL_ATTR_CPLD3	    "/sys/bus/i2c/devices/6-0064/module_rx_los_all"
+/* QSFP device address of eeprom */
+#define PORT_EEPROM_DEVADDR             0x50
+/* QSFP tx disable offset */
+#define QSFP_EEPROM_OFFSET_TXDIS        0x56
 
 
 int sfp_map_bus[] ={21, 22, 23, 24, 26, 25, 28, 27,
@@ -279,22 +283,37 @@ onlp_sfpi_control_set(int port, onlp_sfp_control_t control, int value)
     int rv;
     int addr = 60;
     int bus  = 11;
+    int present = 0;
+
+    if (port < 0 || port >= 34) {
+        return ONLP_STATUS_E_UNSUPPORTED;
+    }
 
     switch(control)
         {
         case ONLP_SFP_CONTROL_TX_DISABLE:
             {
-                if(port==32 || port==33) {
-                    if (onlp_file_write_int(0, MODULE_TXDISABLE_FORMAT, bus, addr, (port+1)) < 0) {
-                        AIM_LOG_ERROR("Unable to set tx_disable status to port(%d)\r\n", port);
+                if(port >= 0 && port <= 31) {
+                    present = onlp_sfpi_is_present(port);
+                    /* read qsfp eeprom offset of tx disable if qsfp on the port */
+                    if(present == 1){
+                        /* txdis valid bit(bit0-bit3), xxxx 1111 */
+                        value = value&0xf;
+
+                        onlp_sfpi_dev_writeb(port, PORT_EEPROM_DEVADDR, QSFP_EEPROM_OFFSET_TXDIS, value);
+
+                        rv = ONLP_STATUS_OK;
+
+                    } else {
                         rv = ONLP_STATUS_E_INTERNAL;
                     }
-                    else {
+                } else {
+                    if (onlp_file_write_int(value, MODULE_TXDISABLE_FORMAT, bus, addr, (port+1)) < 0) {
+                        AIM_LOG_ERROR("Unable to set tx_disable status to port(%d)\r\n", port);
+                        rv = ONLP_STATUS_E_INTERNAL;
+                    } else {
                         rv = ONLP_STATUS_OK;
                     }
-                }
-                else {
-                    rv = ONLP_STATUS_E_UNSUPPORTED;
                 }
                 break;
             }
@@ -313,6 +332,12 @@ onlp_sfpi_control_get(int port, onlp_sfp_control_t control, int* value)
     int rv;
     int addr = 60;
     int bus  = 11;
+    int present = 0;
+    int tx_dis = 0;
+
+    if (port < 0 || port >= 34) {
+        return ONLP_STATUS_E_UNSUPPORTED;
+    }
 
     switch(control)
         {
@@ -352,18 +377,29 @@ onlp_sfpi_control_get(int port, onlp_sfp_control_t control, int* value)
 
         case ONLP_SFP_CONTROL_TX_DISABLE:
             {
-                if(port==32 || port==33) {
-            	    if (onlp_file_read_int(value, MODULE_TXDISABLE_FORMAT, bus, addr, (port+1)) < 0) {
-                        AIM_LOG_ERROR("Unable to read tx_disabled status from port(%d)\r\n", port);
+                if(port >= 0 && port <= 31) {
+                    present = onlp_sfpi_is_present(port);
+                    /* read qsfp eeprom offset of tx disable if qsfp on the port */
+                    if(present == 1)
+                    {
+                        tx_dis = onlp_sfpi_dev_readb(port, PORT_EEPROM_DEVADDR, QSFP_EEPROM_OFFSET_TXDIS);
+
+                        *value = tx_dis;
+
+                        rv = ONLP_STATUS_OK;
+
+                    } else {
                         rv = ONLP_STATUS_E_INTERNAL;
                     }
-                    else {
+                } else {
+                    if (onlp_file_read_int(value, MODULE_TXDISABLE_FORMAT, bus, addr, (port+1)) < 0) {
+                        AIM_LOG_ERROR("Unable to read tx_disabled status from port(%d)\r\n", port);
+                        rv = ONLP_STATUS_E_INTERNAL;
+                    } else {
                         rv = ONLP_STATUS_OK;
                     }
                 }
-                else {
-                    rv = ONLP_STATUS_E_UNSUPPORTED;
-                }
+
                 break;
             }
 

--- a/packages/platforms/accton/x86-64/as7726-32x/onlp/builds/x86_64_accton_as7726_32x/module/src/sfpi.c
+++ b/packages/platforms/accton/x86-64/as7726-32x/onlp/builds/x86_64_accton_as7726_32x/module/src/sfpi.c
@@ -295,7 +295,6 @@ onlp_sfpi_control_set(int port, onlp_sfp_control_t control, int value)
             {
                 if(port >= 0 && port <= 31) {
                     present = onlp_sfpi_is_present(port);
-                    /* read qsfp eeprom offset of tx disable if qsfp on the port */
                     if(present == 1){
                         /* txdis valid bit(bit0-bit3), xxxx 1111 */
                         value = value&0xf;
@@ -379,7 +378,6 @@ onlp_sfpi_control_get(int port, onlp_sfp_control_t control, int* value)
             {
                 if(port >= 0 && port <= 31) {
                     present = onlp_sfpi_is_present(port);
-                    /* read qsfp eeprom offset of tx disable if qsfp on the port */
                     if(present == 1)
                     {
                         tx_dis = onlp_sfpi_dev_readb(port, PORT_EEPROM_DEVADDR, QSFP_EEPROM_OFFSET_TXDIS);


### PR DESCRIPTION
1. set/get the QSFP eeprom tx-disable field via onlp_sfp_control_set() and onlp_sfp_control_get(), respectively, to control the tx-disable functionality