### PR TITLE
fix: #788 #764 #732 #461 buildroot issues

### DIFF
--- a/builds/any/rootfs/stretch/common/amd64-base-packages.yml
+++ b/builds/any/rootfs/stretch/common/amd64-base-packages.yml
@@ -8,7 +8,7 @@
 - smartmontools
 - grub2
 - onl-upgrade
-- hw-management
+# - hw-management
 - onl-kernel-4.9-lts-x86-64-all-modules
 - onl-kernel-4.14-lts-x86-64-all-modules
 - onl-kernel-4.19-lts-x86-64-all-modules

--- a/setup.env
+++ b/setup.env
@@ -31,7 +31,7 @@ $ONL/tools/make-versions.py --import-file=$ONL/tools/onlvi --class-name=OnlVersi
 #
 # buildroot download mirror. We suggest you setup a local repository containing these contents for faster local builds.
 #
-export BUILDROOTMIRROR=${BUILDROOTMIRROR:-"http://buildroot.opennetlinux.org/dl"}
+export BUILDROOTMIRROR=${BUILDROOTMIRROR:-"http://buildroot.onlp.dev/dl"}
 
 # These submodules are required for almost everything.
 $ONL/tools/submodules.py $ONL sm/infra


### PR DESCRIPTION
Fix: Update buildroot location to buildroot.onlp.dev pointing to github.io in the background

Temporary workaround:  remove hw-management from amd64-base-packages.yml - will replace once the package is back on  apt.opennetlinux.org

make on debian 9 built and tested on the AS5712.

@paulmenzel