### PR TITLE
Clean up fixes for buildroot/hw-management

### DIFF
--- a/builds/any/rootfs/jessie/common/amd64-base-packages.yml
+++ b/builds/any/rootfs/jessie/common/amd64-base-packages.yml
@@ -8,7 +8,9 @@
 - smartmontools
 - grub2
 - onl-upgrade
-- hw-management
+# Temporary workaround for apt.opennetlinux.org availability issues (#788, #764, #732, #461)
+# TODO: Re-enable once apt.opennetlinux.org is updated and hw-management package is available
+# - hw-management
 - sx-kernel
 - onl-kernel-3.16-lts-x86-64-all-modules
 - onl-kernel-4.9-lts-x86-64-all-modules

--- a/builds/any/rootfs/stretch/common/amd64-base-packages.yml
+++ b/builds/any/rootfs/stretch/common/amd64-base-packages.yml
@@ -8,7 +8,7 @@
 - smartmontools
 - grub2
 - onl-upgrade
-- hw-management
+# - hw-management
 - onl-kernel-4.9-lts-x86-64-all-modules
 - onl-kernel-4.14-lts-x86-64-all-modules
 - onl-kernel-4.19-lts-x86-64-all-modules

--- a/builds/any/rootfs/stretch/common/amd64-base-packages.yml
+++ b/builds/any/rootfs/stretch/common/amd64-base-packages.yml
@@ -8,6 +8,8 @@
 - smartmontools
 - grub2
 - onl-upgrade
+# Temporary workaround for apt.opennetlinux.org availability issues (#788, #764, #732, #461)
+# TODO: Re-enable once apt.opennetlinux.org is updated and hw-management package is available
 # - hw-management
 - onl-kernel-4.9-lts-x86-64-all-modules
 - onl-kernel-4.14-lts-x86-64-all-modules

--- a/packages/platforms/inventec/x86-64/d10056/onlp/builds/x86_64_inventec_d10056/module/src/sysi.c
+++ b/packages/platforms/inventec/x86-64/d10056/onlp/builds/x86_64_inventec_d10056/module/src/sysi.c
@@ -331,13 +331,13 @@ onlp_sysi_platform_info_get(onlp_platform_info_t* pi)
     if( rv != ONLP_STATUS_OK ) {
         return rv;
     }
-    snprintf(cpld_str, ONLP_CONFIG_INFO_STR_MAX, "%s%s ", cpld_str, version);
+    snprintf(cpld_str, ONLP_CONFIG_INFO_STR_MAX, "%s ", version);
     rv = _sysi_version_parsing(INV_HWMON_PREFIX"version", "ver: ", version);
     if( rv != ONLP_STATUS_OK ) {
         return rv;
     }
-    snprintf(other_str, ONLP_CONFIG_INFO_STR_MAX, "%s%s.%s "
-             ,other_str, "psoc", version);
+    snprintf(other_str, ONLP_CONFIG_INFO_STR_MAX, "%s.%s "
+             , "psoc", version);
 
     /*cpld version*/
     if(strlen(cpld_str) > 0) {

--- a/packages/platforms/inventec/x86-64/d10064/onlp/builds/x86_64_inventec_d10064/module/src/sysi.c
+++ b/packages/platforms/inventec/x86-64/d10064/onlp/builds/x86_64_inventec_d10064/module/src/sysi.c
@@ -158,11 +158,11 @@ onlp_sysi_platform_info_get(onlp_platform_info_t* pi)
 
     rv = _sysi_version_parsing(INV_SYSLED_PREFIX"info", "The CPLD version is ", version);
     if( rv != ONLP_STATUS_OK ) { return rv; }
-    snprintf(cpld_str, ONLP_CONFIG_INFO_STR_MAX, "%s%s ", cpld_str, version);
+    snprintf(cpld_str, ONLP_CONFIG_INFO_STR_MAX, "%s ", version);
     rv = _sysi_version_parsing(INV_HWMON_PREFIX"version", "ver: ", version);
     if( rv != ONLP_STATUS_OK ) { return rv; }
-    snprintf(other_str, ONLP_CONFIG_INFO_STR_MAX, "%s%s.%s "
-                     ,other_str, "psoc", version);
+    snprintf(other_str, ONLP_CONFIG_INFO_STR_MAX, "%s.%s "
+                     , "psoc", version);
 
     /*cpld version*/
     if(strlen(cpld_str) > 0) {

--- a/packages/platforms/inventec/x86-64/d3352/onlp/builds/x86_64_inventec_d3352/module/src/sysi.c
+++ b/packages/platforms/inventec/x86-64/d3352/onlp/builds/x86_64_inventec_d3352/module/src/sysi.c
@@ -118,13 +118,13 @@ onlp_sysi_platform_info_get(onlp_platform_info_t* pi)
     if( rv != ONLP_STATUS_OK ) {
         return rv;
     }
-    snprintf(cpld_str, ONLP_CONFIG_INFO_STR_MAX, "%s%s ", cpld_str, version);
+    snprintf(cpld_str, ONLP_CONFIG_INFO_STR_MAX, "%s ", version);
     rv = _sysi_version_parsing(INV_PSOC_PREFIX"version", "ver: ", version);
     if( rv != ONLP_STATUS_OK ) {
         return rv;
     }
-    snprintf(other_str, ONLP_CONFIG_INFO_STR_MAX, "%s%s%s "
-             ,other_str, "\n\t\tpsoc: ", version);
+    snprintf(other_str, ONLP_CONFIG_INFO_STR_MAX, "%s%s "
+             , "\n\t\tpsoc: ", version);
 
     /*cpld version*/
     if(strlen(cpld_str) > 0) {

--- a/packages/platforms/inventec/x86-64/d5254/onlp/builds/x86_64_inventec_d5254/module/src/sysi.c
+++ b/packages/platforms/inventec/x86-64/d5254/onlp/builds/x86_64_inventec_d5254/module/src/sysi.c
@@ -376,11 +376,11 @@ onlp_sysi_platform_info_get(onlp_platform_info_t* pi)
 
     rv = _sysi_version_parsing(INV_SYSLED_PREFIX"info", "The CPLD version is ", version);
     if( rv != ONLP_STATUS_OK ) { return rv; }
-    snprintf(cpld_str, ONLP_CONFIG_INFO_STR_MAX, "%s%s ", cpld_str, version);
+    snprintf(cpld_str, ONLP_CONFIG_INFO_STR_MAX, "%s ", version);
     rv = _sysi_version_parsing(INV_HWMON_PREFIX"version", "ver: ", version);
     if( rv != ONLP_STATUS_OK ) { return rv; }
-    snprintf(other_str, ONLP_CONFIG_INFO_STR_MAX, "%s%s.%s "
-             ,other_str, "psoc", version);
+    snprintf(other_str, ONLP_CONFIG_INFO_STR_MAX, "%s.%s "
+             , "psoc", version);
 
     /*cpld version*/
     if(strlen(cpld_str) > 0) {

--- a/packages/platforms/inventec/x86-64/d5264q28b/onlp/builds/x86_64_inventec_d5264q28b/module/src/sysi.c
+++ b/packages/platforms/inventec/x86-64/d5264q28b/onlp/builds/x86_64_inventec_d5264q28b/module/src/sysi.c
@@ -158,11 +158,11 @@ onlp_sysi_platform_info_get(onlp_platform_info_t* pi)
 
     rv = _sysi_version_parsing(INV_SYSLED_PREFIX"info", "The CPLD version is ", version);
     if( rv != ONLP_STATUS_OK ) { return rv; }
-    snprintf(cpld_str, ONLP_CONFIG_INFO_STR_MAX, "%s%s ", cpld_str, version);
+    snprintf(cpld_str, ONLP_CONFIG_INFO_STR_MAX, "%s ", version);
     rv = _sysi_version_parsing(INV_HWMON_PREFIX"version", "ver: ", version);
     if( rv != ONLP_STATUS_OK ) { return rv; }
-    snprintf(other_str, ONLP_CONFIG_INFO_STR_MAX, "%s%s.%s "
-                     ,other_str, "psoc", version);
+    snprintf(other_str, ONLP_CONFIG_INFO_STR_MAX, "%s.%s "
+                     , "psoc", version);
 
     /*cpld version*/
     if(strlen(cpld_str) > 0) {

--- a/packages/platforms/inventec/x86-64/d6332/onlp/builds/x86_64_inventec_d6332/module/src/sysi.c
+++ b/packages/platforms/inventec/x86-64/d6332/onlp/builds/x86_64_inventec_d6332/module/src/sysi.c
@@ -89,7 +89,8 @@ static int _sysi_version_parsing(char* file_str, char* str_buf, char* str_buf2, 
         AIM_LOG_ERROR("[ONLP][SYS] Unable to parse cpld2 version\n");
         return ONLP_STATUS_E_INVALID;
     }
-    snprintf(version, ONLP_CONFIG_INFO_STR_MAX, "c1_%s c2_%s", cpld_v1, cpld_v2);
+    /* Limit input strings to prevent truncation: "c1_" (3) + cpld_v1 + " c2_" (4) + cpld_v2 + null (1) */
+    snprintf(version, ONLP_CONFIG_INFO_STR_MAX, "c1_%.26s c2_%.26s", cpld_v1, cpld_v2);
 
     return rv;
 }
@@ -198,7 +199,6 @@ int
 onlp_sysi_platform_info_get(onlp_platform_info_t* pi)
 {
     int rv = ONLP_STATUS_OK;
-    char cpld_str[ONLP_CONFIG_INFO_STR_MAX] = {0};
     char version[ONLP_CONFIG_INFO_STR_MAX];
     pi->cpld_versions = NULL;
 
@@ -206,10 +206,9 @@ onlp_sysi_platform_info_get(onlp_platform_info_t* pi)
     if ( rv != ONLP_STATUS_OK ) {
         return rv;
     }
-    snprintf(cpld_str, ONLP_CONFIG_INFO_STR_MAX, "%s%s ", cpld_str, version);
     /*cpld version*/
-    if (strlen(cpld_str) > 0) {
-        pi->cpld_versions = aim_fstrdup("%s", cpld_str);
+    if (strlen(version) > 0) {
+        pi->cpld_versions = aim_fstrdup("%s", version);
     }
     return rv;
 }

--- a/packages/platforms/inventec/x86-64/d6356/onlp/builds/x86_64_inventec_d6356/module/src/sysi.c
+++ b/packages/platforms/inventec/x86-64/d6356/onlp/builds/x86_64_inventec_d6356/module/src/sysi.c
@@ -81,7 +81,8 @@ static int _sysi_version_parsing(char* file_str, char* str_buf, char* str_buf2, 
     } else {
         return ONLP_STATUS_E_INVALID;
     }
-    snprintf(version, ONLP_CONFIG_INFO_STR_MAX, "c1_%s c2_%s", cpld_v1, cpld_v2);
+    /* Limit input strings to prevent truncation: "c1_" (3) + cpld_v1 + " c2_" (4) + cpld_v2 + null (1) */
+    snprintf(version, ONLP_CONFIG_INFO_STR_MAX, "c1_%.26s c2_%.26s", cpld_v1, cpld_v2);
 
     return rv;
 }
@@ -190,7 +191,6 @@ int
 onlp_sysi_platform_info_get(onlp_platform_info_t* pi)
 {
     int rv = ONLP_STATUS_OK;
-    char cpld_str[ONLP_CONFIG_INFO_STR_MAX] = {0};
     char version[ONLP_CONFIG_INFO_STR_MAX];
     pi->cpld_versions = NULL;
 
@@ -198,10 +198,9 @@ onlp_sysi_platform_info_get(onlp_platform_info_t* pi)
     if ( rv != ONLP_STATUS_OK ) {
         return rv;
     }
-    snprintf(cpld_str, ONLP_CONFIG_INFO_STR_MAX, "%s%s ", cpld_str, version);
     /*cpld version*/
-    if (strlen(cpld_str) > 0) {
-        pi->cpld_versions = aim_fstrdup("%s", cpld_str);
+    if (strlen(version) > 0) {
+        pi->cpld_versions = aim_fstrdup("%s", version);
     }
     return rv;
 }

--- a/packages/platforms/inventec/x86-64/d6432/onlp/builds/x86_64_inventec_d6432/module/src/sysi.c
+++ b/packages/platforms/inventec/x86-64/d6432/onlp/builds/x86_64_inventec_d6432/module/src/sysi.c
@@ -90,7 +90,8 @@ static int _sysi_version_parsing(char* file_str, char* str_buf, char* version)
     } else {
         return ONLP_STATUS_E_INVALID;
     }
-    snprintf(version, ONLP_CONFIG_INFO_STR_MAX, "c1_%s c2_%s", cpld_v1, cpld_v2);
+    /* Limit input strings to prevent truncation: "c1_" (3) + cpld_v1 + " c2_" (4) + cpld_v2 + null (1) */
+    snprintf(version, ONLP_CONFIG_INFO_STR_MAX, "c1_%.26s c2_%.26s", cpld_v1, cpld_v2);
 
     return rv;
 }
@@ -199,7 +200,6 @@ int
 onlp_sysi_platform_info_get(onlp_platform_info_t* pi)
 {
     int rv = ONLP_STATUS_OK;
-    char cpld_str[ONLP_CONFIG_INFO_STR_MAX] = {0};
     char version[ONLP_CONFIG_INFO_STR_MAX];
     pi->cpld_versions = NULL;
 
@@ -207,10 +207,9 @@ onlp_sysi_platform_info_get(onlp_platform_info_t* pi)
     if ( rv != ONLP_STATUS_OK ) {
         return rv;
     }
-    snprintf(cpld_str, ONLP_CONFIG_INFO_STR_MAX, "%s%s ", cpld_str, version);
     /*cpld version*/
-    if (strlen(cpld_str) > 0) {
-        pi->cpld_versions = aim_fstrdup("%s", cpld_str);
+    if (strlen(version) > 0) {
+        pi->cpld_versions = aim_fstrdup("%s", version);
     }
     return rv;
 }

--- a/packages/platforms/inventec/x86-64/d7332/onlp/builds/x86_64_inventec_d7332/module/src/sysi.c
+++ b/packages/platforms/inventec/x86-64/d7332/onlp/builds/x86_64_inventec_d7332/module/src/sysi.c
@@ -90,7 +90,8 @@ static int _sysi_version_parsing(char* file_str, char* str_buf, char* version)
     } else {
         return ONLP_STATUS_E_INVALID;
     }
-    snprintf(version, ONLP_CONFIG_INFO_STR_MAX, "c1_%s c2_%s", cpld_v1, cpld_v2);
+    /* Limit input strings to prevent truncation: "c1_" (3) + cpld_v1 + " c2_" (4) + cpld_v2 + null (1) */
+    snprintf(version, ONLP_CONFIG_INFO_STR_MAX, "c1_%.26s c2_%.26s", cpld_v1, cpld_v2);
 
     return rv;
 }
@@ -199,7 +200,6 @@ int
 onlp_sysi_platform_info_get(onlp_platform_info_t* pi)
 {
     int rv = ONLP_STATUS_OK;
-    char cpld_str[ONLP_CONFIG_INFO_STR_MAX] = {0};
     char version[ONLP_CONFIG_INFO_STR_MAX];
     pi->cpld_versions = NULL;
 
@@ -207,10 +207,9 @@ onlp_sysi_platform_info_get(onlp_platform_info_t* pi)
     if ( rv != ONLP_STATUS_OK ) {
         return rv;
     }
-    snprintf(cpld_str, ONLP_CONFIG_INFO_STR_MAX, "%s%s ", cpld_str, version);
     /*cpld version*/
-    if (strlen(cpld_str) > 0) {
-        pi->cpld_versions = aim_fstrdup("%s", cpld_str);
+    if (strlen(version) > 0) {
+        pi->cpld_versions = aim_fstrdup("%s", version);
     }
     return rv;
 }

--- a/packages/platforms/netberg/x86-64/aurora-610/onlp/builds/x86_64_netberg_aurora_610/module/src/sysi.c
+++ b/packages/platforms/netberg/x86-64/aurora-610/onlp/builds/x86_64_netberg_aurora_610/module/src/sysi.c
@@ -331,13 +331,13 @@ onlp_sysi_platform_info_get(onlp_platform_info_t* pi)
     if( rv != ONLP_STATUS_OK ) {
         return rv;
     }
-    snprintf(cpld_str, ONLP_CONFIG_INFO_STR_MAX, "%s%s ", cpld_str, version);
+    snprintf(cpld_str, ONLP_CONFIG_INFO_STR_MAX, "%s ", version);
     rv = _sysi_version_parsing(NET_HWMON_PREFIX"version", "ver: ", version);
     if( rv != ONLP_STATUS_OK ) {
         return rv;
     }
-    snprintf(other_str, ONLP_CONFIG_INFO_STR_MAX, "%s%s.%s "
-             ,other_str, "psoc", version);
+    snprintf(other_str, ONLP_CONFIG_INFO_STR_MAX, "%s.%s "
+             , "psoc", version);
 
     /*cpld version*/
     if(strlen(cpld_str) > 0) {

--- a/packages/platforms/netberg/x86-64/aurora-820/onlp/builds/x86_64_netberg_aurora_820/module/src/sysi.c
+++ b/packages/platforms/netberg/x86-64/aurora-820/onlp/builds/x86_64_netberg_aurora_820/module/src/sysi.c
@@ -87,7 +87,8 @@ static int _sysi_version_parsing(char* file_str, char* str_buf, char* version)
     } else {
         return ONLP_STATUS_E_INVALID;
     }
-    snprintf(version, ONLP_CONFIG_INFO_STR_MAX, "c1_%s c2_%s", cpld_v1, cpld_v2);
+    /* Limit input strings to prevent truncation: "c1_" (3) + cpld_v1 + " c2_" (4) + cpld_v2 + null (1) */
+    snprintf(version, ONLP_CONFIG_INFO_STR_MAX, "c1_%.26s c2_%.26s", cpld_v1, cpld_v2);
 
     return rv;
 }
@@ -196,7 +197,6 @@ int
 onlp_sysi_platform_info_get(onlp_platform_info_t* pi)
 {
     int rv = ONLP_STATUS_OK;
-    char cpld_str[ONLP_CONFIG_INFO_STR_MAX] = {0};
     char version[ONLP_CONFIG_INFO_STR_MAX];
     pi->cpld_versions = NULL;
 
@@ -204,10 +204,9 @@ onlp_sysi_platform_info_get(onlp_platform_info_t* pi)
     if ( rv != ONLP_STATUS_OK ) {
         return rv;
     }
-    snprintf(cpld_str, ONLP_CONFIG_INFO_STR_MAX, "%s%s ", cpld_str, version);
     /*cpld version*/
-    if (strlen(cpld_str) > 0) {
-        pi->cpld_versions = aim_fstrdup("%s", cpld_str);
+    if (strlen(version) > 0) {
+        pi->cpld_versions = aim_fstrdup("%s", version);
     }
     return rv;
 }

--- a/setup.env
+++ b/setup.env
@@ -31,7 +31,7 @@ $ONL/tools/make-versions.py --import-file=$ONL/tools/onlvi --class-name=OnlVersi
 #
 # buildroot download mirror. We suggest you setup a local repository containing these contents for faster local builds.
 #
-export BUILDROOTMIRROR=${BUILDROOTMIRROR:-"http://buildroot.opennetlinux.org/dl"}
+export BUILDROOTMIRROR=${BUILDROOTMIRROR:-"http://buildroot.onlp.dev/dl"}
 
 # These submodules are required for almost everything.
 $ONL/tools/submodules.py $ONL sm/infra


### PR DESCRIPTION
test: determine how well Claude notates and fixes my changes
fix: apply consistent hw-management workaround across Debian versions

- Comment out hw-management package in jessie to match stretch
- Add TODO comments explaining the temporary workaround
- References issues #788, #764, #732, #461