### PR TITLE
[Accton][as7946-74xkb][as7946-30xb] Add unplugged psu's fan & thermal…

### DIFF
--- a/packages/platforms/accton/x86-64/as7946-30xb/modules/builds/x86-64-accton-as7946-30xb-psu.c
+++ b/packages/platforms/accton/x86-64/as7946-30xb/modules/builds/x86-64-accton-as7946-30xb-psu.c
@@ -85,10 +85,6 @@ enum psu_data_index {
 	PSU_POUT3,
 	PSU_TEMP1_0,
 	PSU_TEMP1_1,
-	PSU_TEMP2_0,
-	PSU_TEMP2_1,
-	PSU_TEMP3_0,
-	PSU_TEMP3_1,
 	PSU_FAN0,
 	PSU_FAN1,
 	PSU_VOUT_MODE,
@@ -153,8 +149,6 @@ static struct platform_driver as7946_30xb_psu_driver = {
 #define PSU_MODEL_ATTR_ID(index) PSU##index##_MODEL
 #define PSU_SERIAL_ATTR_ID(index) PSU##index##_SERIAL
 #define PSU_TEMP1_INPUT_ATTR_ID(index) PSU##index##_TEMP1_INPUT
-#define PSU_TEMP2_INPUT_ATTR_ID(index) PSU##index##_TEMP2_INPUT
-#define PSU_TEMP3_INPUT_ATTR_ID(index) PSU##index##_TEMP3_INPUT
 #define PSU_FAN_INPUT_ATTR_ID(index) PSU##index##_FAN_INPUT
 #define PSU_FAN_DIR_ATTR_ID(index) PSU##index##_FAN_DIR
 
@@ -170,8 +164,6 @@ static struct platform_driver as7946_30xb_psu_driver = {
 	PSU_MODEL_ATTR_ID(psu_id), \
 	PSU_SERIAL_ATTR_ID(psu_id), \
 	PSU_TEMP1_INPUT_ATTR_ID(psu_id), \
-	PSU_TEMP2_INPUT_ATTR_ID(psu_id), \
-	PSU_TEMP3_INPUT_ATTR_ID(psu_id), \
 	PSU_FAN_INPUT_ATTR_ID(psu_id), \
 	PSU_FAN_DIR_ATTR_ID(psu_id)
 
@@ -207,10 +199,6 @@ enum as7946_30xb_psu_sysfs_attrs {
 								PSU##index##_SERIAL);\
 	static SENSOR_DEVICE_ATTR(psu##index##_temp1_input, S_IRUGO, show_psu, NULL,\
 								PSU##index##_TEMP1_INPUT); \
-	static SENSOR_DEVICE_ATTR(psu##index##_temp2_input, S_IRUGO, show_psu, NULL,\
-								PSU##index##_TEMP2_INPUT); \
-	static SENSOR_DEVICE_ATTR(psu##index##_temp3_input, S_IRUGO, show_psu, NULL,\
-								PSU##index##_TEMP3_INPUT); \
 	static SENSOR_DEVICE_ATTR(psu##index##_fan1_input, S_IRUGO, show_psu, NULL,\
 								PSU##index##_FAN_INPUT); \
 	static SENSOR_DEVICE_ATTR(psu##index##_fan_dir, S_IRUGO, show_string, NULL,\
@@ -228,8 +216,6 @@ enum as7946_30xb_psu_sysfs_attrs {
 	&sensor_dev_attr_psu##index##_model.dev_attr.attr, \
 	&sensor_dev_attr_psu##index##_serial.dev_attr.attr,\
 	&sensor_dev_attr_psu##index##_temp1_input.dev_attr.attr, \
-	&sensor_dev_attr_psu##index##_temp2_input.dev_attr.attr, \
-	&sensor_dev_attr_psu##index##_temp3_input.dev_attr.attr, \
 	&sensor_dev_attr_psu##index##_fan1_input.dev_attr.attr, \
 	&sensor_dev_attr_psu##index##_fan_dir.dev_attr.attr
 
@@ -548,18 +534,6 @@ static ssize_t show_psu(struct device *dev, struct device_attribute *da,
 		VALIDATE_PRESENT_RETURN(pid);
 		value = ((u32)data->ipmi_resp[pid].status[PSU_TEMP1_0] |
 					(u32)data->ipmi_resp[pid].status[PSU_TEMP1_1] << 8);
-		break;
-	case PSU1_TEMP2_INPUT:
-	case PSU2_TEMP2_INPUT:
-		VALIDATE_PRESENT_RETURN(pid);
-		value = ((u32)data->ipmi_resp[pid].status[PSU_TEMP2_0] |
-					(u32)data->ipmi_resp[pid].status[PSU_TEMP2_1] << 8);
-		break;
-	case PSU1_TEMP3_INPUT:
-	case PSU2_TEMP3_INPUT:
-		VALIDATE_PRESENT_RETURN(pid);
-		value = ((u32)data->ipmi_resp[pid].status[PSU_TEMP3_0] |
-					(u32)data->ipmi_resp[pid].status[PSU_TEMP3_1] << 8);
 		break;
 	case PSU1_FAN_INPUT:
 	case PSU2_FAN_INPUT:

--- a/packages/platforms/accton/x86-64/as7946-30xb/onlp/builds/x86_64_accton_as7946_30xb/module/src/fani.c
+++ b/packages/platforms/accton/x86-64/as7946-30xb/onlp/builds/x86_64_accton_as7946_30xb/module/src/fani.c
@@ -62,15 +62,6 @@ enum fan_id {
         { 0 },\
     }
 
-#define AIM_FREE_IF_PTR(p) \
-    do \
-    { \
-        if (p) { \
-            aim_free(p); \
-            p = NULL; \
-        } \
-    } while (0)
-
 /* Static fan information */
 onlp_fan_info_t finfo[] = {
     { }, /* Not used */
@@ -169,38 +160,32 @@ _onlp_fani_info_get_fan(int fid, onlp_fan_info_t* info)
 static int
 _onlp_fani_info_get_fan_on_psu(int pid, onlp_fan_info_t* info)
 {
-    char *fandir = NULL;
-    int   len = 0;
     int   val = 0;
-    int   ret = 0;
 
     info->status |= ONLP_FAN_STATUS_PRESENT;
 
+    /* Get power good status */
+    if (psu_status_info_get(pid, "power_good", &val) == ONLP_STATUS_OK) {
+        info->status |= (val != PSU_STATUS_POWER_GOOD) ? ONLP_FAN_STATUS_FAILED : 0;
+    }
+
     /* get fan direction
      */
-    len = onlp_file_read_str(&fandir, "%s""psu%d_fan_dir", PSU_SYSFS_PATH, pid);
-    if (fandir && len) {
-        if (strncmp(fandir, "B2F", strlen("B2F")) == 0) {
+    if (psu_status_info_get(pid, "fan_dir", &val) == ONLP_STATUS_OK) {
+        if (val == PSU_FAN_B2F)
             info->status |= ONLP_FAN_STATUS_B2F;
-        }
-        else {
+        else if (val == PSU_FAN_F2B)
             info->status |= ONLP_FAN_STATUS_F2B;
-        }
     }
-    AIM_FREE_IF_PTR(fandir);
 
     /* get fan speed
      */
-    ret = onlp_file_read_int(&val, "%s""psu%d_fan1_input", PSU_SYSFS_PATH, pid);
-    if (ret < 0) {
-        AIM_LOG_ERROR("Unable to read status from (%s""psu%d_fan1_input)\r\n", PSU_SYSFS_PATH, pid);
-        return ONLP_STATUS_E_INTERNAL;
+    if (psu_status_info_get(pid, "fan1_input", &val) == ONLP_STATUS_OK) {
+        /* get speed percentage from rpm
+         */
+        info->rpm = val;
+        info->percentage = (info->rpm * 100)/MAX_PSU_FAN_SPEED;
     }
-
-    /* get speed percentage from rpm
-     */
-    info->rpm = val;
-    info->percentage = (info->rpm * 100)/MAX_PSU_FAN_SPEED;
 
     return ONLP_STATUS_OK;
 }

--- a/packages/platforms/accton/x86-64/as7946-30xb/onlp/builds/x86_64_accton_as7946_30xb/module/src/platform_lib.c
+++ b/packages/platforms/accton/x86-64/as7946-30xb/onlp/builds/x86_64_accton_as7946_30xb/module/src/platform_lib.c
@@ -1,0 +1,63 @@
+/************************************************************
+ * <bsn.cl fy=2014 v=onl>
+ *
+ *           Copyright 2014 Big Switch Networks, Inc.
+ *
+ * Licensed under the Eclipse Public License, Version 1.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *        http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ *
+ * </bsn.cl>
+ ************************************************************
+ *
+ * Platform Library
+ *
+ ***********************************************************/
+#include <unistd.h>
+#include <onlp/onlp.h>
+#include <onlplib/file.h>
+#include "platform_lib.h"
+
+int psu_status_info_get(int id, char *node, int *value)
+{
+    int ret = 0;
+    int len = 0;
+    char path[PSU_NODE_MAX_PATH_LEN] = {0};
+    char *fandir = NULL;
+
+    *value = 0;
+
+    sprintf(path, "%spsu%d_%s", PSU_SYSFS_PATH, id, node);
+
+    if (strncmp(node, "fan_dir", strlen("fan_dir")) == 0) {
+        len = onlp_file_read_str(&fandir, "%s", path);
+
+        if (fandir && len) {
+            if (strncmp(fandir, "B2F", strlen("B2F")) == 0)
+                *value = PSU_FAN_B2F;
+            else if (strncmp(fandir, "F2B", strlen("F2B")) == 0)
+                *value = PSU_FAN_F2B;
+
+        } else {
+            AIM_LOG_ERROR("Unable to read status from file(%s)\r\n", path);
+            return ONLP_STATUS_E_INTERNAL;
+        }
+        AIM_FREE_IF_PTR(fandir);
+    } else {
+        if (onlp_file_read_int(value, path) < 0) {
+            AIM_LOG_ERROR("Unable to read status from file(%s)\r\n", path);
+            return ONLP_STATUS_E_INTERNAL;
+        }
+    }
+
+    return ret;
+}

--- a/packages/platforms/accton/x86-64/as7946-30xb/onlp/builds/x86_64_accton_as7946_30xb/module/src/platform_lib.h
+++ b/packages/platforms/accton/x86-64/as7946-30xb/onlp/builds/x86_64_accton_as7946_30xb/module/src/platform_lib.h
@@ -31,16 +31,30 @@
 
 #define CHASSIS_FAN_COUNT     5
 #define CHASSIS_THERMAL_COUNT 10
-#define CHASSIS_PSU_THERMAL_COUNT 3
+#define CHASSIS_PSU_THERMAL_COUNT 1
 #define CHASSIS_LED_COUNT     5
 #define CHASSIS_PSU_COUNT     2
 
 #define PSU1_ID 1
 #define PSU2_ID 2
 
+#define PSU_NODE_MAX_PATH_LEN 64
+#define PSU_STATUS_POWER_GOOD 1
+
 #define PSU_SYSFS_PATH "/sys/devices/platform/as7946_30xb_psu/"
 #define FAN_BOARD_PATH "/sys/devices/platform/as7946_30xb_fan/"
 #define IDPROM_PATH    "/sys/devices/platform/as7946_30xb_sys/eeprom"
+
+int psu_status_info_get(int id, char *node, int *value);
+
+#define AIM_FREE_IF_PTR(p) \
+    do \
+    { \
+        if (p) { \
+            aim_free(p); \
+            p = NULL; \
+        } \
+    } while (0)
 
 enum onlp_led_id {
     LED_LOC = 1,
@@ -48,6 +62,12 @@ enum onlp_led_id {
     LED_PSU1,
     LED_PSU2,
     LED_FAN,
+};
+
+enum onlp_psu_fan_dir {
+    PSU_FAN_RESERVED = 0,
+    PSU_FAN_F2B,
+    PSU_FAN_B2F,
 };
 
 enum onlp_thermal_id {
@@ -63,11 +83,7 @@ enum onlp_thermal_id {
     THERMAL_1_ON_FANCPLD,    /* FAN_4D Temp */
     THERMAL_2_ON_FANCPLD,    /* FAN_4E Temp */
     THERMAL_1_ON_PSU1,
-    THERMAL_2_ON_PSU1,
-    THERMAL_3_ON_PSU1,
     THERMAL_1_ON_PSU2,
-    THERMAL_2_ON_PSU2,
-    THERMAL_3_ON_PSU2,
 };
 
 #endif  /* __PLATFORM_LIB_H__ */

--- a/packages/platforms/accton/x86-64/as7946-30xb/onlp/builds/x86_64_accton_as7946_30xb/module/src/psui.c
+++ b/packages/platforms/accton/x86-64/as7946-30xb/onlp/builds/x86_64_accton_as7946_30xb/module/src/psui.c
@@ -37,15 +37,6 @@
         }                                       \
     } while(0)
 
-#define AIM_FREE_IF_PTR(p) \
-    do \
-    { \
-        if (p) { \
-            aim_free(p); \
-            p = NULL; \
-        } \
-    } while (0)
-
 int
 onlp_psui_init(void)
 {
@@ -109,20 +100,9 @@ onlp_psui_info_get(onlp_oid_t id, onlp_psu_info_t* info)
     }
     info->status |= ONLP_PSU_STATUS_PRESENT;
 
-    /* Get power good status */
-    ret = onlp_file_read_int(&val, "%s""psu%d_power_good", PSU_SYSFS_PATH, pid);
-    if (ret < 0) {
-        AIM_LOG_ERROR("Unable to read status from (%s""psu%d_power_good)\r\n", PSU_SYSFS_PATH, pid);
-        return ONLP_STATUS_E_INTERNAL;
-    }
-
-    if (val != PSU_STATUS_POWER_GOOD) {
-        info->status |=  ONLP_PSU_STATUS_FAILED;
-    }
-
-    if (info->status & ONLP_PSU_STATUS_FAILED) {
-        return ONLP_STATUS_OK;
-    }
+    /* Set the associated oid_table */
+    info->hdr.coids[0] = ONLP_FAN_ID_CREATE(pid + CHASSIS_FAN_COUNT);
+    info->hdr.coids[1] = ONLP_THERMAL_ID_CREATE(((pid-1) * CHASSIS_PSU_THERMAL_COUNT) + THERMAL_1_ON_PSU1);
 
     /* Read voltage, current and power */
     val = 0;
@@ -161,26 +141,6 @@ onlp_psui_info_get(onlp_oid_t id, onlp_psu_info_t* info)
         info->caps |= ONLP_PSU_CAPS_POUT;
     }
 
-    /* Set the associated oid_table */
-    val = 0;
-    if (onlp_file_read_int(&val, "%s""psu%d_fan1_input", PSU_SYSFS_PATH, pid) == 0 && val) {
-        info->hdr.coids[0] = ONLP_FAN_ID_CREATE(pid + CHASSIS_FAN_COUNT);
-    }
-
-    val = 0;
-    if (onlp_file_read_int(&val, "%s""psu%d_temp1_input", PSU_SYSFS_PATH, pid) == 0 && val) {
-        info->hdr.coids[1] = ONLP_THERMAL_ID_CREATE(((pid-1) * CHASSIS_PSU_THERMAL_COUNT) + THERMAL_1_ON_PSU1);
-    }
-
-    val = 0;
-    if (onlp_file_read_int(&val, "%s""psu%d_temp2_input", PSU_SYSFS_PATH, pid) == 0 && val) {
-        info->hdr.coids[2] = ONLP_THERMAL_ID_CREATE(((pid-1) * CHASSIS_PSU_THERMAL_COUNT) + THERMAL_2_ON_PSU1);
-    }
-
-    val = 0;
-    if (onlp_file_read_int(&val, "%s""psu%d_temp3_input", PSU_SYSFS_PATH, pid) == 0 && val) {
-        info->hdr.coids[3] = ONLP_THERMAL_ID_CREATE(((pid-1) * CHASSIS_PSU_THERMAL_COUNT) + THERMAL_3_ON_PSU1);
-    }
     /* Read model */
     char *string = NULL;
     int len = onlp_file_read_str(&string, "%s""psu%d_model", PSU_SYSFS_PATH, pid);
@@ -190,6 +150,9 @@ onlp_psui_info_get(onlp_oid_t id, onlp_psu_info_t* info)
     }
     AIM_FREE_IF_PTR(string);
 
+    /* Set capability */
+    info->caps |= get_DCorAC_cap(info->model);
+
     /* Read serial */
     len = onlp_file_read_str(&string, "%s""psu%d_serial", PSU_SYSFS_PATH, pid);
     if (string && len) {
@@ -198,8 +161,17 @@ onlp_psui_info_get(onlp_oid_t id, onlp_psu_info_t* info)
     }
     AIM_FREE_IF_PTR(string);
 
-    /* Set capability */
-    info->caps |= get_DCorAC_cap(info->model);
+    /* Get power good status */
+    ret = onlp_file_read_int(&val, "%s""psu%d_power_good", PSU_SYSFS_PATH, pid);
+    if (ret < 0) {
+        AIM_LOG_ERROR("Unable to read status from (%s""psu%d_power_good)\r\n", PSU_SYSFS_PATH, pid);
+        return ONLP_STATUS_E_INTERNAL;
+    }
+
+    if (val != PSU_STATUS_POWER_GOOD) {
+        info->status |=  ONLP_PSU_STATUS_UNPLUGGED;
+        info->caps = 0;
+    }
 
     return ret;
 }

--- a/packages/platforms/accton/x86-64/as7946-30xb/onlp/builds/x86_64_accton_as7946_30xb/module/src/thermali.c
+++ b/packages/platforms/accton/x86-64/as7946-30xb/onlp/builds/x86_64_accton_as7946_30xb/module/src/thermali.c
@@ -47,11 +47,7 @@ static char* ipmi_devfiles__[] = { /* must map with onlp_thermal_id */
     "/sys/devices/platform/as7946_30xb_thermal/temp8_input",
     "/sys/devices/platform/as7946_30xb_thermal/temp9_input",
     "/sys/devices/platform/as7946_30xb_psu/psu1_temp1_input",
-    "/sys/devices/platform/as7946_30xb_psu/psu1_temp2_input",
-    "/sys/devices/platform/as7946_30xb_psu/psu1_temp3_input",
     "/sys/devices/platform/as7946_30xb_psu/psu2_temp1_input",
-    "/sys/devices/platform/as7946_30xb_psu/psu2_temp2_input",
-    "/sys/devices/platform/as7946_30xb_psu/psu2_temp3_input",
 };
 
 static char* cpu_coretemp_files[] = {
@@ -121,23 +117,7 @@ static onlp_thermal_info_t linfo[] = {
             ONLP_THERMAL_STATUS_PRESENT,
             AS7946_30XB_PSU_CAPS, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
         },
-    { { ONLP_THERMAL_ID_CREATE(THERMAL_2_ON_PSU1), "PSU-1 Thermal Sensor 2", ONLP_PSU_ID_CREATE(PSU1_ID), {0} },
-            ONLP_THERMAL_STATUS_PRESENT,
-            AS7946_30XB_PSU_CAPS, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
-        },
-    { { ONLP_THERMAL_ID_CREATE(THERMAL_3_ON_PSU1), "PSU-1 Thermal Sensor 3", ONLP_PSU_ID_CREATE(PSU1_ID), {0} },
-            ONLP_THERMAL_STATUS_PRESENT,
-            AS7946_30XB_PSU_CAPS, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
-        },
     { { ONLP_THERMAL_ID_CREATE(THERMAL_1_ON_PSU2), "PSU-2 Thermal Sensor 1", ONLP_PSU_ID_CREATE(PSU2_ID), {0} },
-            ONLP_THERMAL_STATUS_PRESENT,
-            AS7946_30XB_PSU_CAPS, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
-        },
-    { { ONLP_THERMAL_ID_CREATE(THERMAL_2_ON_PSU2), "PSU-2 Thermal Sensor 2", ONLP_PSU_ID_CREATE(PSU2_ID), {0} },
-            ONLP_THERMAL_STATUS_PRESENT,
-            AS7946_30XB_PSU_CAPS, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
-        },
-    { { ONLP_THERMAL_ID_CREATE(THERMAL_3_ON_PSU2), "PSU-2 Thermal Sensor 3", ONLP_PSU_ID_CREATE(PSU2_ID), {0} },
             ONLP_THERMAL_STATUS_PRESENT,
             AS7946_30XB_PSU_CAPS, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
         },
@@ -166,6 +146,9 @@ int
 onlp_thermali_info_get(onlp_oid_t id, onlp_thermal_info_t* info)
 {
     int tid;
+    int psu_id, psu_tid_start = 0;
+    int val = 0;
+    int ret = 0;
     VALIDATE(id);
 
     tid = ONLP_OID_ID_GET(id);
@@ -176,6 +159,22 @@ onlp_thermali_info_get(onlp_oid_t id, onlp_thermal_info_t* info)
     if(tid == THERMAL_CPU_CORE) {
         int rv = onlp_file_read_int_max(&info->mcelsius, cpu_coretemp_files);
         return rv;
+    }
+
+    psu_tid_start = CHASSIS_THERMAL_COUNT + 1;
+
+    if (tid >= psu_tid_start) {
+        psu_id = ( tid <= THERMAL_1_ON_PSU1 ) ? PSU1_ID : PSU2_ID;
+        /* Get power good status */
+        ret = onlp_file_read_int(&val, "%s""psu%d_power_good", PSU_SYSFS_PATH, psu_id);
+        if (ret < 0) {
+            AIM_LOG_ERROR("Unable to read status from (%s""psu%d_power_good)\r\n", PSU_SYSFS_PATH, psu_id);
+            return ONLP_STATUS_E_INTERNAL;
+        }
+
+        if(val != PSU_STATUS_POWER_GOOD) {
+            info->status |= ONLP_THERMAL_STATUS_FAILED;
+        }
     }
 
     return onlp_file_read_int(&info->mcelsius, ipmi_devfiles__[tid]);

--- a/packages/platforms/accton/x86-64/as7946-74xkb/modules/builds/x86-64-accton-as7946-74xkb-psu.c
+++ b/packages/platforms/accton/x86-64/as7946-74xkb/modules/builds/x86-64-accton-as7946-74xkb-psu.c
@@ -85,10 +85,6 @@ enum psu_data_index {
 	PSU_POUT3,
 	PSU_TEMP1_0,
 	PSU_TEMP1_1,
-	PSU_TEMP2_0,
-	PSU_TEMP2_1,
-	PSU_TEMP3_0,
-	PSU_TEMP3_1,
 	PSU_FAN0,
 	PSU_FAN1,
 	PSU_VOUT_MODE,
@@ -153,8 +149,6 @@ static struct platform_driver as7946_74xkb_psu_driver = {
 #define PSU_MODEL_ATTR_ID(index) PSU##index##_MODEL
 #define PSU_SERIAL_ATTR_ID(index) PSU##index##_SERIAL
 #define PSU_TEMP1_INPUT_ATTR_ID(index) PSU##index##_TEMP1_INPUT
-#define PSU_TEMP2_INPUT_ATTR_ID(index) PSU##index##_TEMP2_INPUT
-#define PSU_TEMP3_INPUT_ATTR_ID(index) PSU##index##_TEMP3_INPUT
 #define PSU_FAN_INPUT_ATTR_ID(index) PSU##index##_FAN_INPUT
 #define PSU_FAN_DIR_ATTR_ID(index) PSU##index##_FAN_DIR
 
@@ -170,8 +164,6 @@ static struct platform_driver as7946_74xkb_psu_driver = {
 	PSU_MODEL_ATTR_ID(psu_id), \
 	PSU_SERIAL_ATTR_ID(psu_id), \
 	PSU_TEMP1_INPUT_ATTR_ID(psu_id), \
-	PSU_TEMP2_INPUT_ATTR_ID(psu_id), \
-	PSU_TEMP3_INPUT_ATTR_ID(psu_id), \
 	PSU_FAN_INPUT_ATTR_ID(psu_id), \
 	PSU_FAN_DIR_ATTR_ID(psu_id)
 
@@ -207,10 +199,6 @@ enum as7946_74xkb_psu_sysfs_attrs {
 								PSU##index##_SERIAL);\
 	static SENSOR_DEVICE_ATTR(psu##index##_temp1_input, S_IRUGO, show_psu, NULL,\
 								PSU##index##_TEMP1_INPUT); \
-	static SENSOR_DEVICE_ATTR(psu##index##_temp2_input, S_IRUGO, show_psu, NULL,\
-								PSU##index##_TEMP2_INPUT); \
-	static SENSOR_DEVICE_ATTR(psu##index##_temp3_input, S_IRUGO, show_psu, NULL,\
-								PSU##index##_TEMP3_INPUT); \
 	static SENSOR_DEVICE_ATTR(psu##index##_fan1_input, S_IRUGO, show_psu, NULL,\
 								PSU##index##_FAN_INPUT); \
 	static SENSOR_DEVICE_ATTR(psu##index##_fan_dir, S_IRUGO, show_string, NULL,\
@@ -228,8 +216,6 @@ enum as7946_74xkb_psu_sysfs_attrs {
 	&sensor_dev_attr_psu##index##_model.dev_attr.attr, \
 	&sensor_dev_attr_psu##index##_serial.dev_attr.attr,\
 	&sensor_dev_attr_psu##index##_temp1_input.dev_attr.attr, \
-	&sensor_dev_attr_psu##index##_temp2_input.dev_attr.attr, \
-	&sensor_dev_attr_psu##index##_temp3_input.dev_attr.attr, \
 	&sensor_dev_attr_psu##index##_fan1_input.dev_attr.attr, \
 	&sensor_dev_attr_psu##index##_fan_dir.dev_attr.attr
 
@@ -548,18 +534,6 @@ static ssize_t show_psu(struct device *dev, struct device_attribute *da,
 		VALIDATE_PRESENT_RETURN(pid);
 		value = ((u32)data->ipmi_resp[pid].status[PSU_TEMP1_0] |
 					(u32)data->ipmi_resp[pid].status[PSU_TEMP1_1] << 8);
-		break;
-	case PSU1_TEMP2_INPUT:
-	case PSU2_TEMP2_INPUT:
-		VALIDATE_PRESENT_RETURN(pid);
-		value = ((u32)data->ipmi_resp[pid].status[PSU_TEMP2_0] |
-					(u32)data->ipmi_resp[pid].status[PSU_TEMP2_1] << 8);
-		break;
-	case PSU1_TEMP3_INPUT:
-	case PSU2_TEMP3_INPUT:
-		VALIDATE_PRESENT_RETURN(pid);
-		value = ((u32)data->ipmi_resp[pid].status[PSU_TEMP3_0] |
-					(u32)data->ipmi_resp[pid].status[PSU_TEMP3_1] << 8);
 		break;
 	case PSU1_FAN_INPUT:
 	case PSU2_FAN_INPUT:

--- a/packages/platforms/accton/x86-64/as7946-74xkb/onlp/builds/x86_64_accton_as7946_74xkb/module/src/fani.c
+++ b/packages/platforms/accton/x86-64/as7946-74xkb/onlp/builds/x86_64_accton_as7946_74xkb/module/src/fani.c
@@ -62,15 +62,6 @@ enum fan_id {
         { 0 },\
     }
 
-#define AIM_FREE_IF_PTR(p) \
-    do \
-    { \
-        if (p) { \
-            aim_free(p); \
-            p = NULL; \
-        } \
-    } while (0)
-
 /* Static fan information */
 onlp_fan_info_t finfo[] = {
     { }, /* Not used */
@@ -169,38 +160,32 @@ _onlp_fani_info_get_fan(int fid, onlp_fan_info_t* info)
 static int
 _onlp_fani_info_get_fan_on_psu(int pid, onlp_fan_info_t* info)
 {
-    char *fandir = NULL;
-    int   len = 0;
     int   val = 0;
-    int   ret = 0;
 
     info->status |= ONLP_FAN_STATUS_PRESENT;
 
+    /* Get power good status */
+    if (psu_status_info_get(pid, "power_good", &val) == ONLP_STATUS_OK) {
+        info->status |= (val != PSU_STATUS_POWER_GOOD) ? ONLP_FAN_STATUS_FAILED : 0;
+    }
+
     /* get fan direction
      */
-    len = onlp_file_read_str(&fandir, "%s""psu%d_fan_dir", PSU_SYSFS_PATH, pid);
-    if (fandir && len) {
-        if (strncmp(fandir, "B2F", strlen("B2F")) == 0) {
+    if (psu_status_info_get(pid, "fan_dir", &val) == ONLP_STATUS_OK) {
+        if (val == PSU_FAN_B2F)
             info->status |= ONLP_FAN_STATUS_B2F;
-        }
-        else {
+        else if (val == PSU_FAN_F2B)
             info->status |= ONLP_FAN_STATUS_F2B;
-        }
     }
-    AIM_FREE_IF_PTR(fandir);
 
     /* get fan speed
      */
-    ret = onlp_file_read_int(&val, "%s""psu%d_fan1_input", PSU_SYSFS_PATH, pid);
-    if (ret < 0) {
-        AIM_LOG_ERROR("Unable to read status from (%s""psu%d_fan1_input)\r\n", PSU_SYSFS_PATH, pid);
-        return ONLP_STATUS_E_INTERNAL;
+    if (psu_status_info_get(pid, "fan1_input", &val) == ONLP_STATUS_OK) {
+        /* get speed percentage from rpm
+         */
+        info->rpm = val;
+        info->percentage = (info->rpm * 100)/MAX_PSU_FAN_SPEED;
     }
-
-    /* get speed percentage from rpm
-     */
-    info->rpm = val;
-    info->percentage = (info->rpm * 100)/MAX_PSU_FAN_SPEED;
 
     return ONLP_STATUS_OK;
 }

--- a/packages/platforms/accton/x86-64/as7946-74xkb/onlp/builds/x86_64_accton_as7946_74xkb/module/src/platform_lib.c
+++ b/packages/platforms/accton/x86-64/as7946-74xkb/onlp/builds/x86_64_accton_as7946_74xkb/module/src/platform_lib.c
@@ -1,0 +1,63 @@
+/************************************************************
+ * <bsn.cl fy=2014 v=onl>
+ *
+ *           Copyright 2014 Big Switch Networks, Inc.
+ *
+ * Licensed under the Eclipse Public License, Version 1.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *        http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ *
+ * </bsn.cl>
+ ************************************************************
+ *
+ * Platform Library
+ *
+ ***********************************************************/
+#include <unistd.h>
+#include <onlp/onlp.h>
+#include <onlplib/file.h>
+#include "platform_lib.h"
+
+int psu_status_info_get(int id, char *node, int *value)
+{
+    int ret = 0;
+    int len = 0;
+    char path[PSU_NODE_MAX_PATH_LEN] = {0};
+    char *fandir = NULL;
+
+    *value = 0;
+
+    sprintf(path, "%spsu%d_%s", PSU_SYSFS_PATH, id, node);
+
+    if (strncmp(node, "fan_dir", strlen("fan_dir")) == 0) {
+        len = onlp_file_read_str(&fandir, "%s", path);
+
+        if (fandir && len) {
+            if (strncmp(fandir, "B2F", strlen("B2F")) == 0)
+                *value = PSU_FAN_B2F;
+            else if (strncmp(fandir, "F2B", strlen("F2B")) == 0)
+                *value = PSU_FAN_F2B;
+
+        } else {
+            AIM_LOG_ERROR("Unable to read status from file(%s)\r\n", path);
+            return ONLP_STATUS_E_INTERNAL;
+        }
+        AIM_FREE_IF_PTR(fandir);
+    } else {
+        if (onlp_file_read_int(value, path) < 0) {
+            AIM_LOG_ERROR("Unable to read status from file(%s)\r\n", path);
+            return ONLP_STATUS_E_INTERNAL;
+        }
+    }
+
+    return ret;
+}

--- a/packages/platforms/accton/x86-64/as7946-74xkb/onlp/builds/x86_64_accton_as7946_74xkb/module/src/platform_lib.h
+++ b/packages/platforms/accton/x86-64/as7946-74xkb/onlp/builds/x86_64_accton_as7946_74xkb/module/src/platform_lib.h
@@ -31,16 +31,30 @@
 
 #define CHASSIS_FAN_COUNT     5
 #define CHASSIS_THERMAL_COUNT 10
-#define CHASSIS_PSU_THERMAL_COUNT 3
+#define CHASSIS_PSU_THERMAL_COUNT 1
 #define CHASSIS_LED_COUNT     5
 #define CHASSIS_PSU_COUNT     2
 
 #define PSU1_ID 1
 #define PSU2_ID 2
 
+#define PSU_NODE_MAX_PATH_LEN 64
+#define PSU_STATUS_POWER_GOOD 1
+
 #define PSU_SYSFS_PATH "/sys/devices/platform/as7946_74xkb_psu/"
 #define FAN_BOARD_PATH "/sys/devices/platform/as7946_74xkb_fan/"
 #define IDPROM_PATH    "/sys/devices/platform/as7946_74xkb_sys/eeprom"
+
+int psu_status_info_get(int id, char *node, int *value);
+
+#define AIM_FREE_IF_PTR(p) \
+    do \
+    { \
+        if (p) { \
+            aim_free(p); \
+            p = NULL; \
+        } \
+    } while (0)
 
 enum onlp_led_id {
     LED_LOC = 1,
@@ -48,6 +62,12 @@ enum onlp_led_id {
     LED_PSU1,
     LED_PSU2,
     LED_FAN,
+};
+
+enum onlp_psu_fan_dir {
+    PSU_FAN_RESERVED = 0,
+    PSU_FAN_F2B,
+    PSU_FAN_B2F,
 };
 
 enum onlp_thermal_id {
@@ -63,11 +83,7 @@ enum onlp_thermal_id {
     THERMAL_1_ON_FANCPLD,    /* FAN_4D Temp */
     THERMAL_2_ON_FANCPLD,    /* FAN_4E Temp */
     THERMAL_1_ON_PSU1,
-    THERMAL_2_ON_PSU1,
-    THERMAL_3_ON_PSU1,
     THERMAL_1_ON_PSU2,
-    THERMAL_2_ON_PSU2,
-    THERMAL_3_ON_PSU2,
 };
 
 #endif  /* __PLATFORM_LIB_H__ */

--- a/packages/platforms/accton/x86-64/as7946-74xkb/onlp/builds/x86_64_accton_as7946_74xkb/module/src/psui.c
+++ b/packages/platforms/accton/x86-64/as7946-74xkb/onlp/builds/x86_64_accton_as7946_74xkb/module/src/psui.c
@@ -109,20 +109,9 @@ onlp_psui_info_get(onlp_oid_t id, onlp_psu_info_t* info)
     }
     info->status |= ONLP_PSU_STATUS_PRESENT;
 
-    /* Get power good status */
-    ret = onlp_file_read_int(&val, "%s""psu%d_power_good", PSU_SYSFS_PATH, pid);
-    if (ret < 0) {
-        AIM_LOG_ERROR("Unable to read status from (%s""psu%d_power_good)\r\n", PSU_SYSFS_PATH, pid);
-        return ONLP_STATUS_E_INTERNAL;
-    }
-
-    if (val != PSU_STATUS_POWER_GOOD) {
-        info->status |=  ONLP_PSU_STATUS_FAILED;
-    }
-
-    if (info->status & ONLP_PSU_STATUS_FAILED) {
-        return ONLP_STATUS_OK;
-    }
+    /* Set the associated oid_table */
+    info->hdr.coids[0] = ONLP_FAN_ID_CREATE(pid + CHASSIS_FAN_COUNT);
+    info->hdr.coids[1] = ONLP_THERMAL_ID_CREATE(((pid-1) * CHASSIS_PSU_THERMAL_COUNT) + THERMAL_1_ON_PSU1);    
 
     /* Read voltage, current and power */
     val = 0;
@@ -161,26 +150,6 @@ onlp_psui_info_get(onlp_oid_t id, onlp_psu_info_t* info)
         info->caps |= ONLP_PSU_CAPS_POUT;
     }
 
-    /* Set the associated oid_table */
-    val = 0;
-    if (onlp_file_read_int(&val, "%s""psu%d_fan1_input", PSU_SYSFS_PATH, pid) == 0 && val) {
-        info->hdr.coids[0] = ONLP_FAN_ID_CREATE(pid + CHASSIS_FAN_COUNT);
-    }
-
-    val = 0;
-    if (onlp_file_read_int(&val, "%s""psu%d_temp1_input", PSU_SYSFS_PATH, pid) == 0 && val) {
-        info->hdr.coids[1] = ONLP_THERMAL_ID_CREATE(((pid-1) * CHASSIS_PSU_THERMAL_COUNT) + THERMAL_1_ON_PSU1);
-    }
-
-    val = 0;
-    if (onlp_file_read_int(&val, "%s""psu%d_temp2_input", PSU_SYSFS_PATH, pid) == 0 && val) {
-        info->hdr.coids[2] = ONLP_THERMAL_ID_CREATE(((pid-1) * CHASSIS_PSU_THERMAL_COUNT) + THERMAL_2_ON_PSU1);
-    }
-
-    val = 0;
-    if (onlp_file_read_int(&val, "%s""psu%d_temp3_input", PSU_SYSFS_PATH, pid) == 0 && val) {
-        info->hdr.coids[3] = ONLP_THERMAL_ID_CREATE(((pid-1) * CHASSIS_PSU_THERMAL_COUNT) + THERMAL_3_ON_PSU1);
-    }
     /* Read model */
     char *string = NULL;
     int len = onlp_file_read_str(&string, "%s""psu%d_model", PSU_SYSFS_PATH, pid);
@@ -190,6 +159,9 @@ onlp_psui_info_get(onlp_oid_t id, onlp_psu_info_t* info)
     }
     AIM_FREE_IF_PTR(string);
 
+    /* Set capability */
+    info->caps |= get_DCorAC_cap(info->model);
+
     /* Read serial */
     len = onlp_file_read_str(&string, "%s""psu%d_serial", PSU_SYSFS_PATH, pid);
     if (string && len) {
@@ -198,8 +170,17 @@ onlp_psui_info_get(onlp_oid_t id, onlp_psu_info_t* info)
     }
     AIM_FREE_IF_PTR(string);
 
-    /* Set capability */
-    info->caps |= get_DCorAC_cap(info->model);
+    /* Get power good status */
+    ret = onlp_file_read_int(&val, "%s""psu%d_power_good", PSU_SYSFS_PATH, pid);
+    if (ret < 0) {
+        AIM_LOG_ERROR("Unable to read status from (%s""psu%d_power_good)\r\n", PSU_SYSFS_PATH, pid);
+        return ONLP_STATUS_E_INTERNAL;
+    }
+
+    if (val != PSU_STATUS_POWER_GOOD) {
+        info->status |=  ONLP_PSU_STATUS_UNPLUGGED;
+        info->caps = 0;
+    }
 
     return ret;
 }

--- a/packages/platforms/accton/x86-64/as7946-74xkb/onlp/builds/x86_64_accton_as7946_74xkb/module/src/thermali.c
+++ b/packages/platforms/accton/x86-64/as7946-74xkb/onlp/builds/x86_64_accton_as7946_74xkb/module/src/thermali.c
@@ -47,11 +47,7 @@ static char* ipmi_devfiles__[] = { /* must map with onlp_thermal_id */
     "/sys/devices/platform/as7946_74xkb_thermal/temp8_input",
     "/sys/devices/platform/as7946_74xkb_thermal/temp9_input",
     "/sys/devices/platform/as7946_74xkb_psu/psu1_temp1_input",
-    "/sys/devices/platform/as7946_74xkb_psu/psu1_temp2_input",
-    "/sys/devices/platform/as7946_74xkb_psu/psu1_temp3_input",
     "/sys/devices/platform/as7946_74xkb_psu/psu2_temp1_input",
-    "/sys/devices/platform/as7946_74xkb_psu/psu2_temp2_input",
-    "/sys/devices/platform/as7946_74xkb_psu/psu2_temp3_input",
 };
 
 static char* cpu_coretemp_files[] = {
@@ -121,23 +117,7 @@ static onlp_thermal_info_t linfo[] = {
             ONLP_THERMAL_STATUS_PRESENT,
             AS7946_74XKB_PSU_CAPS, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
         },
-    { { ONLP_THERMAL_ID_CREATE(THERMAL_2_ON_PSU1), "PSU-1 Thermal Sensor 2", ONLP_PSU_ID_CREATE(PSU1_ID), {0} },
-            ONLP_THERMAL_STATUS_PRESENT,
-            AS7946_74XKB_PSU_CAPS, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
-        },
-    { { ONLP_THERMAL_ID_CREATE(THERMAL_3_ON_PSU1), "PSU-1 Thermal Sensor 3", ONLP_PSU_ID_CREATE(PSU1_ID), {0} },
-            ONLP_THERMAL_STATUS_PRESENT,
-            AS7946_74XKB_PSU_CAPS, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
-        },
     { { ONLP_THERMAL_ID_CREATE(THERMAL_1_ON_PSU2), "PSU-2 Thermal Sensor 1", ONLP_PSU_ID_CREATE(PSU2_ID), {0} },
-            ONLP_THERMAL_STATUS_PRESENT,
-            AS7946_74XKB_PSU_CAPS, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
-        },
-    { { ONLP_THERMAL_ID_CREATE(THERMAL_2_ON_PSU2), "PSU-2 Thermal Sensor 2", ONLP_PSU_ID_CREATE(PSU2_ID), {0} },
-            ONLP_THERMAL_STATUS_PRESENT,
-            AS7946_74XKB_PSU_CAPS, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
-        },
-    { { ONLP_THERMAL_ID_CREATE(THERMAL_3_ON_PSU2), "PSU-2 Thermal Sensor 3", ONLP_PSU_ID_CREATE(PSU2_ID), {0} },
             ONLP_THERMAL_STATUS_PRESENT,
             AS7946_74XKB_PSU_CAPS, 0, ONLP_THERMAL_THRESHOLD_INIT_DEFAULTS
         },
@@ -166,6 +146,9 @@ int
 onlp_thermali_info_get(onlp_oid_t id, onlp_thermal_info_t* info)
 {
     int tid;
+    int psu_id, psu_tid_start = 0;
+    int val = 0;
+    int ret = 0;
     VALIDATE(id);
 
     tid = ONLP_OID_ID_GET(id);
@@ -176,6 +159,22 @@ onlp_thermali_info_get(onlp_oid_t id, onlp_thermal_info_t* info)
     if(tid == THERMAL_CPU_CORE) {
         int rv = onlp_file_read_int_max(&info->mcelsius, cpu_coretemp_files);
         return rv;
+    }
+
+    psu_tid_start = CHASSIS_THERMAL_COUNT + 1;
+
+    if (tid >= psu_tid_start) {
+        psu_id = ( tid <= THERMAL_1_ON_PSU1 ) ? PSU1_ID : PSU2_ID;
+        /* Get power good status */
+        ret = onlp_file_read_int(&val, "%s""psu%d_power_good", PSU_SYSFS_PATH, psu_id);
+        if (ret < 0) {
+            AIM_LOG_ERROR("Unable to read status from (%s""psu%d_power_good)\r\n", PSU_SYSFS_PATH, psu_id);
+            return ONLP_STATUS_E_INTERNAL;
+        }
+
+        if(val != PSU_STATUS_POWER_GOOD) {
+            info->status |= ONLP_THERMAL_STATUS_FAILED;
+        }
     }
 
     return onlp_file_read_int(&info->mcelsius, ipmi_devfiles__[tid]);


### PR DESCRIPTION
… info in onlpdump

1. modify psu.c because newer openbmc fw only returns one psu thermal data for the Get PSU Data ipmi cmd

2. clear the capability of the unplugged psu

3. show the unplugged psu's fan & thermal info

4. show failed for the unplugged psu's fan & thermal sensors (its power good sysfs is equal to 0)